### PR TITLE
RAT-335: Improve the parsing of gitignore files.

### DIFF
--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -89,6 +89,8 @@
               <exclude>src/test/resources/unit/it2/src.txt</exclude>
               <exclude>src/test/resources/unit/it3/src.apt</exclude>
               <exclude>src/test/resources/unit/it4/*.html</exclude>
+              <exclude>src/test/resources/unit/RAT-335-GitIgnore/*</exclude>
+              <exclude>src/test/resources/unit/RAT-335-GitIgnore/**/*</exclude>
               <exclude>**/*.iml</exclude>
               <!-- RAT-171: needs to be added since SCM ignores are only parsed in project root -->
               <exclude>**/.bzrignore</exclude>
@@ -286,6 +288,17 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>nl.basjes.gitignore</groupId>
+      <artifactId>gitignore-reader</artifactId>
+      <version>1.2.1</version>
     </dependency>
   </dependencies>
   <reporting>

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ExclusionHelper.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ExclusionHelper.java
@@ -2,12 +2,16 @@ package org.apache.rat.mp.util;
 
 import org.apache.maven.plugin.logging.Log;
 import org.apache.rat.config.SourceCodeManagementSystems;
+import org.codehaus.plexus.util.AbstractScanner;
 import org.codehaus.plexus.util.DirectoryScanner;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.codehaus.plexus.util.AbstractScanner.DEFAULTEXCLUDES;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -68,22 +72,22 @@ public final class ExclusionHelper {
                     "*.iws", //
                     ".idea/**/*"));
 
