### PR TITLE
Gradle RAT: Add plainOutput, xmlOutput and htmlOutput options

### DIFF
--- a/apache-rat-gradle/src/site/apt/index.apt
+++ b/apache-rat-gradle/src/site/apt/index.apt
@@ -66,6 +66,17 @@ rat {
     // Fail the build on rat errors, defaults to true
     failOnError = false
 
+    // Enable XML RAT output, defaults to true
+    xmlOutput = true
+
+    // Enable HTML RAT output, defaults to true
+    htmlOutput = true
+
+    // Enable plain text RAT output, defaults to false
+    // Please note that if xml or html output is enabled too,
+    // then two RAT runs will be needed to produce all reports.
+    plainOutput = false
+
 }
 -------
 


### PR DESCRIPTION
As requested in RAT-163, this pull-request contains changes to add RAT plain text output support.
BTW, xml & html output are now optional.
