### PR TITLE
RAT-260: Fix link to Travis status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apache Creadur Rat - Build status
 
-Travis: [![Build Status](https://travis-ci.org/apache/creadur-rat.svg?branch=master)](https://travis-ci.org/apache/creadur-rat.svg?branch=master)
+Travis: [![Build Status](https://travis-ci.org/apache/creadur-rat.svg?branch=master)](https://travis-ci.org/apache/creadur-rat)
 ASF Jenkins: [![ASF Jenkins Build Status](https://builds.apache.org/buildStatus/icon?job=Creadur-Rat&style=plastic)](https://builds.apache.org/view/A-D/view/Creadur/job/Creadur-Rat/)
 
 ## What is RAT?


### PR DESCRIPTION
Hello,

Current link is very confusing for users. We should link to travis status page.

Best regards,
Kamil