### PR TITLE
RAT-77: output files with missing headers

### DIFF
--- a/apache-rat-core/pom.xml
+++ b/apache-rat-core/pom.xml
@@ -53,18 +53,7 @@
           <configuration>
             <excludes>
               <!-- These files have bad license headers because they are used to test bad license headers -->
-              <exclude>src/test/resources/appliedAL20/bad/*.*</exclude>
-              <exclude>src/test/resources/oasis/bad/*.*</exclude>
-              <!-- These files do not have license headers because they are used to test license headers -->
-              <exclude>src/test/resources/elements/Source.java</exclude>
-              <exclude>src/test/resources/elements/ILoggerFactory.java</exclude>
-              <exclude>src/test/resources/elements/sub/Empty.txt</exclude>
-              <exclude>src/test/resources/violations/bad.txt</exclude>
-              <exclude>src/test/resources/violations/FilterTest.cs</exclude>
-              <!-- used to test for binary files; does not work on UTF-8 (e.g. MacOSX) -->
-              <exclude>src/test/resources/binaries/Image-png.not</exclude>
-              <!-- These files have a valid license header that was not recognised by older rat versions -->
-              <exclude>src/test/resources/elements/TextHttps.txt</exclude>
+              <exclude>src/test/resources/**</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -314,15 +314,13 @@ public class Report {
         opts.addOption(null, SCAN_HIDDEN_DIRECTORIES, false, "Scan hidden directories");
 
         OptionGroup addLicenseGroup = new OptionGroup();
-        String addLicenseDesc = "Add the default license header to any file with an unknown license that is not in the exclusion list. "
-                + "By default new files will be created with the license header, "
-                + "to force the modification of existing files use the --force option.";
-
         // RAT-85/RAT-203: Deprecated! added only for convenience and for backwards
         // compatibility
-        Option addLicence = new Option(ADD_OLD, "addLicence", false, addLicenseDesc);
+        Option addLicence = new Option(ADD_OLD, false, "(deprecated) Add the default license header to any file with an unknown license.  Use '-a' or ---addLicense instead.");
         addLicenseGroup.addOption(addLicence);
-        Option addLicense = new Option(ADD, "addLicense", false, addLicenseDesc);
+        Option addLicense = new Option(ADD, "addLicense", false, "Add the default license header to any file with an unknown license that is not in the exclusion list. "
+                + "By default new files will be created with the license header, "
+                + "to force the modification of existing files use the --force option.");
         addLicenseGroup.addOption(addLicense);
         opts.addOptionGroup(addLicenseGroup);
 

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -316,7 +316,7 @@ public class Report {
         OptionGroup addLicenseGroup = new OptionGroup();
         // RAT-85/RAT-203: Deprecated! added only for convenience and for backwards
         // compatibility
-        Option addLicence = new Option(ADD_OLD, false, "(deprecated) Add the default license header to any file with an unknown license.  Use '-a' or ---addLicense instead.");
+        Option addLicence = new Option(ADD_OLD, false, "(deprecated) Add the default license header to any file with an unknown license.  Use '-A' or ---addLicense instead.");
         addLicenseGroup.addOption(addLicence);
         Option addLicense = new Option(ADD, "addLicense", false, "Add the default license header to any file with an unknown license that is not in the exclusion list. "
                 + "By default new files will be created with the license header, "

--- a/apache-rat-core/src/main/resources/org/apache/rat/missing-headers.xsl
+++ b/apache-rat-core/src/main/resources/org/apache/rat/missing-headers.xsl
@@ -1,0 +1,31 @@
+<?xml version='1.0' ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one   *
+ or more contributor license agreements.  See the NOTICE file *
+ distributed with this work for additional information        *
+ regarding copyright ownership.  The ASF licenses this file   *
+ to you under the Apache License, Version 2.0 (the            *
+ "License"); you may not use this file except in compliance   *
+ with the License.  You may obtain a copy of the License at   *
+                                                              *
+   http://www.apache.org/licenses/LICENSE-2.0                 *
+                                                              *
+ Unless required by applicable law or agreed to in writing,   *
+ software distributed under the License is distributed on an  *
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ KIND, either express or implied.  See the License for the    *
+ specific language governing permissions and limitations      *
+ under the License.                                           *
+-->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method='text'/>
+<xsl:template match='/'>Files with missing headers:
+<xsl:for-each select='descendant::resource[header-type/@name="?????"]'>
+  <xsl:text>  </xsl:text>
+  <xsl:value-of select='@name'/>
+  <xsl:text>
+</xsl:text>
+</xsl:for-each>
+</xsl:template>
+</xsl:stylesheet>

--- a/apache-rat-core/src/test/resources/XmlOutputExamples/elements.xml
+++ b/apache-rat-core/src/test/resources/XmlOutputExamples/elements.xml
@@ -1,0 +1,12 @@
+<!-- output generated from src/test/resources/elements directory -->
+<rat-report timestamp='2024-03-18T11:50:49+01:00'><resource name='./src/test/resources/elements/ILoggerFactory.java'><header-type name='MIT  '/><license-family name='The MIT License'/><license-approval name='true'/><type name='standard'/></resource><resource name='./src/test/resources/elements/Image.png'><type name='binary'/></resource><resource name='./src/test/resources/elements/LICENSE'><type name='notice'/></resource><resource name='./src/test/resources/elements/NOTICE'><type name='notice'/></resource><resource name='./src/test/resources/elements/Source.java'><header-sample>package elements;
+
+/*
+ * This file does intentionally *NOT* contain an AL license header,
+ * because it is used in the test suite.
+ */
+public class Source {
+
+}
+</header-sample><header-type name='?????'/><license-family name='Unknown license'/><license-approval name='false'/><type name='standard'/></resource><resource name='./src/test/resources/elements/Text.txt'><header-type name='AL   '/><license-family name='Apache License Version 2.0'/><license-approval name='true'/><type name='standard'/></resource><resource name='./src/test/resources/elements/TextHttps.txt'><header-type name='AL   '/><license-family name='Apache License Version 2.0'/><license-approval name='true'/><type name='standard'/></resource><resource name='./src/test/resources/elements/Xml.xml'><header-type name='AL   '/><license-family name='Apache License Version 2.0'/><license-approval name='true'/><type name='standard'/></resource><resource name='./src/test/resources/elements/buildr.rb'><header-type name='AL   '/><license-family name='Apache License Version 2.0'/><license-approval name='true'/><type name='standard'/></resource><resource name='./src/test/resources/elements/dummy.jar'><type name='archive'/></resource><resource name='./src/test/resources/elements/plain.json'><type name='binary'/></resource><resource name='./src/test/resources/elements/sub/Empty.txt'><header-sample>
+</header-sample><header-type name='?????'/><license-family name='Unknown license'/><license-approval name='false'/><type name='standard'/></resource></rat-report>