-    public static void addPlexusAndScmDefaults(Log log, final boolean useDefaultExcludes,
-                                               final Set<String> excludeList1) {
+    public static Set<String> addPlexusAndScmDefaults(Log log, final boolean useDefaultExcludes) {
+        Set<String> excludeList = new HashSet<>();
         if (useDefaultExcludes) {
             log.debug("Adding plexus default exclusions...");
-            Collections.addAll(excludeList1, DirectoryScanner.DEFAULTEXCLUDES);
+            Collections.addAll(excludeList, DEFAULTEXCLUDES);
             log.debug("Adding SCM default exclusions...");
-            excludeList1.addAll(//
-                    SourceCodeManagementSystems.getPluginExclusions());
+            excludeList.addAll(SourceCodeManagementSystems.getPluginExclusions());
         } else {
             log.debug("rat.useDefaultExcludes set to false. "
                     + "Plexus and SCM default exclusions will not be added");
         }
+        return excludeList;
     }
 
-    public static void addMavenDefaults(Log log, boolean useMavenDefaultExcludes,
-                                        final Set<String> excludeList) {
+    public static Set<String> addMavenDefaults(Log log, boolean useMavenDefaultExcludes) {
+        Set<String> excludeList = new HashSet<>();
         if (useMavenDefaultExcludes) {
             log.debug("Adding exclusions often needed by Maven projects...");
             excludeList.addAll(MAVEN_DEFAULT_EXCLUDES);
@@ -91,10 +95,11 @@ public final class ExclusionHelper {
             log.debug("rat.useMavenDefaultExcludes set to false. "
                     + "Exclusions often needed by Maven projects will not be added.");
         }
+        return excludeList;
     }
 
-    public static void addEclipseDefaults(Log log, boolean useEclipseDefaultExcludes,
-                                          final Set<String> excludeList) {
+    public static Set<String> addEclipseDefaults(Log log, boolean useEclipseDefaultExcludes) {
+        Set<String> excludeList = new HashSet<>();
         if (useEclipseDefaultExcludes) {
             log.debug("Adding exclusions often needed by projects "
                     + "developed in Eclipse...");
@@ -104,10 +109,11 @@ public final class ExclusionHelper {
                     + "Exclusions often needed by projects developed in "
                     + "Eclipse will not be added.");
         }
+        return excludeList;
     }
 
-    public static void addIdeaDefaults(Log log, boolean useIdeaDefaultExcludes,
-                                       final Set<String> excludeList) {
+    public static Set<String> addIdeaDefaults(Log log, boolean useIdeaDefaultExcludes) {
+        Set<String> excludeList = new HashSet<>();
         if (useIdeaDefaultExcludes) {
             log.debug("Adding exclusions often needed by projects "
                     + "developed in IDEA...");
@@ -117,6 +123,7 @@ public final class ExclusionHelper {
                     + "Exclusions often needed by projects developed in "
                     + "IDEA will not be added.");
         }
+        return excludeList;
     }
 
 }

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/GitIgnoreMatcher.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/GitIgnoreMatcher.java
@@ -1,0 +1,56 @@
+package org.apache.rat.mp.util.ignore;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import nl.basjes.gitignore.GitIgnoreFileSet;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.File;
+import java.util.Optional;
+
+public class GitIgnoreMatcher implements IgnoreMatcher {
+
+    private final GitIgnoreFileSet gitIgnoreFileSet;
+
+    public GitIgnoreMatcher(final Log log, final File projectBaseDir) {
+        log.debug("Recursively loading .gitignore files in " + projectBaseDir);
+        // This will walk the project tree and load all .gitignore files
+        gitIgnoreFileSet = new GitIgnoreFileSet(projectBaseDir);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return gitIgnoreFileSet.isEmpty();
+    }
+
+    @Override
+    public Optional<Boolean> isIgnoredFile(String filename) {
+        Boolean isIgnoredFile = gitIgnoreFileSet.isIgnoredFile(filename);
+        if (isIgnoredFile == null) {
+            return Optional.empty();
+        }
+        return Optional.of(isIgnoredFile);
+    }
+
+    @Override
+    public String toString() {
+        return "Loaded .gitignore data:\n" + gitIgnoreFileSet;
+    }
+}

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/GlobIgnoreMatcher.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/GlobIgnoreMatcher.java
@@ -1,0 +1,136 @@
+package org.apache.rat.mp.util.ignore;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public class GlobIgnoreMatcher implements IgnoreMatcher {
+
+    final List<String> exclusionLines = new ArrayList<>();
+
+    private static final List<String> COMMENT_PREFIXES = Arrays.asList("#", "##", "//", "/**", "/*");
+
+    public GlobIgnoreMatcher() {
+        // No rules to load
+    }
+
+    public GlobIgnoreMatcher(final Log log, final File scmIgnore) {
+        loadFile(log, scmIgnore);
+    }
+
+    /**
+     * Add a single rule to the set
+     * @param rule The line that matches some files
+     */
+    public void addRule(final String rule) {
+        if (!exclusionLines.contains(rule)) {
+            exclusionLines.add(rule);
+        }
+    }
+
+    /**
+     * Add a set of rules to the set
+     * @param rules The line that matches some files
+     */
+    public void addRules(final Collection<String> rules) {
+        for (String rule : rules) {
+            if (!exclusionLines.contains(rule)) {
+                exclusionLines.add(rule);
+            }
+        }
+    }
+
+    /**
+     * Parses excludes from the given SCM ignore file.
+     *
+     * @param log       Maven log to show output during RAT runs.
+     * @param scmIgnore if <code>null</code> or invalid an empty list of exclusions is returned.
+     */
+    public void loadFile(final Log log, final File scmIgnore) {
+        if (scmIgnore != null && scmIgnore.exists() && scmIgnore.isFile()) {
+            log.debug("Parsing exclusions from " + scmIgnore);
+            BufferedReader reader = null;
+            try {
+                reader = new BufferedReader(new FileReader(scmIgnore));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (!isComment(line)) {
+                        exclusionLines.add(line);
+                        log.debug("Added " + line);
+                    }
+                }
+            } catch (final IOException e) {
+                log.warn("Cannot parse " + scmIgnore + " for exclusions. Will skip this file.");
+                log.debug("Skip parsing " + scmIgnore + " due to " + e.getMessage());
+            } finally {
+                IOUtils.closeQuietly(reader);
+            }
+        }
+    }
+
+    /**
+     * Determines whether the given line is a comment or not based on scanning
+     * for prefixes
+     * {@see COMMENT_PREFIXES}.
+     *
+     * @param line line to verify.
+     * @return <code>true</code> if the given line is a commented out line.
+     */
+    public static boolean isComment(final String line) {
+        if (line == null || line.length() <= 0) {
+            return false;
+        }
+
+        final String trimLine = line.trim();
+        for (String prefix : COMMENT_PREFIXES) {
+            if (trimLine.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<String> getExclusionLines() {
+        return exclusionLines;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return exclusionLines.isEmpty();
+    }
+
+    @Override
+    public Optional<Boolean> isIgnoredFile(String filename) {
+        // Not used for Glob Rules; using the DirectoryScanner instead
+        // It CAN be moved here if so desired.
+        return Optional.empty() ;
+    }
+}

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/IgnoreMatcher.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/IgnoreMatcher.java
@@ -1,0 +1,37 @@
+package org.apache.rat.mp.util.ignore;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Optional;
+
+public interface IgnoreMatcher {
+    /**
+     * Checks if the file matches the stored expressions.
+     * @param filename The filename to be checked
+     * @return empty: not matched, True: must be ignored, False: it must be UNignored
+     */
+    Optional<Boolean> isIgnoredFile(String filename);
+
+    /**
+     * Returns {@code true} if this IgnoreMatcher contains no rules.
+     * @return {@code true} if this IgnoreMatcher contains no rules
+     */
+    boolean isEmpty();
+}

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/IgnoringDirectoryScanner.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/IgnoringDirectoryScanner.java
@@ -1,0 +1,74 @@
+package org.apache.rat.mp.util.ignore;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.util.DirectoryScanner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
+public class IgnoringDirectoryScanner extends DirectoryScanner {
+
+    public IgnoringDirectoryScanner() {
+        super();
+    }
+
+    List<IgnoreMatcher> ignoreMatcherList = new ArrayList<>();
+
+    public void addIgnoreMatcher(IgnoreMatcher ignoreMatcher) {
+        ignoreMatcherList.add(ignoreMatcher);
+    }
+
+    private boolean matchesAnIgnoreMatcher(String name) {
+        for (IgnoreMatcher ignoreMatcher : ignoreMatcherList) {
+            if (ignoreMatcher.isIgnoredFile(name).orElse(FALSE) == TRUE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected boolean isExcluded(String name) {
+        if (matchesAnIgnoreMatcher(name)) {
+            return true;
+        }
+        return super.isExcluded(name);
+    }
+
+    @Override
+    protected boolean isExcluded(String name, String[] tokenizedName) {
+        if (matchesAnIgnoreMatcher(name)) {
+            return true;
+        }
+        return super.isExcluded(name, tokenizedName);
+    }
+
+    @Override
+    protected boolean isExcluded(String name, char[][] tokenizedName) {
+        if (matchesAnIgnoreMatcher(name)) {
+            return true;
+        }
+        return super.isExcluded(name, tokenizedName);
+    }
+}

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/util/ExclusionHelperTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/util/ExclusionHelperTest.java
@@ -56,33 +56,33 @@ public class ExclusionHelperTest {
     @Test
     public void testAddingEclipseExclusions() {
         final Set<String> exclusion = new HashSet<>();
-        addEclipseDefaults(log, false, exclusion);
+        exclusion.addAll(addEclipseDefaults(log, false));
         assertTrue(exclusion.isEmpty());
-        addEclipseDefaults(log, true, exclusion);
+        exclusion.addAll(addEclipseDefaults(log, true));
         assertEquals(5, exclusion.size());
-        addEclipseDefaults(log, true, exclusion);
+        exclusion.addAll(addEclipseDefaults(log, true));
         assertEquals(5, exclusion.size());
     }
 
     @Test
     public void testAddingIdeaExclusions() {
         final Set<String> exclusion = new HashSet<>();
-        addIdeaDefaults(log, false, exclusion);
+        exclusion.addAll(addIdeaDefaults(log, false));
         assertTrue(exclusion.isEmpty());
-        addIdeaDefaults(log, true, exclusion);
+        exclusion.addAll(addIdeaDefaults(log, true));
         assertEquals(4, exclusion.size());
-        addIdeaDefaults(log, true, exclusion);
+        exclusion.addAll(addIdeaDefaults(log, true));
         assertEquals(4, exclusion.size());
     }
 
     @Test
     public void testAddingMavenExclusions() {
         final Set<String> exclusion = new HashSet<>();
-        addMavenDefaults(log, false, exclusion);
+        exclusion.addAll(addMavenDefaults(log, false));
         assertTrue(exclusion.isEmpty());
-        addMavenDefaults(log, true, exclusion);
+        exclusion.addAll(addMavenDefaults(log, true));
         assertEquals(8, exclusion.size());
-        addMavenDefaults(log, true, exclusion);
+        exclusion.addAll(addMavenDefaults(log, true));
         assertEquals(8, exclusion.size());
     }
 
@@ -91,14 +91,14 @@ public class ExclusionHelperTest {
         final int expectedSizeMergedFromPlexusDefaultsAndScm = (37 + SourceCodeManagementSystems.getPluginExclusions().size());
 
         final Set<String> exclusion = new HashSet<>();
-        addPlexusAndScmDefaults(log, false, exclusion);
+        exclusion.addAll(addPlexusAndScmDefaults(log, false));
         assertTrue(exclusion.isEmpty());
-        addPlexusAndScmDefaults(log, true, exclusion);
+        exclusion.addAll(addPlexusAndScmDefaults(log, true));
         assertEquals(
                 "Did you upgrade plexus to get more default excludes?",//
                 expectedSizeMergedFromPlexusDefaultsAndScm,//
                 exclusion.size());
-        addPlexusAndScmDefaults(log, true, exclusion);
+        exclusion.addAll(addPlexusAndScmDefaults(log, true));
         assertEquals(
                 "Did you upgrade plexus to get more default excludes?",//
                 expectedSizeMergedFromPlexusDefaultsAndScm,//

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/util/ScmIgnoreParserTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/util/ScmIgnoreParserTest.java
@@ -18,6 +18,7 @@ package org.apache.rat.mp.util;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.rat.mp.util.ignore.GlobIgnoreMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -31,9 +32,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.rat.mp.util.ScmIgnoreParser.getExcludesFromFile;
 import static org.apache.rat.mp.util.ScmIgnoreParser.getExclusionsFromSCM;
-import static org.apache.rat.mp.util.ScmIgnoreParser.isComment;
+import static org.apache.rat.mp.util.ignore.GlobIgnoreMatcher.isComment;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -67,6 +67,9 @@ public class ScmIgnoreParserTest {
         assertTrue(isComment("     /* comment that is */ "));
     }
 
+    public List<String> getExcludesFromFile(final Log log, final File scmIgnore) {
+        return new GlobIgnoreMatcher(log, scmIgnore).getExclusionLines();
+    }
 
     @Test
     public void parseFromNonExistingFileOrDirectoryOrNull() {
@@ -77,7 +80,8 @@ public class ScmIgnoreParserTest {
 
     @Test
     public void parseFromTargetDirectoryHopefullyWithoutSCMIgnores() {
-        assertTrue(getExclusionsFromSCM(log, new File("./target")).isEmpty());
+        // The target directory contains ignore files from other tests
+        assertTrue(getExclusionsFromSCM(log, new File("./target/classes")).isEmpty());
     }
 
     @Test

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore
@@ -1,0 +1,7 @@
+*.md
+
+# This makes it ignore dir3/dir3.log and dir3/file3.log
+*.log
+
+# This makes it "unignore" dir3/file3.log
+!file*.log

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/README.txt
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/README.txt
@@ -1,0 +1,12 @@
+Note the output when running in the real commandline version of git
+
+# Files that must be ignored (dropping the gitignore matches outside of this test tree)
+$ git check-ignore --no-index --verbose $(find . -type f|sort) | fgrep 'apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/'
+
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore:2:!dir1.md  ./dir1/dir1.md
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore:1:*.txt     ./dir1/dir1.txt
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore:3:file1.log ./dir1/file1.log
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:1:*.md   ./dir2/dir2.md
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:4:*.log  ./dir3/dir3.log
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:7:!file*.log     ./dir3/file3.log
+apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:1:*.md   ./root.md

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore
@@ -1,0 +1,3 @@
+*.txt
+!dir1.md
+file1.log

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/dir1.md
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/dir1.md
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/dir1.txt
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/dir1.txt
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/file1.log
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/file1.log
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir2/dir2.md
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir2/dir2.md
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir2/dir2.txt
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir2/dir2.txt
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir3/dir3.log
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir3/dir3.log
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir3/file3.log
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir3/file3.log
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/invoker.properties
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/invoker.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean apache-rat:check

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/pom.xml
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.rat.test</groupId>
+  <artifactId>RAT335</artifactId>
+  <version>1.0</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+
+          <!-- Minimize the number of active rules to keep the test minimal -->
+          <excludes>
+            <exclude>**/.gitignore</exclude>
+          </excludes>
+          <useDefaultExcludes>false</useDefaultExcludes>
+          <useMavenDefaultExcludes>false</useMavenDefaultExcludes>
+          <useEclipseDefaultExcludes>false</useEclipseDefaultExcludes>
+          <useIdeaDefaultExcludes>false</useIdeaDefaultExcludes>
+
+          <parseSCMIgnoresAsExcludes>true</parseSCMIgnoresAsExcludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/root.md
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/root.md
@@ -1,0 +1,1 @@
+File without a valid license

--- a/pom.xml
+++ b/pom.xml
@@ -635,6 +635,10 @@ agnostic home for software distribution comprehension and audit tools.
       <name>Claude Warren</name>
       <email>claude@apache.org</email>
     </contributor>
+    <contributor>
+      <name>Niels Basjes</name>
+      <email>nielsbasjes@apache.org</email>
+    </contributor>
   </contributors>
   <scm>
     <connection>scm:git:https://gitbox.apache.org/repos/asf/creadur-rat.git</connection>


### PR DESCRIPTION
Fixing the issue described in https://issues.apache.org/jira/browse/RAT-335

Correctly following the rules in a gitignore file is not simply checking them all and stopping if one matches. So for the actual parsing and evaluation I have used a library I wrote a while ago for this exact purpose.

To allow having more complex rules like this and the default rules side by side I have added a `IgnoreMatcher` interface. A new subclass of `DirectoryScanner` is used which will check both the provided `IgnoreMatcher` instances and the existing rules.

Please let me know what you think of this approach.