### PR TITLE
RAT-241: Do not emit all excludes at info logging

### DIFF
--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
@@ -405,8 +405,9 @@ public abstract class AbstractRatMojo extends AbstractMojo {
         if (excludes == null || excludes.length == 0) {
             getLog().info("No excludes explicitly specified.");
         } else {
+            getLog().info(excludes.length + " explicit excludes (use -debug for more details).");
         	for (final String exclude : excludes) {
-                getLog().info("Exclude: " + exclude);
+                getLog().debug("Exclude: " + exclude);
             }
         }
         if (excludes != null) {


### PR DESCRIPTION
This matches the behavior of includes.  Previously rat spammed the
maven logs but now has the succinct output:

```
[INFO] --- apache-rat-plugin:0.13-SNAPSHOT:check (default) @ jclouds-resources ---
[INFO] Enabled default license matchers.
[INFO] Will parse SCM ignores for exclusions...
[INFO] Finished adding exclusions from SCM ignore files.
[INFO] 61 implicit excludes (use -debug for more details).
[INFO] 56 explicit excludes (use -debug for more details).
[INFO] 2 resources included (use -debug for more details)
[INFO] Rat check: Summary over all files. Unapproved: 0, unknown: 0, generated: 0, approved: 2 licenses.
```