--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -98,6 +98,7 @@
               <exclude>src/it/CustomLicense/src/**/</exclude>
               <!-- RAT-171: needs to be added since SCM ignores are only parsed in project root -->
               <exclude>**/.bzrignore</exclude>
+              <exclude>src/test/resources/XmlOutputExamples/**/*</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/apache-rat/src/site/apt/index.apt.vm
+++ b/apache-rat/src/site/apt/index.apt.vm
@@ -131,14 +131,13 @@ Available options
 +------------------------------------------+
 
 ** Styling output
- 
- Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
- 
-  * plain-rat  The default stylesheet.
-  
-  * unapproved-licenses  Lists only the files with unapproved licenses.
-  
-  * missing-headers  List only files that are missing headers.
-   
- These stylesheets can be specified using options in the command line, Maven or Ant clients.
 
+ Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
+
+  * {{{https://gitbox.apache.org/repos/asf/creadur-rat/blob/master/apache-rat-core/src/main/resources/org/apache/rat/plain-rat.xsl}plain-rat}} - The default stylesheet.
+
+  * {{{https://gitbox.apache.org/repos/asf/creadur-rat/blob/master/apache-rat-core/src/main/resources/org/apache/rat/unapproved-licenses.xsl}unapproved-licenses}} - Lists only the files with unapproved licenses.
+
+  * {{{https://gitbox.apache.org/repos/asf/creadur-rat/blob/master/apache-rat-core/src/main/resources/org/apache/rat/missing-headers.xsl}missing-headers}} - List only files that are missing headers.
+
+ These stylesheets can be specified using options in the command line, Maven or Ant clients.

--- a/apache-rat/src/site/apt/index.apt.vm
+++ b/apache-rat/src/site/apt/index.apt.vm
@@ -81,7 +81,7 @@ usage: java -jar apache-rat/target/apache-rat-${project.version}.jar
 Available options
  -a                             (deprecated) Add the default license
                                 header to any file with an unknown
-                                license.  Use '-a' or ---addLicense
+                                license.  Use '-A' or ---addLicense
                                 instead.
  -A,--addLicense                Add the default license header to any file
                                 with an unknown license that is not in the

--- a/apache-rat/src/site/apt/index.apt.vm
+++ b/apache-rat/src/site/apt/index.apt.vm
@@ -79,12 +79,10 @@ usage: java -jar apache-rat/target/apache-rat-${project.version}.jar
             [options] [DIR|TARBALL]
 
 Available options
- -a,--addLicence                Add the default license header to any file
-                                with an unknown license that is not in the
-                                exclusion list. By default new files will
-                                be created with the license header, to
-                                force the modification of existing files
-                                use the --force option.
+ -a                             (deprecated) Add the default license
+                                header to any file with an unknown
+                                license.  Use '-a' or ---addLicense
+                                instead.
  -A,--addLicense                Add the default license header to any file
                                 with an unknown license that is not in the
                                 exclusion list. By default new files will
@@ -105,19 +103,42 @@ Available options
                                 using this parameter.
  -f,--force                     Forces any changes in files to be written
                                 directly to the source files (i.e. new
-                                files are not created)
+                                files are not created).
  -h,--help                      Print help for the RAT command line
-                                interface and exit
+                                interface and exit.
     --licenses <arg>            File names or URLs for license definitions
-    --list-approved-families    List all defined license families
-    --list-licenses             List all active licenses
+    --list-families <arg>       List the defined license families (default
+                                is none). Valid options are: all,
+                                approved, none.
+    --list-licenses <arg>       List the defined licenses (default is
+                                none). Valid options are: all, approved,
+                                none.
+    --log-level <level>         sets the log level.  Valid options are:
+                                DEBUG, INFO, WARN, ERROR, OFF
     --no-default-licenses       Ignore default configuration. By default
                                 all approved default licenses are used
- -o,--out <arg>                 Define the output file where to write
-                                report (default is System.out)
+ -o,--out <arg>                 Define the output file where to write a
+                                report to (default is System.out).
  -s,--stylesheet <arg>          XSLT stylesheet to use when creating the
-                                report.  Not compatible with -x
+                                report.  Not compatible with -x.  Either
+                                an external xsl file may be specified or
+                                one of the internal named sheets:
+                                plain-rat (default), missing-headers, or
+                                unapproved-licenses
     --scan-hidden-directories   Scan hidden directories
  -x,--xml                       Output the report in raw XML format.  Not
                                 compatible with -s
 +------------------------------------------+
+
+** Styling output
+ 
+ Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
+ 
+  * plain-rat  The default stylesheet.
+  
+  * unapproved-licenses  Lists only the files with unapproved licenses.
+  
+  * missing-headers  List only files that are missing headers.
+   
+ These stylesheets can be specified using options in the command line, Maven or Ant clients.
+

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -75,6 +75,10 @@ https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd
       <action issue="RAT-345" type="update" dev="pottlinger" due-to="dependabot">
         TODO: collect all dependabot updates for release 0.17.
       </action>
+      <action issue="RAT-77" type="add" dev="claudenw">
+        Adds another stylesheet to explicitly output files with missing-headers. Thus plain-rat (default), missing-headers, and unapproved-licenses can be used from the CLI with the -s option to use a short name (e.g. -s missing-headers or -s unapproved-licenses).
+      </action>
+
     </release>
     <release version="0.16.1" date="2024-01-24" description=
 "As release 0.16 introduced breaking changes concerning the configurability of the Maven plugin, these configuration options are reintroduced albeit as deprecated elements.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -76,7 +76,7 @@ https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd
         TODO: collect all dependabot updates for release 0.17.
       </action>
       <action issue="RAT-77" type="add" dev="claudenw">
-        Adds another stylesheet to explicitly output files with missing-headers. Thus plain-rat (default), missing-headers, and unapproved-licenses can be used from the CLI with the -s option to use a short name (e.g. -s missing-headers or -s unapproved-licenses).
+        Adds another stylesheet to explicitly output files with missing-headers. Thus plain-rat (default), missing-headers, and unapproved-licenses can be used in all RAT clients. From the CLI the -s option allows to use a short name (e.g. -s missing-headers or -s unapproved-licenses).
       </action>
 
     </release>

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -82,8 +82,6 @@ Apache Rat
 
 * Quick Start: Running Rat
 
-Rat supports three clients: a command line, Maven and Ant.
-
 ** Command Line
 
  Quick start by
@@ -114,15 +112,17 @@ java -jar apache-rat-${project.version}.jar --help
 
  Read more {{{./apache-rat-plugin/index.html} here}}.
  
- ** Styling output
+** Styling output
  
  Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
  
-    plain-rat  The default stylesheet.
-    unapproved-licenses  Lists only the files with unapproved licenses.
-    missing-headers  List only files that are missing headers.
+  * plain-rat  The default stylesheet.
+  
+  * unapproved-licenses  Lists only the files with unapproved licenses.
+  
+  * missing-headers  List only files that are missing headers.
    
-These stylesheets can be specified using options in the command line, Maven or Ant clients.
+ These stylesheets can be specified using options in the command line, Maven or Ant clients.
 
 
 * Checking Out Rat

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -82,6 +82,8 @@ Apache Rat
 
 * Quick Start: Running Rat
 
+Rat supports three clients: a command line, Maven and Ant.
+
 ** Command Line
 
  Quick start by
@@ -111,6 +113,17 @@ java -jar apache-rat-${project.version}.jar --help
 +------------------------------------------+
 
  Read more {{{./apache-rat-plugin/index.html} here}}.
+ 
+ ** Styling output
+ 
+ Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
+ 
+   * org/apache/rat/plain-rat.xsl  The default stylesheet.
+   * org/apache/rat/unapproved-licenses.xsl Lists only the files with unapproved licenses.
+   * org/apache/rat/missing-headers.xsl List only files that are missing headers.
+   
+These stylesheets can be specified using options in the command line, Maven or Ant clients.
+
 
 * Checking Out Rat
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -118,11 +118,9 @@ java -jar apache-rat-${project.version}.jar --help
  
  Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
  
-   plain-rat  The default stylesheet.
-   
-   unapproved-licenses  Lists only the files with unapproved licenses.
-   
-   missing-headers  List only files that are missing headers.
+    plain-rat  The default stylesheet.
+    unapproved-licenses  Lists only the files with unapproved licenses.
+    missing-headers  List only files that are missing headers.
    
 These stylesheets can be specified using options in the command line, Maven or Ant clients.
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -111,19 +111,18 @@ java -jar apache-rat-${project.version}.jar --help
 +------------------------------------------+
 
  Read more {{{./apache-rat-plugin/index.html} here}}.
- 
-** Styling output
- 
- Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
- 
-  * plain-rat  The default stylesheet.
-  
-  * unapproved-licenses  Lists only the files with unapproved licenses.
-  
-  * missing-headers  List only files that are missing headers.
-   
- These stylesheets can be specified using options in the command line, Maven or Ant clients.
 
+** Styling output
+
+ Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
+
+  * {{{https://gitbox.apache.org/repos/asf/creadur-rat/blob/master/apache-rat-core/src/main/resources/org/apache/rat/plain-rat.xsl}plain-rat}} - The default stylesheet.
+
+  * {{{https://gitbox.apache.org/repos/asf/creadur-rat/blob/master/apache-rat-core/src/main/resources/org/apache/rat/unapproved-licenses.xsl}unapproved-licenses}} - Lists only the files with unapproved licenses.
+
+  * {{{https://gitbox.apache.org/repos/asf/creadur-rat/blob/master/apache-rat-core/src/main/resources/org/apache/rat/missing-headers.xsl}missing-headers}} - List only files that are missing headers.
+
+ These stylesheets can be specified using options in the command line, Maven or Ant clients.
 
 * Checking Out Rat
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -118,9 +118,11 @@ java -jar apache-rat-${project.version}.jar --help
  
  Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
  
-   * plain-rat  The default stylesheet.
-   * unapproved-licenses  Lists only the files with unapproved licenses.
-   * missing-headers  List only files that are missing headers.
+   plain-rat  The default stylesheet.
+   
+   unapproved-licenses  Lists only the files with unapproved licenses.
+   
+   missing-headers  List only files that are missing headers.
    
 These stylesheets can be specified using options in the command line, Maven or Ant clients.
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -118,9 +118,9 @@ java -jar apache-rat-${project.version}.jar --help
  
  Rat allows you to style the output as you see fit.  Three stylesheets are included in the rat package.
  
-   * org/apache/rat/plain-rat.xsl  The default stylesheet.
-   * org/apache/rat/unapproved-licenses.xsl Lists only the files with unapproved licenses.
-   * org/apache/rat/missing-headers.xsl List only files that are missing headers.
+   * plain-rat  The default stylesheet.
+   * unapproved-licenses  Lists only the files with unapproved licenses.
+   * missing-headers  List only files that are missing headers.
    
 These stylesheets can be specified using options in the command line, Maven or Ant clients.
 


### PR DESCRIPTION
Fix for RAT-77

This was mostly fixed earlier.  This pull 

- adds another stylesheet to the package (missing-headers.xsl) to the two that already existed: plain-rat (default), missing-headers, and unapproved-licenses
- allows the -s option to use a short name (e.g. `-s missing-headers` or `-s unapproved-licenses`
- updates the documentation to talk about the stylesheets. 
