### PR TITLE
RAT-348: Update gitignore reader

### DIFF
--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -305,7 +305,7 @@
     <dependency>
       <groupId>nl.basjes.gitignore</groupId>
       <artifactId>gitignore-reader</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.0</version>
     </dependency>
   </dependencies>
   <reporting>


### PR DESCRIPTION
Just updating to the latest version.
This fixes some of the special expressions in a gitignore file that are allowed yet poorly documented.