### PR TITLE
RAT-349: Fix NPE on addDefaultLicenses=false

### DIFF
--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
@@ -318,6 +318,8 @@ public abstract class AbstractRatMojo extends AbstractMojo {
         reportDeprecatedProcessing();
         if (addDefaultLicenses) {
             config.setFrom(getDefaultsBuilder().build());
+        } else {
+            config.setStyleSheet(Defaults.getPlainStyleSheet());
         }
         if (additionalLicenseFiles != null) {
             for (String licenseFile : additionalLicenseFiles) {


### PR DESCRIPTION
The place where the NPE occurs is here 
https://github.com/apache/creadur-rat/blob/21b726a0945f905d67ef8854950aa1e4530873a3/apache-rat-core/src/main/java/org/apache/rat/Reporter.java#L56

Because no config is set the stylesheet is null which NPEs on the `.get()`.

If you normally set a config without a styleSheet something similar is done.
