### PR TITLE
Use new release in build of 0.15-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ agnostic home for software distribution comprehension and audit tools.
     <mavenChangesVersion>2.12.1</mavenChangesVersion>
     <mavenJavadocPluginVersion>3.4.0</mavenJavadocPluginVersion>
     <mavenPmdPluginVersion>3.16.0</mavenPmdPluginVersion>
-    <previousRatVersion>0.13</previousRatVersion>
+    <previousRatVersion>0.14</previousRatVersion>
   </properties>
   <distributionManagement>
     <site>
@@ -265,7 +265,7 @@ agnostic home for software distribution comprehension and audit tools.
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <!-- Do not use property values here as this causes problems during release -->
-        <version>0.13</version>
+        <version>0.14</version>
       </plugin>
     </plugins>
   </reporting>
@@ -326,7 +326,7 @@ agnostic home for software distribution comprehension and audit tools.
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <!-- Do not use property values here as this causes problems during release -->
-          <version>0.13</version>
+          <version>0.14</version>
           <configuration>
             <excludes>
               <!-- This file only describes how to build the project and it has no license header -->
@@ -368,7 +368,7 @@ agnostic home for software distribution comprehension and audit tools.
                     <artifactId>
         							apache-rat-plugin
         						</artifactId>
-                    <versionRange>[0.13,)</versionRange>
+                    <versionRange>[0.14,)</versionRange>
                     <goals>
                       <goal>check</goal>
                     </goals>
@@ -695,4 +695,11 @@ agnostic home for software distribution comprehension and audit tools.
       </build>
     </profile>
   </profiles>
+    <!-- in order to test new releases this reference can be activated locally
+    <pluginRepositories>
+      <pluginRepository>
+        <id>staged-releases-rat-014</id>
+        <url>https://repository.apache.org/content/repositories/orgapachecreadur-1007/</url>
+      </pluginRepository>
+    </pluginRepositories-->
 </project>


### PR DESCRIPTION
Needs to be merged once 0.14 is propagated as a new release
* vote thread is open until 2022-06-03 12:00 UTC

PR does not build properly as GH does not support defining custom repositories and the release 0.14 is not yet propagated to Maven central.