### PR TITLE
RAT-212,RAT-253: Support all valid ASF2.0-License urls 

### DIFF
--- a/apache-rat-core/pom.xml
+++ b/apache-rat-core/pom.xml
@@ -65,6 +65,8 @@
               <exclude>src/test/resources/violations/FilterTest.cs</exclude>
               <!-- used to test for binary files; does not work on UTF-8 (e.g. MacOSX) -->
               <exclude>src/test/resources/binaries/Image-png.not</exclude>
+              <!-- These files have a valid license header that was not recognised by older rat versions -->
+              <exclude>src/test/resources/elements/TextHttps.txt</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/license/ApacheSoftwareLicense20.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/license/ApacheSoftwareLicense20.java
@@ -29,8 +29,19 @@ public final class ApacheSoftwareLicense20 extends SimplePatternBasedLicense {
     public static final String FIRST_LICENSE_LINE_SHORT = "Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.";
     public static final String LICENSE_REFERENCE_LINE = "http://www.apache.org/licenses/LICENSE-2.0";
 
+    // These are all allowed variants as mentioned in https://issues.apache.org/jira/browse/LEGAL-265
+    public static final String LICENSE_URL_HTTP       = LICENSE_REFERENCE_LINE;
+    public static final String LICENSE_URL_HTTPS      = "https://www.apache.org/licenses/LICENSE-2.0";
+    public static final String LICENSE_URL_HTTP_HTML  = "http://www.apache.org/licenses/LICENSE-2.0.html";
+    public static final String LICENSE_URL_HTTPS_HTML = "https://www.apache.org/licenses/LICENSE-2.0.html";
+    public static final String LICENSE_URL_HTTP_TXT   = "http://www.apache.org/licenses/LICENSE-2.0.txt";
+    public static final String LICENSE_URL_HTTPS_TXT  = "https://www.apache.org/licenses/LICENSE-2.0.txt";
     public ApacheSoftwareLicense20() {
         super(MetaData.RAT_LICENSE_FAMILY_CATEGORY_DATUM_ASL, MetaData.RAT_LICENSE_FAMILY_NAME_DATUM_APACHE_LICENSE_VERSION_2_0,
-                "", new String[]{FIRST_LICENSE_LINE, FIRST_LICENSE_LINE_SHORT, LICENSE_REFERENCE_LINE, });
+                "", new String[]{FIRST_LICENSE_LINE, FIRST_LICENSE_LINE_SHORT,
+                        LICENSE_URL_HTTP,       LICENSE_URL_HTTPS,
+                        LICENSE_URL_HTTP_HTML,  LICENSE_URL_HTTPS_HTML,
+                        LICENSE_URL_HTTP_TXT,   LICENSE_URL_HTTPS_TXT,});
     }
 }
+

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
@@ -50,9 +50,9 @@ public class ReportTest {
                 NL + "Notes: 2" + NL +//
                         "Binaries: 1" + NL +//
                         "Archives: 1" + NL +//
-                        "Standards: 6" + NL +//
+                        "Standards: 7" + NL +//
                         "" + NL +//
-                        "Apache Licensed: 3" + NL +//
+                        "Apache Licensed: 4" + NL +//
                         "Generated Documents: 0" + NL +//
                         "" + NL +//
                         "JavaDocs are generated, thus a license header is optional." + NL +//
@@ -84,6 +84,7 @@ public class ReportTest {
                         "  N     " + pElementsPath + "/NOTICE" + NL +//
                         " !????? " + pElementsPath + "/Source.java" + NL +//
                         "  AL    " + pElementsPath + "/Text.txt" + NL +//
+                        "  AL    " + pElementsPath + "/TextHttps.txt" + NL +//
                         "  AL    " + pElementsPath + "/Xml.xml" + NL +//
                         "  AL    " + pElementsPath + "/buildr.rb" + NL +//
                         "  A     " + pElementsPath + "/dummy.jar" + NL +//

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -82,6 +82,8 @@ public class XmlReportFactoryTest {
                 "</resource>" +
                 "<resource name='" + elementsPath + "/Text.txt'><type name='standard'/>" +
                 "</resource>" +
+                "<resource name='" + elementsPath + "/TextHttps.txt'><type name='standard'/>" +
+                "</resource>" +
                 "<resource name='" + elementsPath + "/Xml.xml'><type name='standard'/>" +
                 "</resource>" +
                 "<resource name='" + elementsPath + "/buildr.rb'><type name='standard'/>" +
@@ -91,7 +93,7 @@ public class XmlReportFactoryTest {
         assertTrue("Is well formed", XmlUtils.isWellFormedXml(output));
         assertEquals("Binary files", Integer.valueOf(1), statistic.getDocumentCategoryMap().get(MetaData.RAT_DOCUMENT_CATEGORY_VALUE_BINARY));
         assertEquals("Notice files", Integer.valueOf(2), statistic.getDocumentCategoryMap().get(MetaData.RAT_DOCUMENT_CATEGORY_VALUE_NOTICE));
-        assertEquals("Standard files", Integer.valueOf(5), statistic.getDocumentCategoryMap().get(MetaData.RAT_DOCUMENT_CATEGORY_VALUE_STANDARD));
+        assertEquals("Standard files", Integer.valueOf(6), statistic.getDocumentCategoryMap().get(MetaData.RAT_DOCUMENT_CATEGORY_VALUE_STANDARD));
         assertEquals("Archives", Integer.valueOf(1), statistic.getDocumentCategoryMap().get(MetaData.RAT_DOCUMENT_CATEGORY_VALUE_ARCHIVE));
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
@@ -121,6 +121,27 @@ public class XmlReportTest {
 "\n" +
 "            \n" +
 "</header-sample><header-type name='?????'/><license-family name='?????'/><type name='standard'/></resource>" +
+"<resource name='" + elementsPath + "/TextHttps.txt'><header-sample>/*\n" +
+" * Licensed to the Apache Software Foundation (ASF) under one\n" +
+" * or more contributor license agreements.  See the NOTICE file\n" +
+" * distributed with this work for additional information\n" +
+" * regarding copyright ownership.  The ASF licenses this file\n" +
+" * to you under the Apache License, Version 2.0 (the \"License\");\n" +
+" * you may not use this file except in compliance with the License.\n" +
+" * You may obtain a copy of the License at\n" +
+" *\n" +
+" *    https://www.apache.org/licenses/LICENSE-2.0.txt\n" +
+" *\n" +
+" * Unless required by applicable law or agreed to in writing,\n" +
+" * software distributed under the License is distributed on an\n" +
+" * \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n" +
+" * KIND, either express or implied.  See the License for the\n" +
+" * specific language governing permissions and limitations\n" +
+" * under the License.    \n" +
+" */\n" +
+"\n" +
+"            \n" +
+"</header-sample><header-type name='?????'/><license-family name='?????'/><type name='standard'/></resource>" +
                     "<resource name='" + elementsPath + "/Xml.xml'><header-sample>&lt;?xml version='1.0'?&gt;\n" +
 "&lt;!--\n" +
 " Licensed to the Apache Software Foundation (ASF) under one   *\n" +

--- a/apache-rat-core/src/test/resources/elements/TextHttps.txt
+++ b/apache-rat-core/src/test/resources/elements/TextHttps.txt
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.    
+ */
+
+            


### PR DESCRIPTION
An https url is currently classified as invalid.
According to https://issues.apache.org/jira/browse/LEGAL-265 these should be valid too.
This pull request intends to fix this.