### PR TITLE
RAT-270: Change default logging behaviour to output errors onto console instead of rat.txt only

### DIFF
--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatCheckMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatCheckMojo.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Run Rat to perform a violation check.
@@ -93,11 +94,11 @@ public class RatCheckMojo extends AbstractRatMojo {
 
     /**
      * Whether to output the names of files that have unapproved licenses to the
-     * console.
+     * console. Defaults to {@code true} to ease builds in containers where you are unable to access rat.txt easily.
      *
      * @since 0.12
      */
-    @Parameter(property = "rat.consoleOutput", defaultValue = "false")
+    @Parameter(property = "rat.consoleOutput", defaultValue = "true")
     private boolean consoleOutput;
 
     private ClaimStatistic getRawReport()
@@ -106,7 +107,7 @@ public class RatCheckMojo extends AbstractRatMojo {
         try {
             fw = new OutputStreamWriter(
                    new FileOutputStream(reportFile),
-                   Charset.forName("UTF-8"));
+                    StandardCharsets.UTF_8);
             final ClaimStatistic statistic = createReport(fw, getStyleSheet());
             fw.close();
             fw = null;

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -55,6 +55,9 @@ The <action> type attribute can be add,update,fix,remove.
 
   <body>
     <release version="0.14-SNAPSHOT" date="2020-xx-xx" description="Current SNAPSHOT - to be done">
+      <action issue="RAT-270" type="add" dev="pottlinger">
+        Change default behaviour to output erroneous files to console. Can be disabled by setting rat.consoleOutput to false.
+      </action>
       <action issue="RAT-269" type="fix" dev="pottlinger">
         Update to latest Apache Ant to fix CVE-2020-1945.
       </action>


### PR DESCRIPTION
As requested by users and discussed via ML.