### PR TITLE
RAT-353, MPLUGIN-507: Enable maven-plugin-report-plugin to see NPE with Maven 4.x only

### DIFF
--- a/.buildtools/generateStagingSiteInWebpageRepo
+++ b/.buildtools/generateStagingSiteInWebpageRepo
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-mvn clean site:site site:stage
+./mvnw clean site:site site:stage
 cp -rvf target/staging/* ../creadur-site/rat0161/

--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -132,6 +132,10 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-report-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <cloneProjectsTo>${project.build.directory}/invoker</cloneProjectsTo>
@@ -326,6 +330,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
+        <version>${mavenPluginPluginVersion}</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-report-plugin</artifactId>
         <version>${mavenPluginPluginVersion}</version>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,11 @@ agnostic home for software distribution comprehension and audit tools.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-report-plugin</artifactId>
+          <version>${mavenPluginPluginVersion}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.12.1</version>
           <configuration>


### PR DESCRIPTION
Filed a bug in the maven-plugin-report-plugin: [MPLUGIN-507](https://issues.apache.org/jira/browse/MPLUGIN-507)

[RAT-353](https://issues.apache.org/jira/browse/RAT-353) brought to the light that the following files were not generated in RAT 0.16 and 0.16.1:
* plugin-info.html
* check-mojo.html
* rat-mojo.html
due to a breaking change in maven-plugin-annotations v3.11.0 that separated the generation logics into a new plugin a new configuration is needed. This new plugin yields a NPE and breaks the site build.

