### PR TITLE
RAT-325: Changed CLI-default logging level to WARN

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -144,7 +144,7 @@ public class Report {
                 Log.Level level = Log.Level.valueOf(cl.getOptionValue(LOG_LEVEL).toUpperCase());
                 DefaultLog.INSTANCE.setLevel(level);
             } catch (IllegalArgumentException e) {
-                DefaultLog.INSTANCE.warn(String.format("Invalied Log Level (%s) specified.", cl.getOptionValue(LOG_LEVEL)));
+                DefaultLog.INSTANCE.warn(String.format("Invalid Log Level (%s) specified.", cl.getOptionValue(LOG_LEVEL)));
                 DefaultLog.INSTANCE.warn(String.format("Log level set at: %s", DefaultLog.INSTANCE.getLevel()));
             }
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -50,6 +50,7 @@ import org.apache.rat.config.AddLicenseHeaders;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.report.IReportable;
 import org.apache.rat.utils.DefaultLog;
+import org.apache.rat.utils.Log;
 import org.apache.rat.utils.Log.Level;
 import org.apache.rat.walker.ArchiveWalker;
 import org.apache.rat.walker.DirectoryWalker;
@@ -110,6 +111,7 @@ public class Report {
      */
     private static final String LIST_FAMILIES = "list-families";
 
+    private static final String LOG_LEVEL = "log-level";
 
     /**
      * Set unstyled XML output
@@ -137,6 +139,15 @@ public class Report {
                     // for "cl"
         }
 
+        if (cl.hasOption(LOG_LEVEL)) {
+            try {
+                Log.Level level = Log.Level.valueOf(cl.getOptionValue(LOG_LEVEL).toUpperCase());
+                DefaultLog.INSTANCE.setLevel(level);
+            } catch (IllegalArgumentException e) {
+                DefaultLog.INSTANCE.warn(String.format("Invalied Log Level (%s) specified.", cl.getOptionValue(LOG_LEVEL)));
+                DefaultLog.INSTANCE.warn(String.format("Log level set at: %s", DefaultLog.INSTANCE.getLevel()));
+            }
+        }
         if (cl.hasOption(HELP)) {
             printUsage(opts);
         }
@@ -327,6 +338,10 @@ public class Report {
         Option dir = new Option("d", "dir", false, "Used to indicate source when using --exclude");
         opts.addOption(dir);
 
+        opts.addOption( Option.builder().argName("level").longOpt(LOG_LEVEL)
+                .hasArgs().desc("sets the log level.  Valid options are: DEBUG, INFO, WARN, ERROR, NONE")
+                .build() );
+        
         OptionGroup outputType = new OptionGroup();
 
         Option xml = new Option(XML, "xml", false, "Output the report in raw XML format.  Not compatible with -s");
@@ -336,6 +351,8 @@ public class Report {
                 "XSLT stylesheet to use when creating the" + " report.  Not compatible with -x");
         outputType.addOption(xslt);
         opts.addOptionGroup(outputType);
+        
+        
 
         return opts;
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -339,7 +339,7 @@ public class Report {
         opts.addOption(dir);
 
         opts.addOption( Option.builder().argName("level").longOpt(LOG_LEVEL)
-                .hasArgs().desc("sets the log level.  Valid options are: DEBUG, INFO, WARN, ERROR, NONE")
+                .hasArgs().desc("sets the log level.  Valid options are: DEBUG, INFO, WARN, ERROR, OFF")
                 .build() );
         
         OptionGroup outputType = new OptionGroup();

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/DefaultLog.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/DefaultLog.java
@@ -31,7 +31,7 @@ public class DefaultLog implements Log {
     private Level level;
 
     private DefaultLog() {
-        level = Level.INFO;
+        level = Level.WARN;
     }
 
     public void setLevel(Level level) {

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/DefaultLog.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/DefaultLog.java
@@ -37,6 +37,11 @@ public class DefaultLog implements Log {
     public void setLevel(Level level) {
         this.level = level;
     }
+    
+    public Level getLevel() {
+        return level;
+    }
+    
     @Override
     public void log(Level level, String msg) {
         if (this.level.ordinal() <= level.ordinal())


### PR DESCRIPTION
Rather than moving the file lists to the noisier DEBUG level I update the default logging level to WARN.  This seems appropriate for CLI.

The default logging level only applies to the CLI and  tests.
In all other extant UIs the logging is performed by the native system and so the logging needs to be set there.