### PR TITLE
[RAT-309] Upgrade Maven Reporting API to 3.1.1/Complete with Maven Re…

### DIFF
--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -237,13 +237,23 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven.doxia</groupId>
+      <artifactId>doxia-integration-tools</artifactId>
+      <version>${doxiaSitetoolsVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-site-renderer</artifactId>
       <version>${doxiaSitetoolsVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.3.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
@@ -140,7 +140,7 @@ public abstract class AbstractRatMojo extends AbstractMojo {
      */
     @Parameter(property="rat.includesFileCharset", defaultValue="${project.build.sourceEncoding}")
     private String includesFileCharset;
-    
+
     /**
      * Specifies files, which are excluded in the report. By default, no files
      * are excluded.
@@ -236,7 +236,7 @@ public abstract class AbstractRatMojo extends AbstractMojo {
      * Holds the maven-internal project to allow resolution of artifact properties during mojo runs.
      */
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
-    private MavenProject project;
+    protected MavenProject project;
 
     /**
      * @return Returns the Maven project.
@@ -400,7 +400,7 @@ public abstract class AbstractRatMojo extends AbstractMojo {
     	}
     	return patterns;
     }
-    
+
     private void setExcludes(DirectoryScanner ds) throws MojoExecutionException {
         final List<String> excludeList = mergeDefaultExclusions();
         if (excludes == null || excludes.length == 0) {

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatReportMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatReportMojo.java
@@ -20,36 +20,36 @@ package org.apache.rat.mp;
  */
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.sink.SinkFactory;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
-import org.apache.maven.doxia.site.decoration.Body;
 import org.apache.maven.doxia.site.decoration.DecorationModel;
-import org.apache.maven.doxia.site.decoration.Skin;
 import org.apache.maven.doxia.siterenderer.Renderer;
 import org.apache.maven.doxia.siterenderer.RendererException;
 import org.apache.maven.doxia.siterenderer.RenderingContext;
 import org.apache.maven.doxia.siterenderer.SiteRenderingContext;
 import org.apache.maven.doxia.siterenderer.sink.SiteRendererSink;
+import org.apache.maven.doxia.tools.SiteTool;
+import org.apache.maven.doxia.tools.SiteToolException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.apache.maven.reporting.MavenReport;
+import org.apache.maven.reporting.MavenMultiPageReport;
 import org.apache.maven.reporting.MavenReportException;
+import org.apache.maven.shared.utils.WriterFactory;
 import org.apache.rat.Defaults;
+import org.codehaus.plexus.util.ReaderFactory;
+
+import static org.apache.maven.shared.utils.logging.MessageUtils.buffer;
 
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.*;
 
@@ -58,108 +58,318 @@ import java.util.*;
  * Generates a report with Rat's output.
  */
 @Mojo(name = "rat", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
-public class RatReportMojo extends AbstractRatMojo implements MavenReport {
-    public static final String DOT_HTML = ".html";
-    @Component
-    private Renderer siteRenderer;
-
-    @Component
-    private ArtifactFactory factory;
-
-    @Component
-    private ArtifactResolver resolver;
+public class RatReportMojo extends AbstractRatMojo implements MavenMultiPageReport {
 
     /**
-     * Specifies the directory where the report will be generated
+     * The output directory for the report. Note that this parameter is only evaluated if the goal is run directly from
+     * the command line. If the goal is run indirectly as part of a site generation, the output directory configured in
+     * the Maven Site Plugin is used instead.
      */
-    @Parameter(defaultValue = "${project.reporting.outputDirectory}", required = true)
-    private File outputDirectory;
-
-    @Parameter(defaultValue = "${localRepository}", required = true, readonly = true)
-    private ArtifactRepository localRepository;
+    @Parameter( defaultValue = "${project.reporting.outputDirectory}", readonly = true, required = true )
+    protected File outputDirectory;
 
     /**
-     * Returns the skins artifact file.
+     * Specifies the input encoding.
+     */
+    @Parameter( property = "encoding", defaultValue = "${project.build.sourceEncoding}", readonly = true )
+    private String inputEncoding;
+
+    /**
+     * Specifies the output encoding.
+     */
+    @Parameter( property = "outputEncoding", defaultValue = "${project.reporting.outputEncoding}", readonly = true )
+    private String outputEncoding;
+
+    /**
+     * The local repository.
+     */
+    @Parameter( defaultValue = "${localRepository}", readonly = true, required = true )
+    protected ArtifactRepository localRepository;
+
+    /**
+     * Remote repositories used for the project.
+     */
+    @Parameter( defaultValue = "${project.remoteArtifactRepositories}", readonly = true, required = true )
+    protected List<ArtifactRepository> remoteRepositories;
+
+    /**
+     * SiteTool.
+     */
+    @Component
+    protected SiteTool siteTool;
+
+    /**
+     * Doxia Site Renderer component.
+     */
+    @Component
+    protected Renderer siteRenderer;
+
+    /** The current sink to use */
+    private Sink sink;
+
+    /** The sink factory to use */
+    private SinkFactory sinkFactory;
+
+    /** The current report output directory to use */
+    private File reportOutputDirectory;
+
+
+    /**
+     * This method is called when the report generation is invoked directly as a standalone Mojo.
      *
-     * @return Artifact 
-     * @throws MojoFailureException   An error in the plugin configuration was detected.
-     * @throws MojoExecutionException An error occurred while searching for the artifact file.
+     * @throws MojoExecutionException if an error occurs when generating the report
+     * @see org.apache.maven.plugin.Mojo#execute()
      */
-    private Artifact getSkinArtifactFile() throws MojoFailureException, MojoExecutionException {
-        final Skin skin = Skin.getDefaultSkin();
-
-        String version = skin.getVersion();
-        final Artifact artifact;
-        try {
-            if (version == null) {
-                version = Artifact.RELEASE_VERSION;
-            }
-            VersionRange versionSpec = VersionRange.createFromVersionSpec(version);
-            artifact =
-                    factory.createDependencyArtifact(skin.getGroupId(), skin.getArtifactId(), versionSpec, "jar", null,
-                            null);
-
-            resolver.resolve(artifact, getProject().getRemoteArtifactRepositories(), localRepository);
-        } catch (InvalidVersionSpecificationException e) {
-            throw new MojoFailureException("The skin version '" + version + "' is not valid: " + e.getMessage());
-        } catch (ArtifactResolutionException e) {
-            throw new MojoExecutionException("Unable to find skin", e);
-        } catch (ArtifactNotFoundException e) {
-            throw new MojoFailureException("The skin does not exist: " + e.getMessage());
-        }
-
-        return artifact;
-    }
-
-    /**
-     * Called from Maven to invoke the plugin.
-     *
-     * @throws MojoFailureException   An error in the plugin configuration was detected.
-     * @throws MojoExecutionException An error occurred while creating the report.
-     */
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        if (skip) {
-            getLog().info("RAT will not execute since it is configured to be skipped via system property 'rat.skip'.");
+    @Override
+    public void execute()
+        throws MojoExecutionException
+    {
+        if ( !canGenerateReport() )
+        {
             return;
         }
 
-        final DecorationModel model = new DecorationModel();
-        model.setBody(new Body());
-        final Map<String, String> attributes = new HashMap<>();
-        attributes.put("outputEncoding", "UTF-8");
-        final Locale locale = Locale.getDefault();
-        try {
-            final SiteRenderingContext siteContext =
-                    siteRenderer.createContextForSkin(getSkinArtifactFile(), attributes, model, getName(locale),
-                            locale);
-            final RenderingContext context = new RenderingContext(outputDirectory, getOutputName() + DOT_HTML);
+        File outputDirectory = new File( getOutputDirectory() );
 
-            final SiteRendererSink sink = new SiteRendererSink(context);
-            generate(sink, locale);
+        String filename = getOutputName() + ".html";
 
-            if (!outputDirectory.mkdirs() && !outputDirectory.isDirectory()) {
-                throw new IOException("Could not create output directory " + outputDirectory);
+        Locale locale = Locale.getDefault();
+
+        try
+        {
+            SiteRenderingContext siteContext = createSiteRenderingContext( locale );
+
+            // copy resources
+            getSiteRenderer().copyResources( siteContext, outputDirectory );
+
+            // TODO Replace null with real value
+            RenderingContext docRenderingContext = new RenderingContext( outputDirectory, filename, null );
+
+            SiteRendererSink sink = new SiteRendererSink( docRenderingContext );
+
+            generate( sink, null, locale );
+
+            if ( !isExternalReport() ) // MSHARED-204: only render Doxia sink if not an external report
+            {
+                outputDirectory.mkdirs();
+
+                try ( Writer writer =
+                      new OutputStreamWriter( new FileOutputStream( new File( outputDirectory, filename ) ),
+                                              getOutputEncoding() ) )
+                {
+                    // render report
+                    getSiteRenderer().mergeDocumentIntoSite( writer, sink, siteContext );
+                }
             }
 
-
-            final Writer writer = new FileWriter(new File(outputDirectory, getOutputName() + DOT_HTML));
-
-            siteRenderer.generateDocument(writer, sink, siteContext);
-
-
-            siteRenderer.copyResources(siteContext, outputDirectory);
-        } catch (IOException | RendererException | MavenReportException e) {
-            throw new MojoExecutionException(e.getMessage(), e);
+            // copy generated resources also
+            getSiteRenderer().copyResources( siteContext, outputDirectory );
+        }
+        catch ( RendererException | IOException | MavenReportException e )
+        {
+            throw new MojoExecutionException(
+                "An error has occurred in " + getName( Locale.ENGLISH ) + " report generation.", e );
         }
     }
 
+    private SiteRenderingContext createSiteRenderingContext( Locale locale )
+            throws MavenReportException, IOException
+    {
+        DecorationModel decorationModel = new DecorationModel();
+
+        Map<String, Object> templateProperties = new HashMap<>();
+        // We tell the skin that we are rendering in standalone mode
+        templateProperties.put( "standalone", Boolean.TRUE );
+        templateProperties.put( "project", getProject() );
+        templateProperties.put( "inputEncoding", getInputEncoding() );
+        templateProperties.put( "outputEncoding", getOutputEncoding() );
+        // Put any of the properties in directly into the Velocity context
+        for ( Map.Entry<Object, Object> entry : getProject().getProperties().entrySet() )
+        {
+            templateProperties.put( (String) entry.getKey(), entry.getValue() );
+        }
+
+        SiteRenderingContext context;
+        try
+        {
+           Artifact skinArtifact =
+               siteTool.getSkinArtifactFromRepository( localRepository, remoteRepositories, decorationModel );
+
+           getLog().info( buffer().a( "Rendering content with " ).strong( skinArtifact.getId()
+               + " skin" ).a( '.' ).toString() );
+
+            context = siteRenderer.createContextForSkin( skinArtifact, templateProperties, decorationModel,
+                                                         project.getName(), locale );
+        }
+        catch ( SiteToolException e )
+        {
+            throw new MavenReportException( "Failed to retrieve skin artifact", e );
+        }
+        catch ( RendererException e )
+        {
+            throw new MavenReportException( "Failed to create context for skin", e );
+        }
+
+        // Generate static site
+        context.setRootDirectory( project.getBasedir() );
+
+        return context;
+    }
+
     /**
-     * Returns, whether the report may be generated.
+     * Generate a report.
      *
-     * @return Always true.
+     * @param sink the sink to use for the generation.
+     * @param locale the wanted locale to generate the report, could be null.
+     * @throws MavenReportException if any
+     * @deprecated use {@link #generate(Sink, SinkFactory, Locale)} instead.
      */
-    public boolean canGenerateReport() {
-        return true;
+    @Deprecated
+    @Override
+    public void generate( org.codehaus.doxia.sink.Sink sink, Locale locale )
+        throws MavenReportException
+    {
+        generate( sink, null, locale );
+    }
+
+    /**
+     * Generate a report.
+     *
+     * @param sink
+     * @param locale
+     * @throws MavenReportException
+     * @deprecated use {@link #generate(Sink, SinkFactory, Locale)} instead.
+     */
+    @Deprecated
+    public void generate( Sink sink, Locale locale )
+        throws MavenReportException
+    {
+        generate( sink, null, locale );
+    }
+
+    /**
+     * This method is called when the report generation is invoked by maven-site-plugin.
+     *
+     * @param sink
+     * @param sinkFactory
+     * @param locale
+     * @throws MavenReportException
+     */
+    @Override
+    public void generate( Sink sink, SinkFactory sinkFactory, Locale locale )
+        throws MavenReportException
+    {
+        if ( !canGenerateReport() )
+        {
+            getLog().info( "This report cannot be generated as part of the current build. "
+                           + "The report name should be referenced in this line of output." );
+            return;
+        }
+
+        this.sink = sink;
+
+        this.sinkFactory = sinkFactory;
+
+        executeReport( locale );
+
+        closeReport();
+    }
+
+    /**
+     * @return CATEGORY_PROJECT_REPORTS
+     */
+    @Override
+    public String getCategoryName()
+    {
+        return CATEGORY_PROJECT_REPORTS;
+    }
+
+    @Override
+    public File getReportOutputDirectory()
+    {
+        if ( reportOutputDirectory == null )
+        {
+            reportOutputDirectory = new File( getOutputDirectory() );
+        }
+
+        return reportOutputDirectory;
+    }
+
+    @Override
+    public void setReportOutputDirectory( File reportOutputDirectory )
+    {
+        this.reportOutputDirectory = reportOutputDirectory;
+        this.outputDirectory = reportOutputDirectory;
+    }
+
+    protected String getOutputDirectory()
+    {
+        return outputDirectory.getAbsolutePath();
+    }
+
+    protected Renderer getSiteRenderer()
+    {
+        return siteRenderer;
+    }
+
+    /**
+     * Gets the input files encoding.
+     *
+     * @return The input files encoding, never <code>null</code>.
+     */
+    protected String getInputEncoding()
+    {
+        return ( inputEncoding == null ) ? ReaderFactory.FILE_ENCODING : inputEncoding;
+    }
+
+    /**
+     * Gets the effective reporting output files encoding.
+     *
+     * @return The effective reporting output file encoding, never <code>null</code>.
+     */
+    protected String getOutputEncoding()
+    {
+        return ( outputEncoding == null ) ? WriterFactory.UTF_8 : outputEncoding;
+    }
+
+    /**
+     * Actions when closing the report.
+     */
+    protected void closeReport()
+    {
+        getSink().close();
+    }
+
+    /**
+     * @return the sink used
+     */
+    public Sink getSink()
+    {
+        return sink;
+    }
+
+    /**
+     * @return the sink factory used
+     */
+    public SinkFactory getSinkFactory()
+    {
+        return sinkFactory;
+    }
+
+    /**
+     * @see org.apache.maven.reporting.MavenReport#isExternalReport()
+     * @return {@code false} by default.
+     */
+    @Override
+    public boolean isExternalReport()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean canGenerateReport()
+    {
+        return !skip;
     }
 
     /**
@@ -167,6 +377,7 @@ public class RatReportMojo extends AbstractRatMojo implements MavenReport {
      *
      * @return Version number, if found, or null.
      */
+    // TODO The canonical way is to read the pom.properties for the artifact desired in META-INF/maven
     private String getRatVersion() {
         //noinspection unchecked
         for (Artifact a : (Iterable<Artifact>) getProject().getDependencyArtifacts()) {
@@ -184,7 +395,7 @@ public class RatReportMojo extends AbstractRatMojo implements MavenReport {
      * @param locale The locale to use for writing the report.
      * @throws MavenReportException Writing the report failed.
      */
-    public void generate(Sink sink, Locale locale) throws MavenReportException {
+    protected void executeReport(Locale locale) throws MavenReportException {
         ResourceBundle bundle = getBundle(locale);
         final String title = bundle.getString("report.rat.title");
         sink.head();
@@ -226,15 +437,6 @@ public class RatReportMojo extends AbstractRatMojo implements MavenReport {
     }
 
     /**
-     * Returns the reports category name.
-     *
-     * @return {@link MavenReport#CATEGORY_PROJECT_REPORTS}
-     */
-    public String getCategoryName() {
-        return MavenReport.CATEGORY_PROJECT_REPORTS;
-    }
-
-    /**
      * Returns the reports bundle
      *
      * @param locale Requested locale of the bundle
@@ -271,32 +473,5 @@ public class RatReportMojo extends AbstractRatMojo implements MavenReport {
      */
     public String getOutputName() {
         return "rat-report";
-    }
-
-    /**
-     * Returns the reports output directory.
-     *
-     * @return Value of the "outputDirectory" parameter.
-     */
-    public File getReportOutputDirectory() {
-        return outputDirectory;
-    }
-
-    /**
-     * Returns, whether this is an external report.
-     *
-     * @return Always false.
-     */
-    public boolean isExternalReport() {
-        return false;
-    }
-
-    /**
-     * Sets the reports output directory.
-     *
-     * @param pOutputDirectory Reports target directory.
-     */
-    public void setReportOutputDirectory(File pOutputDirectory) {
-        outputDirectory = pOutputDirectory;
     }
 }


### PR DESCRIPTION
…porting Impl 3.2.0

This not only upgrades to Maven Reporting API 3.1.1, but also logically
completes this plugin with bits from Maven Reporting Impl 3.2.0 because
we cannot inherit from AbstractMavenReport since Java does not support
multiple inheritance. It should now behave as if using m-r-impl.