### PR TITLE
RAT-224 website correction

### DIFF
--- a/apache-rat-plugin/src/site/apt/examples/custom-license.apt.vm
+++ b/apache-rat-plugin/src/site/apt/examples/custom-license.apt.vm
@@ -114,7 +114,7 @@ Approved License Families
           </licenses>
           <licenseFamilies>
             <licenseFamily implementation="org.apache.rat.license.SimpleLicenseFamily">
-              <familyName>Yet Another Software License</familyName>
+              <familyName>Yet Another Software License (YASL) 1.0</familyName>
             </licenseFamily>
           </licenseFamilies>
         </configuration>


### PR DESCRIPTION
If you follow the custom license example, it fails as the license isn't approved as mismatch between license familyName.