### PR TITLE
Apache Rat Gradle Plugin

### DIFF
--- a/apache-rat-gradle/.gitignore
+++ b/apache-rat-gradle/.gitignore
@@ -1,0 +1,3 @@
+src/gradle/.gradle
+src/gradle/.nb-gradle
+src/gradle/build

--- a/apache-rat-gradle/pom.xml
+++ b/apache-rat-gradle/pom.xml
@@ -1,0 +1,196 @@
+<?xml version='1.0'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-project</artifactId>
+        <version>0.12-SNAPSHOT</version>
+    </parent>
+    <artifactId>apache-rat-gradle</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache Creadur Rat::Plugin4Gradle</name>
+    <description> A plugin for Apache Gradle that runs Apache Rat to audit the source to be distributed.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.rat</groupId>
+            <artifactId>apache-rat-tasks</artifactId>
+        </dependency>
+    </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.fortasoft</groupId>
+                <artifactId>gradle-maven-plugin</artifactId>
+                <version>1.0.7</version>
+                <!-- Hook Gradle tasks into Maven phases -->
+                <configuration>
+                    <gradleVersion>2.4</gradleVersion>
+                    <gradleProjectDirectory>${project.basedir}/src/gradle</gradleProjectDirectory>
+                    <args>
+                        <arg>-Dversion=${project.version}</arg>
+                        <arg>-Dgradle.publish.key=${gradle.publish.key}</arg>
+                        <arg>-Dgradle.publish.secret=${gradle.publish.secret}</arg>
+                    </args>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>gradle-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>invoke</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <task>clean</task>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>gradle-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>invoke</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <task>check</task>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>gradle-assemble</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>invoke</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <task>assemble</task>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                    <!-- Uncomment to deploy the plugin to plugins.gradle.org on maven 'deploy' phase
+                    You'll then need to provide the `gradle.publish.key` and `gradle.publish.secret` properties
+                    See https://plugins.gradle.org/docs/submit -->
+                    <!--
+                    <execution>
+                        <id>gradle-deploy</id>
+                        <phase>deploy</phase>
+                        <goals><goal>invoke</goal></goals>
+                        <configuration>
+                            <tasks><task>publishPlugins</task></tasks>
+                        </configuration>
+                    </execution>
+                    -->
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <!-- Overwrite the main artifact and sources/javadocs with the ones built by Gradle -->
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <copy file="${project.build.directory}/gradle-build/libs/${project.build.finalName}.jar"
+                                      tofile="${project.build.directory}/${project.build.finalName}.jar"
+                                      overwrite="true"/>
+                                <copy file="${project.build.directory}/gradle-build/libs/${project.build.finalName}-sources.jar"
+                                      tofile="${project.build.directory}/${project.build.finalName}-sources.jar"
+                                      overwrite="true"/>
+                                <copy file="${project.build.directory}/gradle-build/libs/${project.build.finalName}-javadoc.jar"
+                                      tofile="${project.build.directory}/${project.build.finalName}-javadoc.jar"
+                                      overwrite="true"/>
+                                <copy file="${project.build.directory}/gradle-build/libs/${project.build.finalName}-groovydoc.jar"
+                                      tofile="${project.build.directory}/${project.build.finalName}-groovydoc.jar"
+                                      overwrite="true"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.rat</groupId>
+                    <artifactId>apache-rat-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>src/gradle/.nb-gradle/**</exclude>
+                            <exclude>src/gradle/.gradle/**</exclude>
+                            <exclude>src/gradle/build/**</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+    <profiles>
+        <profile>
+            <id>apache-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.9.1</version>
+                        <!-- Attach javadoc and groovydoc artifacts built by Gradle -->
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>${project.build.directory}/gradle-build/libs/${project.build.finalName}-javadoc.jar</file>
+                                            <type>jar</type>
+                                            <classifier>javadoc</classifier>
+                                        </artifact>
+                                        <artifact>
+                                            <file>${project.build.directory}/gradle-build/libs/${project.build.finalName}-groovydoc.jar</file>
+                                            <type>jar</type>
+                                            <classifier>groovydoc</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/apache-rat-gradle/src/gradle/build.gradle
+++ b/apache-rat-gradle/src/gradle/build.gradle
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath "com.gradle.publish:plugin-publish-plugin:0.9.0"
+    }
+}
+
+plugins {
+    id 'java-gradle-plugin'
+    id 'groovy'
+    id 'maven'
+    id 'eclipse'
+    id 'idea'
+}
+
+version = System.getProperty( 'version' )
+
+sourceCompatibility = "1.5"
+targetCompatibility = "1.5"
+
+sourceSets {
+    main {
+        output.dir( file( '../../target/classes' ) )
+    }
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    testCompile 'com.netflix.nebula:nebula-test:2.2.1', {
+        exclude module: 'groovy-all'
+    }
+}
+
+apply plugin: "com.gradle.plugin-publish"

--- a/apache-rat-gradle/src/gradle/gradle.properties
+++ b/apache-rat-gradle/src/gradle/gradle.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+group=org.apache.rat
+buildDir=../../target/gradle-build
+systemProp.file.encoding=utf-8

--- a/apache-rat-gradle/src/gradle/settings.gradle
+++ b/apache-rat-gradle/src/gradle/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+rootProject.name = 'apache-rat-gradle'

--- a/apache-rat-gradle/src/gradle/src/main/groovy/org/apache/rat/gradle/RatPlugin.groovy
+++ b/apache-rat-gradle/src/gradle/src/main/groovy/org/apache/rat/gradle/RatPlugin.groovy
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rat.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.JavaBasePlugin
+
+class RatPlugin implements Plugin<Project> {
+
+    void apply( Project project ) {
+        configureDependencies( project )
+        Task ratTask = project.task(
+            'rat',
+            type: RatTask,
+            group: 'Apache Creadur',
+            description: 'Runs Apache Rat checks'
+        )
+        if( project.plugins.hasPlugin( JavaBasePlugin ) ) {
+            project.tasks[JavaBasePlugin.CHECK_TASK_NAME].dependsOn ratTask
+        }
+    }
+
+    void configureDependencies( Project project ) {
+        project.configurations {
+            rat
+        }
+        project.repositories {
+            jcenter()
+            // maven { url 'https://repository.apache.org/snapshots' }
+        }
+        project.dependencies {
+            rat 'org.apache.rat:apache-rat-tasks:0.11'
+            // rat 'org.apache.rat:apache-rat-tasks:0.12-SNAPSHOT'
+        }
+    }
+}

--- a/apache-rat-gradle/src/gradle/src/main/groovy/org/apache/rat/gradle/RatTask.groovy
+++ b/apache-rat-gradle/src/gradle/src/main/groovy/org/apache/rat/gradle/RatTask.groovy
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rat.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.internal.project.IsolatedAntBuilder
+
+class RatTask extends DefaultTask {
+
+    boolean failOnError = true
+    boolean verbose = false
+
+    @Input
+    String inputDir = '.'
+
+    @Input
+    List<String> excludes = ['**/.gradle/**']
+
+    @OutputDirectory
+    File reportDir = project.file( project.buildDir.canonicalPath + '/reports/rat' )
+
+    @InputFiles
+    Set<File> getInputFiles() {
+        project.fileTree(dir: inputDir, excludes: excludes).files
+    }
+
+    @TaskAction
+    def rat() {
+        if( !reportDir.exists() ) {
+            reportDir.mkdirs()
+        }
+        def xmlReport = generateXmlReport()
+        def errorCount = countUnaprovedUnknownLicenses( xmlReport )
+        def htmlReport = generateHtmlReport( xmlReport )
+        if( failOnError && errorCount > 0 ) {
+            throw new GradleException(
+                "Found $errorCount files with unapproved/unknown licenses. See ${htmlReport.toURI()}"
+            )
+        }
+    }
+
+    def generateXmlReport() {
+        def xmlReport = new File( reportDir , 'rat-report.xml' )
+        def antBuilder = services.get( IsolatedAntBuilder )
+        def ratClasspath = project.configurations.rat
+        antBuilder.withClasspath( ratClasspath ).execute {
+            ant.taskdef( resource: 'org/apache/rat/anttasks/antlib.xml' )
+            ant.report( format: 'xml', reportFile: xmlReport.absolutePath ) {
+                fileset( dir: inputDir ) {
+                    patternset {
+                        excludes.each { exclude( name: it ) }
+                    }
+                }
+            }
+        }
+        project.logger.info "Rat XML report: ${xmlReport.toURI()}"
+        return xmlReport
+    }
+
+    def countUnaprovedUnknownLicenses( xmlReport ) {
+        def ratXml = new XmlParser().parse( xmlReport )
+        def errorCount = 0
+        ratXml.resource.each { resource ->
+            if( resource.'license-approval'.@name[0] == "false" ) {
+                def log = 'Unapproved/unknown license: ' + resource.@name
+                if( verbose ) println( log )
+                else  project.logger.debug( log )
+                errorCount++
+            }
+        }
+        return errorCount
+    }
+
+    def generateHtmlReport( xmlReport ) {
+        def htmlReport = new File( reportDir, 'index.html' )
+        def stylesheet = project.file( project.buildDir.canonicalPath + '/tmp/rat/stylesheet.xsl' )
+        stylesheet.parentFile.mkdirs()
+        stylesheet.text = this.getClass().getResource( 'apache-rat-output-to-html.xsl' ).text
+        def antBuilder = services.get( IsolatedAntBuilder )
+        def ratClasspath = project.configurations.rat
+        antBuilder.withClasspath( ratClasspath ).execute {
+            ant.xslt(
+                in: xmlReport.absolutePath,
+                style: stylesheet.absolutePath,
+                out: htmlReport.absolutePath,
+                classpath: ratClasspath
+            )
+        }
+        project.logger.info "Rat HTML report: ${htmlReport.toURI()}"
+        return htmlReport
+    }
+
+}

--- a/apache-rat-gradle/src/gradle/src/main/resources/META-INF/gradle-plugins/org.apache.rat.properties
+++ b/apache-rat-gradle/src/gradle/src/main/resources/META-INF/gradle-plugins/org.apache.rat.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+implementation-class=org.apache.rat.gradle.RatPlugin

--- a/apache-rat-gradle/src/gradle/src/main/resources/org/apache/rat/gradle/apache-rat-output-to-html.xsl
+++ b/apache-rat-gradle/src/gradle/src/main/resources/org/apache/rat/gradle/apache-rat-output-to-html.xsl
@@ -1,0 +1,204 @@
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+
+<!--***********************************************************
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ ***********************************************************-->
+
+<!-- This style sheet converts any rat-report.xml file.  -->
+
+<xsl:template match="/">
+
+  <html>
+    <head>
+     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+     <style type="text/css">
+    &lt;!--
+body {margin-top: 0px;font-size: 0.8em;background-color: #F9F7ED;}
+
+h1 {color:red;}
+h2 {color:blue;}
+h3 {color:green;}
+h4 {color:orange;}
+
+/* Table Design */
+
+table,tr,td {text-align:center;font-weight:bold;border:1px solid #000;}
+caption {color:blue;text-align:left;}
+.notes, .binaries, .archives, .standards {width:25%;}
+.notes {background:#D7EDEE;}
+.binaries {background:#D0F2F4;}
+.archives {background:#ABE7E9;}
+.standards {background:#A0F0F4;}
+.licenced, .generated {width:50%;}
+.licenced {background:#C6EBDD;}
+.generated {background:#ABE9D2;}
+.java_note {background:#D6EBC6;}
+.generated_note {background:#C9E7A9;}
+.unknown {width:100%;background:#E92020;}
+.unknown-zero {color:#00CC00;}
+.center{text-align:center;margin:0 auto;}
+--&gt;
+     </style>
+    </head>
+    <body>
+      <xsl:apply-templates/>
+      <xsl:call-template name="generated"/>
+    </body>
+  </html>
+</xsl:template>
+
+<xsl:template match="rat-report">
+
+  <h1>Rat Report</h1>
+<div class="center">
+<table id="rat-reports summary" cellspacing="0" summary="A snapshot summary of this rat report">
+<caption>
+Table 1: A snapshot summary of this rat report.
+</caption>
+  <tr>
+    <td colspan="1" class="notes">Notes: <xsl:value-of select="count(descendant::type[attribute::name=&quot;notice&quot;])"/></td>
+    <td colspan="1" class="binaries">Binaries: <xsl:value-of select="count(descendant::type[attribute::name=&quot;binary&quot;])"/></td>
+    <td colspan="1" class="archives">Archives: <xsl:value-of select="count(descendant::type[attribute::name=&quot;archive&quot;])"/></td>
+    <td colspan="1" class="standards">Standards: <xsl:value-of select="count(descendant::type[attribute::name=&quot;standard&quot;])"/></td>
+  </tr>
+  <tr>
+    <td colspan="2" class="licenced">Apache Licensed: <xsl:value-of select="count(descendant::header-type[attribute::name=&quot;AL   &quot;])"/></td>
+    <td colspan="2" class="generated">Generated Documents: <xsl:value-of select="count(descendant::header-type[attribute::name=&quot;GEN  &quot;])"/></td>
+  </tr>
+  <tr>
+    <td colspan="2" class="java_note">Note: JavaDocs are generated and so license header is optional</td>
+    <td colspan="2" class="generated_note">Note: Generated files do not require license headers</td>
+  </tr>
+  <tr>
+<xsl:choose>
+  <xsl:when test="count(descendant::header-type[attribute::name=&quot;?????&quot;]) &gt; 0">
+    <td colspan="4" class="unknown"><xsl:value-of select="count(descendant::header-type[attribute::name=&quot;?????&quot;])"/> Unknown Licenses - or files without a license.</td>
+  </xsl:when>
+  <xsl:otherwise>
+    <td colspan="4" class="unknown-zero"><xsl:value-of select="count(descendant::header-type[attribute::name=&quot;?????&quot;])"/> Unknown Licenses - or files without a license.</td>
+  </xsl:otherwise>
+</xsl:choose>
+  </tr>
+</table>
+</div>
+<hr/>
+  <h3>Unapproved Licenses:</h3>
+
+  <xsl:for-each select="descendant::resource[license-approval/@name=&quot;false&quot;]">
+  <xsl:text>  </xsl:text>
+  <xsl:value-of select="@name"/><br/>
+  <xsl:text>
+</xsl:text>
+</xsl:for-each>
+<hr/>
+
+<h3>Archives:</h3>
+
+<xsl:for-each select="descendant::resource[type/@name=&quot;archive&quot;]">
+ + <xsl:value-of select="@name"/>
+ <br/>
+ </xsl:for-each>
+ <hr/>
+
+ <p>
+   Files with Apache License headers will be marked AL<br/>
+   Binary files (which do not require AL headers) will be marked B<br/>
+  Compressed archives will be marked A<br/>
+  Notices, licenses etc will be marked N<br/>
+  </p>
+
+ <xsl:for-each select="descendant::resource">
+  <xsl:choose>
+   <xsl:when test="license-approval/@name=&quot;false&quot;">!</xsl:when>
+   <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+ </xsl:choose>
+ <xsl:choose>
+   <xsl:when test="type/@name=&quot;notice&quot;">N   </xsl:when>
+   <xsl:when test="type/@name=&quot;archive&quot;">A   </xsl:when>
+   <xsl:when test="type/@name=&quot;binary&quot;">B   </xsl:when>
+   <xsl:when test="type/@name=&quot;standard&quot;"><xsl:value-of select="header-type/@name"/></xsl:when>
+   <xsl:otherwise>!!!!!</xsl:otherwise>
+ </xsl:choose>
+ <xsl:text>      </xsl:text>
+ <xsl:value-of select="@name"/><br/>
+ <xsl:text>
+ </xsl:text>
+ </xsl:for-each>
+ <hr/>
+
+ <h3>Printing headers for files without AL header...</h3>
+
+ <xsl:for-each select="descendant::resource[header-type/@name=&quot;?????&quot;]">
+
+   <h4><xsl:value-of select="@name"/></h4>
+  <xsl:value-of select="header-sample"/>
+  <hr/>
+</xsl:for-each>
+<br/>
+
+ <!-- <xsl:apply-templates select="resource"/>
+    <xsl:apply-templates select="header-sample"/>
+    <xsl:apply-templates select="header-type"/>
+    <xsl:apply-templates select="license-family"/>
+    <xsl:apply-templates select="license-approval"/>
+    <xsl:apply-templates select="type"/> -->
+
+</xsl:template>
+
+<xsl:template match="resource">
+  <div>
+    <h3>Resource: <xsl:value-of select="@name"/></h3>
+      <xsl:apply-templates/>
+    </div>
+</xsl:template>
+
+<xsl:template match="header-sample">
+  <xsl:if test="normalize-space(.) != ''">
+  <h4>First few lines of non-compliant file</h4>
+    <p>
+      <xsl:value-of select="."/>
+    </p>
+    </xsl:if>
+    <h4>Other Info:</h4>
+</xsl:template>
+
+<xsl:template match="header-type">
+  Header Type: <xsl:value-of select="@name"/>
+  <br/>
+</xsl:template>
+
+<xsl:template match="license-family">
+  License Family: <xsl:value-of select="@name"/>
+  <br/>
+</xsl:template>
+
+<xsl:template match="license-approval">
+  License Approval: <xsl:value-of select="@name"/>
+  <br/>
+</xsl:template>
+
+<xsl:template match="type">
+  Type: <xsl:value-of select="@name"/>
+  <br/>
+</xsl:template>
+
+<xsl:template name="generated">
+</xsl:template>
+</xsl:transform>

--- a/apache-rat-gradle/src/gradle/src/test/groovy/org/apache/rat/gradle/RatIntegrationSpec.groovy
+++ b/apache-rat-gradle/src/gradle/src/test/groovy/org/apache/rat/gradle/RatIntegrationSpec.groovy
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rat.gradle
+
+import nebula.test.IntegrationSpec
+import nebula.test.functional.ExecutionResult
+
+/**
+ * Rat IntegrationSpec.
+ */
+class RatIntegrationSpec extends IntegrationSpec {
+
+    def 'success'() {
+        setup:
+        fork = true
+        def inputDir = buildFile.parentFile.absolutePath.replaceAll('\\\\', '/')
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'org.apache.rat'
+            rat {
+                verbose = true
+                inputDir = '$inputDir'
+                excludes = [
+                    'build.gradle', 'settings.gradle', 'build/**', '.gradle/**', '.gradle-test-kit/**',
+                    'no-license-file.txt'
+                ]
+            }
+        """.stripIndent()
+        createFile( 'no-license-file.txt' ).text = 'Nothing here.'
+
+        when:
+        ExecutionResult result = runTasksSuccessfully( 'check' )
+
+        then:
+        wasExecuted( 'rat' )
+        fileExists( 'build/reports/rat/rat-report.xml' )
+        fileExists( 'build/reports/rat/index.html' )
+    }
+
+    def 'do not fail but report errors when rat.failOnError is false'() {
+        setup:
+        fork = true
+        def inputDir = buildFile.parentFile.absolutePath.replaceAll('\\\\', '/')
+        buildFile << """
+            apply plugin: 'org.apache.rat'
+            rat {
+                verbose = true
+                inputDir = '$inputDir'
+                failOnError = false
+                excludes = [
+                    'build.gradle', 'settings.gradle', 'build/**', '.gradle/**', '.gradle-test-kit/**'
+                ]
+            }
+        """.stripIndent()
+        createFile( 'no-license-file.txt' ).text = 'Nothing here.'
+
+        when:
+        ExecutionResult result = runTasksSuccessfully( 'rat' )
+
+        then:
+        wasExecuted( 'rat' )
+        fileExists( 'build/reports/rat/rat-report.xml' )
+        fileExists( 'build/reports/rat/index.html' )
+    }
+
+    def 'fail the build when finding a file with unapproved/unknown license'() {
+        setup:
+        fork = true
+        def inputDir = buildFile.parentFile.absolutePath.replaceAll('\\\\', '/')
+        buildFile << """
+            apply plugin: 'org.apache.rat'
+            rat {
+                verbose = true
+                inputDir = '$inputDir'
+                excludes = [
+                    'build.gradle', 'settings.gradle', 'build/**', '.gradle/**', '.gradle-test-kit/**'
+                ]
+            }
+        """.stripIndent()
+        createFile( 'no-license-file.txt' ).text = 'Nothing here.'
+
+        when:
+        ExecutionResult result = runTasksWithFailure( 'rat' )
+
+        then:
+        wasExecuted( 'rat' )
+        fileExists( 'build/reports/rat/rat-report.xml' )
+        fileExists( 'build/reports/rat/index.html' )
+    }
+
+    def 'success on custom reportPath'() {
+        setup:
+        fork = true
+        def inputDir = buildFile.parentFile.absolutePath.replaceAll('\\\\', '/')
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'org.apache.rat'
+            rat {
+                verbose = true
+                inputDir = '$inputDir'
+                excludes = [
+                    'build.gradle', 'settings.gradle', 'build/**', '.gradle/**', '.gradle-test-kit/**',
+                    'no-license-file.txt'
+                ]
+                reportDir = file( 'build/reports/rat-custom' )
+            }
+        """.stripIndent()
+        createFile( 'no-license-file.txt' ).text = 'Nothing here.'
+
+        when:
+        ExecutionResult result = runTasksSuccessfully( 'check' )
+
+        then:
+        wasExecuted( 'rat' )
+        fileExists( 'build/reports/rat-custom/rat-report.xml' )
+        fileExists( 'build/reports/rat-custom/index.html' )
+    }
+
+}

--- a/apache-rat-gradle/src/gradle/src/test/groovy/org/apache/rat/gradle/RatPluginProjectSpec.groovy
+++ b/apache-rat-gradle/src/gradle/src/test/groovy/org/apache/rat/gradle/RatPluginProjectSpec.groovy
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.rat.gradle
+
+import nebula.test.PluginProjectSpec
+
+/**
+ * Rat PluginProjectSpec.
+ */
+class RatPluginProjectSpec extends PluginProjectSpec {
+    @Override
+    String getPluginName() { return 'org.apache.rat' }
+}
+

--- a/apache-rat-gradle/src/site/apt/index.apt
+++ b/apache-rat-gradle/src/site/apt/index.apt
@@ -1,0 +1,76 @@
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~   Licensed to the Apache Software Foundation (ASF) under one or more
+~~   contributor license agreements.  See the NOTICE file distributed with
+~~   this work for additional information regarding copyright ownership.
+~~   The ASF licenses this file to You under the Apache License, Version 2.0
+~~   (the "License"); you may not use this file except in compliance with
+~~   the License.  You may obtain a copy of the License at
+~~
+~~       http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~   Unless required by applicable law or agreed to in writing, software
+~~   distributed under the License is distributed on an "AS IS" BASIS,
+~~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~~   See the License for the specific language governing permissions and
+~~   limitations under the License.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+                        -----
+                        Introduction
+                        -----
+
+Apache Rat Gradle Plugin
+
+ The Gradle Plugin provides a single Gradle task to run Rat, the
+ {{{../index.html}Release Audit Tool}}, from inside {{{https://gradle.org/}Gradle}}.
+
+Requirements
+
+ The Rat Gradle Plugin requires Gradle 2.0 or higher, Apache Rat Ant Tasks and
+ transitively all dependencies of Apache Rat Ant Tasks.
+
+Installation
+
+ Build script snippet for use in all Gradle versions:
+
+-------
+buildscript {
+  repositories { mavenCentral() }
+  dependencies { classpath "org.apache.rat:apache-rat-gradle:${version}" }
+ }
+apply plugin: "org.apache.rat"
+-------
+
+ Build script snippet for new, incubating, plugin mechanism introduced in Gradle 2.1:
+
+-------
+plugins {
+  id "org.apache.rat" version "${version}"
+}
+-------
+
+Configuration
+
+-------
+rat {
+
+    // Input directory, defaults to '.'
+    inputDir = 'some/path'
+
+    // XML and HTML reports directory, defaults to project.buildDir + '/reports/rat'
+    reportDir = project.file( 'some/other/path' )
+
+    // List of exclude directives, defaults to ['**/.gradle/**']
+    excludes = [ '**/build/**' ]
+
+    // Fail the build on rat errors, defaults to true
+    failOnError = false
+
+}
+-------
+
+Usage
+
+-------
+gradle rat
+-------

--- a/apache-rat-gradle/src/site/resources/css/site.css
+++ b/apache-rat-gradle/src/site/resources/css/site.css
@@ -1,0 +1,27 @@
+/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.    
+*/
+footer {
+    font-family: "Mate SC", "Lucida Console", Monaco, monospace;
+    font-size: 9pt;
+    padding: 5px 10px;
+    text-align: justify;
+    border: thin solid #D0D0D0;
+    background-color: #F8F8F8;
+    color: #404040;
+}

--- a/apache-rat-gradle/src/site/site.xml
+++ b/apache-rat-gradle/src/site/site.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.3.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd"
+         name="Apache Rat&trade;">
+  <body>    
+    <head>
+        <link 
+            href='http://fonts.googleapis.com/css?family=Mate+SC' 
+            rel='stylesheet' 
+            type='text/css'/>
+    </head>
+  
+    <menu ref="parent"/>
+    <menu ref="reports"/>
+  </body>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -582,6 +582,10 @@ agnostic home for software distribution comprehension and audit tools.
       <name>Garrett Rooney</name>
       <email>rooneg@apache.org</email>
     </contributor>
+    <contributor>
+      <name>Paul Merlin</name>
+      <email>paulmerlin@apache.org</email>
+    </contributor>
   </contributors>
   <scm>
     <connection>scm:svn:http://svn.apache.org/repos/asf/creadur/rat/trunk</connection>
@@ -599,6 +603,7 @@ agnostic home for software distribution comprehension and audit tools.
     <module>apache-rat-api</module>
     <module>apache-rat-core</module>
     <module>apache-rat-plugin</module>
+    <module>apache-rat-gradle</module>
     <module>apache-rat-tasks</module>
     <module>apache-rat</module>
   </modules>

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -51,7 +51,9 @@ Apache Rat
 
    * {{{http://ant.apache.org/} Apache Ant}},
 
-   * {{{http://maven.apache.org}Apache Maven}} and
+   * {{{http://maven.apache.org}Apache Maven}},
+
+   * {{{https://gradle.org}Gradle}} and
 
    * the command line.
 
@@ -112,6 +114,17 @@ java -jar apache-rat-${project.version}.jar --help
 
  Read more {{{./apache-rat-plugin/index.html} here}}.
 
+** Gradle
+
+ Use the plugin for {{{https://gradle.org}Gradle}}.
+
++------------------------------------------+
+plugins {
+  id "org.apache.rat" version "${version}"
+}
++------------------------------------------+
+
+ Read more {{{./apache-rat-gradle/index.html} here}}.
 
 * Checking Out Rat
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -56,6 +56,7 @@
       <item name="From The Command Line" href="apache-rat/index.html"/>
       <item name="With Ant" href="apache-rat-tasks/index.html"/>
       <item name="With Maven" href="apache-rat-plugin/index.html"/>
+      <item name="With Gradle" href="apache-rat-gradle/index.html"/>
     </menu>
 
     <menu name="Apache Creadur&trade;" inherit="bottom">


### PR DESCRIPTION
Following up on RAT-163 here is a GitHub pull-request to review the contribution before donation.

* add an `apache-rat-gradle` maven module
* the maven module invoke Gradle to build the plugin
* `apache-release` profile should do the right thing
* add Gradle support information to the maven site
* deploy the artifact alongside the others for use from Maven Central
* commented facility to publish to https://plugins.gradle.org/ (see `apache-rat-gradle/pom.xml#L97`)
