### PR TITLE
RAT-349: Fail the build if integration tests fail

### DIFF
--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -145,7 +145,7 @@
             <id>integration-test</id>
             <goals>
               <goal>install</goal>
-              <goal>integration-test</goal>
+              <goal>run</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
As mentioned here https://github.com/apache/creadur-rat/pull/194#issuecomment-1890590107 if the integration tests fails the build does not fail.

The cause is that currently the build uses the `integration-test` goal which is documented as `will never fail the build`: https://maven.apache.org/plugins/maven-invoker-plugin/plugin-info.html

The `run` goal does the same thing and will let the build fail if one of the tests fails.