### PR TITLE
RequestForComments/Feedback - RAT-273: Due to JDK changes test expectations had to be changed when building against newer JDKs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 # RAT-296: disable JDK10 due to
 # Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
-        java: [8, 11, 12, 13, 14, 15]
+        java: [8, 11, 17, 18]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 # RAT-296: disable JDK10 due to
 # Caused by: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
-        java: [8, 11, 17, 18]
+# RAT-273: JDK18 is not there yet
+        java: [8, 11, 17]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,3 @@ jobs:
         - name: "Java 17"
           jdk: openjdk17
           script: mvn -e -B -V clean package site
-
-        - name: "Java 18 - newest"
-          jdk: openjdk18
-          script: mvn -e -B -V clean package site

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ jobs:
           jdk: openjdk8
           script: mvn -e -B -V clean package site
 
-        - name: "Java 14"
-          jdk: openjdk14
+        - name: "Java 11"
+          jdk: openjdk11
+          script: mvn -e -B -V clean package site
+
+        - name: "Java 17"
+          jdk: openjdk17
+          script: mvn -e -B -V clean package site
+
+        - name: "Java 18 - newest"
+          jdk: openjdk18
           script: mvn -e -B -V clean package site

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 
     tools {
         maven 'maven_3_latest'
-        jdk 'jdk_14_latest'
+        jdk 'jdk_17_latest'
     }
 
     options {

--- a/apache-rat-core/src/test/java/org/apache/rat/header/HeaderMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/header/HeaderMatcherTest.java
@@ -67,22 +67,38 @@ public class HeaderMatcherTest {
 
     @Test
     public void noLines() throws Exception {
-        StringReader reader = new StringReader("None");
+        StringReader reader = new StringReader("");
         matcher.read(reader);
         assertEquals("No lines read", 0, matcher.lines());
     }
-    
+
+    @Test
+    public void noLines_lineEndingHandledDifferentlyInNewerJDK() throws Exception {
+        StringReader reader = new StringReader("None");
+        matcher.read(reader);
+        int numberOfLinesRead = matcher.lines();
+        assertTrue("No lines read in older JDK or one line in newer JDK as implicit stream end is counted as line ending", numberOfLinesRead == 0 || numberOfLinesRead == 1);
+    }
+
+    @Test
+    public void lines_lineEndingHandledDifferentlyInNewerJDK() throws Exception {
+        StringReader reader = new StringReader("One\nTwo");
+        matcher.read(reader);
+        int numberOfLinesRead = matcher.lines();
+        assertTrue("One line read read in older JDK or two lines in newer JDK as implicit stream end is counted as line ending", numberOfLinesRead == 1 || numberOfLinesRead == 2);
+
+        reader = new StringReader("One\nTwo\nThree");
+        matcher.read(reader);
+        numberOfLinesRead = matcher.lines();
+        assertTrue("Two lines read read in older JDK or three lines in newer JDK as implicit stream end is counted as line ending", numberOfLinesRead == 2 || numberOfLinesRead == 3);
+    }
+
     @Test
     public void lines() throws Exception {
         StringReader reader = new StringReader("One\n");
         matcher.read(reader);
         assertEquals("One line read", 1, matcher.lines());
-        reader = new StringReader("One\nTwo");
-        matcher.read(reader);
-        assertEquals("One line read", 1, matcher.lines());
-        reader = new StringReader("One\nTwo\nThree");
-        matcher.read(reader);
-        assertEquals("Two lines read", 2, matcher.lines());
+
         reader = new StringReader("One\nTwo\nThree\n");
         matcher.read(reader);
         assertEquals("Three lines read", 3, matcher.lines());


### PR DESCRIPTION
LineNumberReader behaves differently in newer JDKs, thus test expectations read more lines as a line ending is treated differently than in JDK8.

see details in https://issues.apache.org/jira/browse/RAT-273

* [ ] RFC/ wait for feedback
* [ ] adapt changelog after merge to get these changes into the release log
* [ ] fix Javadoc errors happening with JDK17
* [ ] fix error in RatCheckMojoTest
```
Caused by: java.lang.reflect.InaccessibleObjectException: 
Unable to make field private static volatile java.nio.charset.Charset java.nio.charset.Charset.defaultCharset accessible: 
module java.base does not "opens java.nio.charset" to unnamed module @2a098129
```