### PR TITLE
Stream backed writers passed to XMLWriter must use UTF-8 encoding

### DIFF
--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatCheckMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatCheckMojo.java
@@ -34,9 +34,12 @@ import org.apache.rat.report.claim.ClaimStatistic;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 
 /**
  * Run Rat to perform a violation check.
@@ -99,9 +102,11 @@ public class RatCheckMojo extends AbstractRatMojo {
 
     private ClaimStatistic getRawReport()
             throws MojoExecutionException, MojoFailureException {
-        FileWriter fw = null;
+        Writer fw = null;
         try {
-            fw = new FileWriter(reportFile);
+            fw = new OutputStreamWriter(
+                    new FileOutputStream(reportFile), 
+                    Charset.forName("UTF-8"));
             final ClaimStatistic statistic = createReport(fw, getStyleSheet());
             fw.close();
             fw = null;

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
@@ -42,6 +42,7 @@ package org.apache.rat.anttasks;
  import java.io.InputStream;
  import java.io.OutputStreamWriter;
  import java.io.PrintWriter;
+import java.nio.charset.Charset;
  import java.util.ArrayList;
  import java.util.List;
 
@@ -188,8 +189,8 @@ public class Report extends Task {
             if (reportFile == null) {
                 out = new PrintWriter(
                           new OutputStreamWriter(
-                              new LogOutputStream(this, Project.MSG_INFO)
-                              )
+                              new LogOutputStream(this, Project.MSG_INFO),
+                              Charset.forName("UTF-8"))
                           );
             } else {
                 out = new PrintWriter(new FileWriter(reportFile));


### PR DESCRIPTION
The XMLWriter writes a character stream and outputs 

<?xml version='1.0'?>

as XML declaration. The encoding declaration is missing, so encoding
must comply with UTF-8.

This change modifies the places where the output is written into a
file to use UTF-8 encoding. Without this change the default charset
of the platform is used, resulting in illegal bytesequences in the
output file.