### PR TITLE
RAT-234: Support TypeScript .ts files

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/document/impl/guesser/BinaryGuesser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/document/impl/guesser/BinaryGuesser.java
@@ -226,8 +226,8 @@ public class BinaryGuesser {
             "NCB", "IDB",
             "SUO", "XCF",
             "RAJ", "CERT",
-            "KS", "TS",
-            "ODP", "SWF",
+            "KS",  "ODP",
+            "SWF",
             // fonts
             "WOFF2", "WOFF", "TTF", "EOT"
     };


### PR DESCRIPTION
RAT-234: The .ts extension is marked as binary as it is a common extension for datastream video files.
The .ts extension is used for TypeScript files so the .ts extension can't be use to determine the file content.

Removed TS from DATA_EXTENSIONS so .ts files are tested to determine the content