### PR TITLE
RAT-322: add option to be able to scan hidden directories and minor cleanups

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -96,6 +96,10 @@ public class Report {
      */
     private static final String NO_DEFAULTS = "no-default-licenses";
     /**
+     * Scan hidden directory, e.g. directory starting with dot.
+     */
+    private static final String SCAN_HIDDEN_DIRECTORIES = "scan-hidden-directories";
+    /**
      * List the licenses that were used for the run.
      */
     private static final String LIST_LICENSES = "list-licenses";
@@ -147,6 +151,10 @@ public class Report {
         if (args == null || args.length != 1) {
             printUsage(opts);
         } else {
+
+            if (cl.hasOption(SCAN_HIDDEN_DIRECTORIES)) {
+                configuration.setScanHiddenDirectories(true);
+            }
 
             if (cl.hasOption('a') || cl.hasOption('A')) {
                 configuration
@@ -272,6 +280,7 @@ public class Report {
         opts.addOption(null, LICENSES, true, "File names or URLs for license definitions");
         opts.addOption(null, LIST_LICENSES, false, "List all active licenses");
         opts.addOption(null, LIST_LICENSE_FAMILIES, false, "List all defined license families");
+        opts.addOption(null, SCAN_HIDDEN_DIRECTORIES, false, "Scan hidden directories e.g. directory starting with dot");
 
         OptionGroup addLicenseGroup = new OptionGroup();
         String addLicenseDesc = "Add the default license header to any file with an unknown license that is not in the exclusion list. "
@@ -359,7 +368,7 @@ public class Report {
             }
 
             if (base.isDirectory()) {
-                return new DirectoryWalker(base, config.getInputFileFilter());
+                return new DirectoryWalker(base, config.getInputFileFilter(), config.isScanHiddenDirectories());
             }
 
             try {

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -59,6 +59,7 @@ public class ReportConfiguration {
     private IOSupplier<InputStream> styleSheet = null;
     private IReportable reportable = null;
     private FilenameFilter inputFileFilter = null;
+    private boolean scanHiddenDirectories = false;
 
     /**
      * @return The filename filter for the potential input files.
@@ -194,7 +195,7 @@ public class ReportConfiguration {
      * Adds multiple licenses to the list of licenses. Does not add the licenses to
      * the list of approved licenses.
      *
-     * @param license The license t oadd.
+     * @param licenses The licenses to add.
      */
     public void addLicenses(Collection<ILicense> licenses) {
         this.licenses.addAll(licenses);
@@ -277,7 +278,6 @@ public class ReportConfiguration {
      * This value is ignored, if no license headers are added.
      *
      * @param copyrightMessage message to set.
-     * @see #setAddingLicenses(boolean)
      */
     public void setCopyrightMessage(String copyrightMessage) {
         this.copyrightMessage = copyrightMessage;
@@ -308,7 +308,6 @@ public class ReportConfiguration {
      * 
      * @param addLicenseHeaders enables/disables or forces adding of licenses
      * headers.
-     * @see #setAddingLicensesForced(boolean)
      * @see #setCopyrightMessage(String)
      */
     public void setAddLicenseHeaders(AddLicenseHeaders addLicenseHeaders) {
@@ -367,9 +366,26 @@ public class ReportConfiguration {
     }
 
     /**
+     *
+     * @return true if rat scan hidden directories (e.g. directory starting with dot), false to ignore hidden directories
+     */
+    public boolean isScanHiddenDirectories() {
+        return this.scanHiddenDirectories;
+    }
+
+    /**
+     * Define if rat should scan hidden directories (e.g. directory starting with dot) or not.
+     *
+     * @param scanHiddenDirectories true to scan hidden directories, false else.
+     */
+    public void setScanHiddenDirectories(boolean scanHiddenDirectories) {
+        this.scanHiddenDirectories = scanHiddenDirectories;
+    }
+
+    /**
      * Validates that the configuration is valid.
      * 
-     * @param a String consumer to log warning messages to.
+     * @param logger String consumer to log warning messages to.
      */
     public void validate(Consumer<String> logger) {
         if (reportable == null) {

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/DirectoryWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/DirectoryWalker.java
@@ -37,8 +37,10 @@ public class DirectoryWalker extends Walker implements IReportable {
 
     protected static final FileNameComparator COMPARATOR = new FileNameComparator();
 
-    public DirectoryWalker(File file) {
-        this(file, (FilenameFilter) null);
+    private boolean walkHiddenDirectories = false;
+
+    public DirectoryWalker(File file, boolean walkHiddenDirectories) {
+        this(file, (FilenameFilter) null, walkHiddenDirectories);
     }
 
     /**
@@ -47,17 +49,16 @@ public class DirectoryWalker extends Walker implements IReportable {
      * @param file   not null
      * @param filter filters input files (optional),
      *               or null when no filtering should be performed
+     * @param walkHiddenDirectories true to walk hidden directories (e.g. directory with a dot), false else
      */
-    public DirectoryWalker(File file, final FilenameFilter filter) {
+    public DirectoryWalker(File file, final FilenameFilter filter, boolean walkHiddenDirectories) {
         super(file.getPath(), file, filter);
+        this.walkHiddenDirectories = walkHiddenDirectories;
     }
 
-    public DirectoryWalker(File file, final Pattern ignoreNameRegex) {
+    public DirectoryWalker(File file, final Pattern ignoreNameRegex, boolean walkHiddenDirectories) {
         super(file.getPath(), file, regexFilter(ignoreNameRegex));
-    }
-
-    public boolean isRestricted() {
-        return false;
+        this.walkHiddenDirectories = walkHiddenDirectories;
     }
 
     /**
@@ -68,7 +69,11 @@ public class DirectoryWalker extends Walker implements IReportable {
      * @throws RatException
      */
     private void processDirectory(RatReport report, final File file) throws RatException {
-        if (!isRestricted(file)) {
+        if (file.getName().startsWith(".")) {
+            if (walkHiddenDirectories) {
+                process(report, file);
+            }
+        } else {
             process(report, file);
         }
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/Walker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/Walker.java
@@ -48,10 +48,6 @@ public abstract class Walker implements IReportable {
             }
         };
     }
-
-    protected boolean isRestricted(File file) {
-        return file.getName().startsWith(".");
-    }
  
     protected final boolean isNotIgnored(final File file) {
         boolean result = false;

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
@@ -51,7 +51,7 @@ public class ReporterTest {
         final ReportConfiguration configuration = new ReportConfiguration();
         configuration.setStyleReport(false);
         configuration.setFrom(defaults);
-        configuration.setReportable(new DirectoryWalker(new File(elementsPath)));
+        configuration.setReportable(new DirectoryWalker(new File(elementsPath), false));
         configuration.setOut(() -> out);
         Reporter.report(configuration);
         Document doc = XmlUtils.toDom(new ByteArrayInputStream(out.toByteArray()));
@@ -91,7 +91,7 @@ public class ReporterTest {
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
         final ReportConfiguration configuration = new ReportConfiguration();
         configuration.setFrom(defaults);
-        configuration.setReportable(new DirectoryWalker(new File(elementsPath)));
+        configuration.setReportable(new DirectoryWalker(new File(elementsPath), false));
         configuration.setOut(() -> out);
         Reporter.report(configuration);
 

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -75,7 +75,7 @@ public class XmlReportFactoryTest {
         when(mockLicense.matches(any())).thenReturn(State.t);
         when(mockLicense.getLicenseFamily()).thenReturn(family);
 
-        DirectoryWalker directory = new DirectoryWalker(new File(elementsPath), IGNORE_EMPTY);
+        DirectoryWalker directory = new DirectoryWalker(new File(elementsPath), IGNORE_EMPTY, false);
         final ClaimStatistic statistic = new ClaimStatistic();
         final ReportConfiguration configuration = new ReportConfiguration();
         configuration.addLicense(mockLicense);

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
@@ -88,7 +88,7 @@ public class XmlReportTest {
     @Test
     public void baseReport() throws Exception {
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
-        DirectoryWalker directory = new DirectoryWalker(new File(elementsPath), IGNORE);
+        DirectoryWalker directory = new DirectoryWalker(new File(elementsPath), IGNORE, false);
         report.startReport();
         report(directory);
         report.endReport();

--- a/apache-rat-core/src/test/java/org/apache/rat/walker/DirectoryWalkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/walker/DirectoryWalkerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
+package org.apache.rat.walker;
+
+import org.apache.rat.api.Document;
+import org.apache.rat.api.RatException;
+import org.apache.rat.report.RatReport;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DirectoryWalkerTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void walk() throws IOException, RatException {
+        File toWalk = folder.newFolder("test");
+        File regular = new File(toWalk, "regular");
+        regular.mkdir();
+        File regularFile = new File(regular, "test");
+        FileWriter writer = new FileWriter(regularFile);
+        writer.write("test");
+        writer.flush();
+        writer.close();
+
+        File hidden = new File(toWalk, ".hidden");
+        hidden.mkdir();
+        File hiddenFile = new File(hidden, "test");
+        writer = new FileWriter(hiddenFile);
+        writer.write("test");
+        writer.flush();
+        writer.close();
+
+        DirectoryWalker walker = new DirectoryWalker(toWalk, false);
+        List<String> scanned = new ArrayList<>();
+        walker.run(new TestRatReport(scanned));
+
+        Assert.assertEquals(1, scanned.size());
+
+        walker = new DirectoryWalker(toWalk, true);
+        scanned = new ArrayList<>();
+        walker.run(new TestRatReport(scanned));
+
+        Assert.assertEquals(2, scanned.size());
+    }
+
+    class TestRatReport implements RatReport {
+
+        private List<String> scanned;
+
+        public TestRatReport(List<String> scanned) {
+            this.scanned = scanned;
+        }
+
+        @Override
+        public void startReport() throws RatException {
+            System.out.println("Start");
+        }
+
+        @Override
+        public void report(Document document) throws RatException {
+            scanned.add(document.getName());
+        }
+
+        @Override
+        public void endReport() throws RatException {
+            System.out.println("End");
+        }
+    }
+
+}

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatCheckMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatCheckMojo.java
@@ -95,6 +95,15 @@ public class RatCheckMojo extends AbstractRatMojo {
     private boolean consoleOutput;
 
     /**
+     * Enable scan on hidden directories (e.g. directory starting with dot).
+     * Defaults is {@code false}.
+     *
+     * @since 0.16
+     */
+    @Parameter(property = "rat.scanHiddenDirectories", defaultValue = "false")
+    private boolean scanHiddenDirectories;
+
+    /**
      * Invoked by Maven to execute the Mojo.
      *
      * @throws MojoFailureException An error in the plugin configuration was
@@ -109,6 +118,7 @@ public class RatCheckMojo extends AbstractRatMojo {
             return;
         }
         ReportConfiguration config = getConfiguration();
+        config.setScanHiddenDirectories(scanHiddenDirectories);
         config.setFrom(getDefaultsBuilder().build());
         logLicenses(config.getLicenses(LicenseFilter.all));
         final File parent = reportFile.getParentFile();

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
@@ -107,10 +107,14 @@ public class Report extends Task {
         licenses.add(lic);
     }
 
+    public void setScanHiddenDirectories(boolean scanHiddenDirectories) {
+        configuration.setScanHiddenDirectories(scanHiddenDirectories);
+    }
+
     /**
      * 
      * @param styleSheet
-     * @deprecated us {@link #addStyleSheet(File)}
+     * @deprecated us {@link #addStyleSheet(Resource)}
      */
     @Deprecated
     public void addStylesheet(Resource styleSheet) {


### PR DESCRIPTION
* add support to scan hidden directories flag to `DirectoryWalker`
* add scan hidden directories to the `ReportConfiguration`
* cleanup `Walker` moving `isRestricted` to the `DirectoryWalker` as it's specific
* expose scan hidden directories configuration in CLI, Ant task and Maven plugin