### PR TITLE
RAT-366: switch to single match call

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
@@ -30,6 +30,7 @@ import org.apache.rat.document.impl.guesser.BinaryGuesser;
 import org.apache.rat.document.impl.guesser.NoteGuesser;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.utils.Log;
+import org.apache.rat.utils.Log.Level;
 
 /**
  * Creates default analysers.
@@ -38,7 +39,7 @@ public class DefaultAnalyserFactory {
 
     /**
      * Creates a DocumentAnalyser from a collection of ILicenses.
-     * @param licenses The licenses to use in the Analyser.
+     * @param licenses The licenses to use in  the Analyser.
      * @return A document analyser that uses the provides licenses.
      */
     public static IDocumentAnalyser createDefaultAnalyser(Log log, Collection<ILicense> licenses) {

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
@@ -30,7 +30,6 @@ import org.apache.rat.document.impl.guesser.BinaryGuesser;
 import org.apache.rat.document.impl.guesser.NoteGuesser;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.utils.Log;
-import org.apache.rat.utils.Log.Level;
 
 /**
  * Creates default analysers.
@@ -39,7 +38,7 @@ public class DefaultAnalyserFactory {
 
     /**
      * Creates a DocumentAnalyser from a collection of ILicenses.
-     * @param licenses The licenses to use in  the Analyser.
+     * @param licenses The licenses to use in the Analyser.
      * @return A document analyser that uses the provides licenses.
      */
     public static IDocumentAnalyser createDefaultAnalyser(Log log, Collection<ILicense> licenses) {

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
@@ -56,8 +56,7 @@ public class HeaderCheckWorker {
     /**
      * Read the input and perform the header check.
      *
-     * @throws RatHeaderAnalysisException on IO Exception.
-     * @throws IOException
+     * @throws IOException on input failure
      */
     public static IHeaders readHeader(BufferedReader reader, int numberOfLines) throws IOException {
         final StringBuilder headers = new StringBuilder();

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
@@ -24,7 +24,6 @@ import java.io.Reader;
 import java.util.Locale;
 import java.util.Objects;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.rat.ConfigurationException;
 import org.apache.rat.analysis.matchers.FullTextMatcher;
 import org.apache.rat.api.Document;
@@ -32,15 +31,16 @@ import org.apache.rat.api.MetaData;
 import org.apache.rat.license.ILicense;
 
 /**
- * Reads from a stream to check license.
- * <p>
- * <strong>Note</strong> that this class is not thread safe.
- * </p>
+ * Reads from a stream to check license. <p> <strong>Note</strong> that this
+ * class is not thread safe. </p>
  */
 public class HeaderCheckWorker {
 
-    /* TODO revisit this class.  It is only used in one place and can be moved inline as the DocumentHeaderAnalyser states.
-     * However, it may also be possible to make the entire set threadsafe so that multiple files can be checked simultaneously.
+    /*
+     * TODO revisit this class. It is only used in one place and can be moved inline
+     * as the DocumentHeaderAnalyser states. However, it may also be possible to
+     * make the entire set threadsafe so that multiple files can be checked
+     * simultaneously.
      */
     /**
      * The default number of header lines to read while looking for the license
@@ -53,44 +53,44 @@ public class HeaderCheckWorker {
     private final ILicense license;
     private final Document document;
 
-
     /**
      * Read the input and perform the header check.
-     * 
+     *
      * @throws RatHeaderAnalysisException on IO Exception.
-     * @throws IOException 
+     * @throws IOException
      */
     public static IHeaders readHeader(BufferedReader reader, int numberOfLines) throws IOException {
         final StringBuilder headers = new StringBuilder();
-        int headerLinesRead=0;
+        int headerLinesRead = 0;
         String line;
-        
-            while (headerLinesRead < numberOfLines && (line = reader.readLine()) != null) {
-                headers.append(line).append("\n");
-            }
-            final String raw = headers.toString();
-            final String pruned = FullTextMatcher.prune(raw).toLowerCase(Locale.ENGLISH);
-            return new IHeaders() {
-                @Override
-                public String raw() {
-                    return raw;
-                }
 
-                @Override
-                public String pruned() {
-                    return pruned;
-                }
-                
-                public String toString() {
-                    return "HeaderCheckWorker";
-                }
-            };
+        while (headerLinesRead < numberOfLines && (line = reader.readLine()) != null) {
+            headers.append(line).append("\n");
+        }
+        final String raw = headers.toString();
+        final String pruned = FullTextMatcher.prune(raw).toLowerCase(Locale.ENGLISH);
+        return new IHeaders() {
+            @Override
+            public String raw() {
+                return raw;
+            }
+
+            @Override
+            public String pruned() {
+                return pruned;
+            }
+
+            @Override
+            public String toString() {
+                return "HeaderCheckWorker";
+            }
+        };
     }
-    
+
     /**
      * Convenience constructor wraps given <code>Reader</code> in a
      * <code>BufferedReader</code>.
-     * 
+     *
      * @param reader The reader on the document. not null.
      * @param license The license to check against. not null.
      * @param name The document that is being checked. possibly null
@@ -101,7 +101,7 @@ public class HeaderCheckWorker {
 
     /**
      * Constructs a check worker for the license against the specified document.
-     * 
+     *
      * @param reader The reader on the document. not null.
      * @param numberOfRetainedHeaderLine the maximum number of lines to read to find
      * the license information.
@@ -123,7 +123,7 @@ public class HeaderCheckWorker {
 
     /**
      * Read the input and perform the header check.
-     * 
+     *
      * @throws RatHeaderAnalysisException on IO Exception.
      */
     public void read() throws RatHeaderAnalysisException {

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/IHeaderMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/IHeaderMatcher.java
@@ -33,40 +33,6 @@ import org.apache.rat.configuration.builders.TextBuilder;
  */
 public interface IHeaderMatcher {
     /**
-     * The state of the matcher.
-     * <ul>
-     * <li>{@code t} - The matcher has located a match.</li>
-     * <li>{@code f} - The matcher has determined that it will not match the
-     * document.</li>
-     * <li>{@code i} - The matcher can not yet determine if a matche is made or
-     * not.</li>
-     * </ul>
-     */
-    enum State {
-        t("true"), f("false"), i("indeterminent");
-
-        private final String desc;
-
-        State(String desc) {
-            this.desc = desc;
-        }
-
-        public boolean asBoolean() {
-            switch (this) {
-            case t : return true;
-            case f : return false;
-            default:
-            case i : throw new IllegalStateException( "'asBoolean' should never be called on an indeterminate state");
-            }
-        }
-        
-        @Override
-        public String toString() {
-            return super.toString()+" "+desc;
-        }
-    }
-
-    /**
      * Get the identifier for this matcher.
      * <p>All matchers must have unique identifiers</p>
      * 
@@ -84,24 +50,10 @@ public interface IHeaderMatcher {
      * Attempts to match {@code line} and returns the State after
      * the match is attempted.
      * 
-     * @param line next line of text, not null
+     * @param headers the representations of the headers to check
      * @return the new state after the matching was attempted.
      */
-    State matches(String line);
-
-    /**
-     * Gets the final state for this matcher. This is called after the EOF on the
-     * input. At this point there should be no matchers in an {@code State.i} state.
-     */
-    State finalizeState();
-
-    /**
-     * Gets the the current state of the matcher. All matchers should be
-     * in {@code State.i} at the start.
-     * 
-     * @return the current state of the matcher.
-     */
-    State currentState();
+    boolean matches(IHeaders headers);
 
     /**
      * An IHeaderMatcher builder.

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/IHeaders.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/IHeaders.java
@@ -1,3 +1,4 @@
+package org.apache.rat.analysis;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one   *
  * or more contributor license agreements.  See the NOTICE file *
@@ -16,25 +17,18 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  */
-package org.apache.rat.analysis.matchers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Arrays;
-
-import org.apache.rat.analysis.IHeaderMatcher;
-import org.apache.rat.testhelpers.TestingMatcher;
-import org.junit.jupiter.api.Test;
-
-public class OrMatcherTest extends AbstractMatcherTest {
-
+/**
+ * The processed headers from a file.
+ */
+public interface IHeaders {
+    /**
+     * @return the raw header as read from the file.
+     */
+    public String raw();
+    /**
+     * @return The pruned header.
+     */
+    public String pruned();
     
-    @Test
-    public void trueTest() {
-        IHeaderMatcher one = new TestingMatcher("one", false, false, true, true);
-        IHeaderMatcher two = new TestingMatcher("two", false, true, false, true);
-        OrMatcher target = new OrMatcher("Testing", Arrays.asList(one, two));
-        assertValues(target, false, true, true, true);
-        target.reset();
-    }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/LicenseCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/LicenseCollection.java
@@ -38,7 +38,6 @@ class LicenseCollection extends AbstractMatcherContainer implements ILicense {
             .setLicenseFamilyName("HeaderMatcherCollection default license family").build();
     private final Collection<ILicense> enclosed;
     private ILicense matchingLicense;
-    private State lastState;
 
     /**
      * Constructs the LicenseCollection from the provided ILicense collection.
@@ -48,7 +47,6 @@ class LicenseCollection extends AbstractMatcherContainer implements ILicense {
         super(enclosed);
         this.enclosed = Collections.unmodifiableCollection(enclosed);
         this.matchingLicense = null;
-        this.lastState = State.i;
     }
 
     @Override
@@ -59,52 +57,18 @@ class LicenseCollection extends AbstractMatcherContainer implements ILicense {
     @Override
     public void reset() {
         enclosed.forEach(ILicense::reset);
-        this.lastState = State.i;
         this.matchingLicense = null;
     }
 
     @Override
-    public State matches(String line) {
-        State dflt = State.f;
+    public boolean matches(IHeaders headers) {
         for (ILicense license : enclosed) {
-            switch (license.matches(line)) {
-            case t:
-                this.matchingLicense = license;
-                lastState = State.t;
-                return State.t;
-            case i:
-                dflt = State.i;
-                break;
-            default:
-                // do nothing
-                break;
+            if (license.matches(headers)) {
+                matchingLicense = license;
+                return true;
             }
         }
-        lastState = dflt;
-        return dflt;
-    }
-
-    @Override
-    public State currentState() {
-        if (lastState == State.t) {
-            return lastState;
-        }
-        for (ILicense license : enclosed) {
-            switch (license.currentState()) {
-            case t:
-                this.matchingLicense = license;
-                lastState = State.t;
-                return lastState;
-            case i:
-                lastState = State.i;
-                return lastState;
-            case f:
-                // do nothing;
-                break;
-            }
-        }
-        lastState = State.f;
-        return lastState;
+        return false;
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
@@ -40,7 +40,7 @@ public class UnknownLicense implements ILicense {
     /**
      * Do not allow other constructions.
      */
-    private UnknownLicense() {
+    UnknownLicense() {
         family = new ILicenseFamilyBuilder().setLicenseFamilyCategory("?????")
                 .setLicenseFamilyName("Unknown license").build();
     }
@@ -56,18 +56,8 @@ public class UnknownLicense implements ILicense {
     }
 
     @Override
-    public State matches(String line) {
-        return State.f;
-    }
-
-    @Override
-    public State finalizeState() {
-        return State.f;
-    }
-
-    @Override
-    public State currentState() {
-        return State.f;
+    public boolean matches(IHeaders headers) {
+        return false;
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/AbstractMatcherContainer.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/AbstractMatcherContainer.java
@@ -59,10 +59,4 @@ public abstract class AbstractMatcherContainer extends AbstractHeaderMatcher {
     public void reset() {
         enclosed.forEach(IHeaderMatcher::reset);
     }
-
-    @Override
-    public State finalizeState() {
-        enclosed.forEach(IHeaderMatcher::finalizeState);
-        return currentState();
-    }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/AbstractSimpleMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/AbstractSimpleMatcher.java
@@ -24,7 +24,6 @@ package org.apache.rat.analysis.matchers;
  * {@code finalizeState()} method will convert {@code State.i} to {@code State.f}.
  */
 public abstract class AbstractSimpleMatcher extends AbstractHeaderMatcher {
-    private State lastState;
 
     /**
      * Constructs the AbstractSimpleMatcher with the specified id.
@@ -33,42 +32,11 @@ public abstract class AbstractSimpleMatcher extends AbstractHeaderMatcher {
      */
     protected AbstractSimpleMatcher(String id) {
         super(id);
-        this.lastState = State.i;
     }
-
-    /**
-     * Performs the actual match test.
-     * @param line the line to check.
-     * @return {@code true} if the line matches, {@code false} otherwise.
-     */
-    abstract protected boolean doMatch(String line);
-
-    @Override
-    public final State matches(String line) {
-        if (lastState == State.t) {
-            return lastState;
-        }
-        if (line != null && doMatch(line)) {
-            lastState = State.t;
-        }
-        return lastState;
-    }
-
+    
+    
     @Override
     public void reset() {
-        lastState = State.i;
-    }
-
-    @Override
-    public State finalizeState() {
-        if (lastState == State.i) {
-            lastState = State.f;
-        }
-        return lastState;
-    }
-
-    @Override
-    public final State currentState() {
-        return lastState;
+        // do nothing.
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/AndMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/AndMatcher.java
@@ -21,6 +21,7 @@ package org.apache.rat.analysis.matchers;
 import java.util.Collection;
 
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * A matcher that performs a logical {@code AND} across all the contained matchers.
@@ -45,32 +46,13 @@ public class AndMatcher extends AbstractMatcherContainer {
     }
 
     @Override
-    public State currentState() {
-        State dflt = State.t;
+    public boolean matches(IHeaders headers) {
         for (IHeaderMatcher matcher : enclosed) {
-            switch (matcher.currentState()) {
-            case f:
-                return State.f;
-            case i:
-                dflt = State.i;
-                break;
-            default:
-                // do nothing
-                break;
+            if (!matcher.matches(headers))
+            {
+                return false;
             }
         }
-        return dflt;
-    }
-
-    @Override
-    public State matches(String line) {
-        enclosed.stream().filter(x -> x.currentState() == State.i).forEach(x -> x.matches(line));
-        return currentState();
-    }
-
-    @Override
-    public State finalizeState() {
-        enclosed.forEach(IHeaderMatcher::finalizeState);
-        return currentState();
+        return true;
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/CopyrightMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/CopyrightMatcher.java
@@ -22,6 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * Matches a typical Copyright header line only based on a regex pattern which
@@ -105,12 +106,12 @@ public class CopyrightMatcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    protected boolean doMatch(String line) {
-        String lowerLine = line.toLowerCase();
-        if (lowerLine.contains("copyright") || lowerLine.contains("(c)") || line.contains("©")) {
-            Matcher matcher = COPYRIGHT_PATTERN.matcher(line);
+    public boolean matches(IHeaders headers) {
+        String lowerLine = headers.raw().toLowerCase();
+        if (lowerLine.contains("copyright") || lowerLine.contains("(c)") || lowerLine.contains("©")) {
+            Matcher matcher = COPYRIGHT_PATTERN.matcher(headers.raw());
             if (matcher.find()) {
-                String buffer = line.substring(matcher.end());
+                String buffer = headers.raw().substring(matcher.end());
                 matcher = dateOwnerPattern.matcher(buffer);
                 if (matcher.find() && matcher.start() == 0) {
                     return true;

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/FullTextMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/FullTextMatcher.java
@@ -19,7 +19,6 @@
 package org.apache.rat.analysis.matchers;
 
 import java.util.Locale;
-import java.util.Objects;
 
 import org.apache.rat.analysis.IHeaders;
 
@@ -28,20 +27,16 @@ import org.apache.rat.analysis.IHeaders;
  * it to the full text of a given license (after reducing it to letters and
  * numbers as well).
  *
- * <p>
- * The text comparison is case insensitive but assumes only characters in the
- * US-ASCII charset are being matched.
- * </p>
+ * <p> The text comparison is case insensitive but assumes only characters in
+ * the US-ASCII charset are being matched. </p>
  */
 public class FullTextMatcher extends AbstractSimpleMatcher {
-
-    // Number of match characters assumed to be present on first line
-    private static final int DEFAULT_INITIAL_LINE_LENGTH = 20;
 
     private final String fullText;
 
     /**
-     * Constructs the full text matcher with a unique random id and the specified text to match.
+     * Constructs the full text matcher with a unique random id and the specified
+     * text to match.
      * @param fullText the text to match
      */
     public FullTextMatcher(String fullText) {
@@ -60,7 +55,7 @@ public class FullTextMatcher extends AbstractSimpleMatcher {
 
     /**
      * Removes everything except letter or digit from text.
-     * 
+     *
      * @param text The text to remove extra chars from.
      * @return the pruned text.
      */

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/FullTextMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/FullTextMatcher.java
@@ -21,6 +21,8 @@ package org.apache.rat.analysis.matchers;
 import java.util.Locale;
 import java.util.Objects;
 
+import org.apache.rat.analysis.IHeaders;
+
 /**
  * Accumulates all letters and numbers contained inside the header and compares
  * it to the full text of a given license (after reducing it to letters and
@@ -38,12 +40,6 @@ public class FullTextMatcher extends AbstractSimpleMatcher {
 
     private final String fullText;
 
-    private final String firstLine;
-
-    private boolean seenFirstLine;
-
-    private final StringBuilder buffer = new StringBuilder();
-
     /**
      * Constructs the full text matcher with a unique random id and the specified text to match.
      * @param fullText the text to match
@@ -59,15 +55,7 @@ public class FullTextMatcher extends AbstractSimpleMatcher {
      */
     public FullTextMatcher(String id, String fullText) {
         super(id);
-        Objects.requireNonNull(fullText, "fullText may not be null");
-        int offset = fullText.indexOf('\n');
-        if (offset == -1) {
-            offset = Math.min(DEFAULT_INITIAL_LINE_LENGTH, fullText.length());
-        }
-        firstLine = prune(fullText.substring(0, offset)).toLowerCase(Locale.ENGLISH);
         this.fullText = prune(fullText).toLowerCase(Locale.ENGLISH);
-        buffer.setLength(0);
-        seenFirstLine = false;
     }
 
     /**
@@ -89,44 +77,10 @@ public class FullTextMatcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    public boolean doMatch(String line) {
-        final String inputToMatch = prune(line).toLowerCase(Locale.ENGLISH);
-        if (seenFirstLine) { // Accumulate more input
-            buffer.append(inputToMatch);
-        } else {
-            int offset = inputToMatch.indexOf(firstLine);
-            if (offset >= 0) {
-                // we have a match, save the text starting with the match
-                buffer.append(inputToMatch.substring(offset));
-                seenFirstLine = true;
-                // Drop out to check whether full text is matched
-            } else {
-                // we assume that the first line must appear in a single line
-                return false; // no more to do here
-            }
-        }
-
-        if (buffer.length() >= fullText.length()) { // we have enough data to match
-            if (buffer.toString().contains(fullText)) {
-                return true;
-            }
-            // buffer contains first line but does not contain full text
-            // It's possible that the buffer contains the first line again
-            int offset = buffer.substring(1).indexOf(firstLine);
-            if (offset >= 0) { // first line found again
-                buffer.delete(0, offset); // reset buffer to the new start
-            } else { // buffer does not even contain first line, so cannot be used to match full text
-                reset();
-            }
+    public boolean matches(IHeaders headers) {
+        if (headers.pruned().length() >= fullText.length()) { // we have enough data to match
+            return headers.pruned().contains(fullText);
         }
         return false;
     }
-
-    @Override
-    public void reset() {
-        super.reset();
-        buffer.setLength(0);
-        seenFirstLine = false;
-    }
-
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/NotMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/NotMatcher.java
@@ -21,6 +21,7 @@ package org.apache.rat.analysis.matchers;
 import java.util.Objects;
 
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 /**
  * An IHeaderMatcher that reverses the result of an enclosed matcher.
  */
@@ -48,32 +49,12 @@ public class NotMatcher extends AbstractHeaderMatcher {
     }
 
     @Override
-    public State matches(String line) {
-        enclosed.matches(line);
-        return currentState();
+    public boolean matches(IHeaders headers) {
+        return !enclosed.matches(headers);
     }
 
     @Override
     public void reset() {
         enclosed.reset();
-    }
-
-    @Override
-    public State finalizeState() {
-        enclosed.finalizeState();
-        return currentState();
-    }
-
-    @Override
-    public State currentState() {
-        switch (enclosed.currentState()) {
-        case t:
-            return State.f;
-        case f:
-            return State.t;
-        default:
-        case i:
-            return State.i;
-        }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/OrMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/OrMatcher.java
@@ -21,13 +21,12 @@ package org.apache.rat.analysis.matchers;
 import java.util.Collection;
 
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * A matcher that performs a logical {@code OR} across all the contained matchers.
  */
 public class OrMatcher extends AbstractMatcherContainer {
-
-    private State lastState;
 
     /**
      * Constructs the matcher from the enclosed matchers.
@@ -44,52 +43,16 @@ public class OrMatcher extends AbstractMatcherContainer {
      */
     public OrMatcher(String id, Collection<? extends IHeaderMatcher> enclosed) {
         super(id, enclosed);
-        lastState = State.i;
     }
 
     @Override
-    public State matches(String line) {
-        if (lastState == State.t) {
-            return State.t;
-        }
+    public boolean matches(IHeaders headers) {
         for (IHeaderMatcher matcher : enclosed) {
-            switch (matcher.matches(line)) {
-            case t:
-                lastState = State.t;
-                return lastState;
-            case f:
-            case i:
-                lastState = State.i;
+            if (matcher.matches(headers)) {
+                return true;
             }
+            
         }
-        return lastState;
-    }
-
-    @Override
-    public State currentState() {
-        if (lastState == State.t) {
-            return lastState;
-        }
-        for (IHeaderMatcher matcher : enclosed) {
-            switch (matcher.currentState()) {
-            case t:
-                lastState = State.t;
-                return lastState;
-            case i:
-                lastState = State.i;
-                return lastState;
-            case f:
-                // do nothing;
-                break;
-            }
-        }
-        lastState = State.f;
-        return lastState;
-    }
-
-    @Override
-    public void reset() {
-        super.reset();
-        lastState = State.i;
+        return false;
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SPDXMatcherFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SPDXMatcherFactory.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.ConfigurationException;
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * Defines a factory to produce matchers for an SPDX tag. SPDX tag is of the format
@@ -124,8 +125,8 @@ public class SPDXMatcherFactory {
         }
 
         @Override
-        protected boolean doMatch(String line) {
-            return SPDXMatcherFactory.this.check(line, this);
+        public boolean matches(IHeaders headers) {
+            return SPDXMatcherFactory.this.check(headers.raw(), this);
         }
         
         @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SimpleRegexMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SimpleRegexMatcher.java
@@ -20,6 +20,8 @@ package org.apache.rat.analysis.matchers;
 
 import java.util.regex.Pattern;
 
+import org.apache.rat.analysis.IHeaders;
+
 /**
  * A simple regular expression matching IHeaderMatcher
  */
@@ -45,7 +47,7 @@ public class SimpleRegexMatcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    public boolean doMatch(String line) {
-        return pattern.matcher(line).find();
+    public boolean matches(IHeaders headers) {
+        return pattern.matcher(headers.raw()).find();
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SimpleTextMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SimpleTextMatcher.java
@@ -19,6 +19,7 @@
 package org.apache.rat.analysis.matchers;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * A simple text matching IHeaderMatcher implementation.
@@ -48,7 +49,7 @@ public class SimpleTextMatcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    public boolean doMatch(String line) {
-        return line.contains(pattern);
+    public boolean matches(IHeaders headers) {
+        return headers.raw().contains(pattern);
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/builders/MatcherRefBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/builders/MatcherRefBuilder.java
@@ -21,6 +21,7 @@ package org.apache.rat.configuration.builders;
 import java.util.Map;
 
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * A reference matching Matcher builder.
@@ -104,21 +105,9 @@ public class MatcherRefBuilder extends AbstractBuilder {
         }
 
         @Override
-        public State matches(String line) {
+        public boolean matches(IHeaders headers) {
             checkProxy();
-            return wrapped.matches(line);
-        }
-
-        @Override
-        public State currentState() {
-            checkProxy();
-            return wrapped.currentState();
-        }
-
-        @Override
-        public State finalizeState() {
-            checkProxy();
-            return wrapped.finalizeState();
+            return wrapped.matches(headers);
         }
     }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.rat.analysis.IHeaders;
+
 /**
  * Class to take a set of ILicenses and collection of approved license categories and extract Subsets.
  */
@@ -166,8 +168,8 @@ public class LicenseSetFactory {
             }
     
             @Override
-            public State matches(String line) {
-                return State.f;
+            public boolean matches(IHeaders headers) {
+                return false;
             }
     
             @Override
@@ -193,16 +195,6 @@ public class LicenseSetFactory {
             @Override
             public String getName() {
                 return searchFamily.getFamilyName();
-            }
-    
-            @Override
-            public State finalizeState() {
-                return State.f;
-            }
-    
-            @Override
-            public State currentState() {
-                return State.f;
             }
     
         };

--- a/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicense.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 
 /**
  * A simple implementation of ILicense.
@@ -82,18 +83,8 @@ class SimpleLicense implements ILicense {
     }
 
     @Override
-    public State matches(String line) {
-        return matcher.matches(line);
-    }
-    
-    @Override
-    public State finalizeState() {
-        return matcher.finalizeState();
-    }
-
-    @Override
-    public State currentState() {
-        return matcher.currentState();
+    public boolean matches(IHeaders headers) {
+        return matcher.matches(headers);
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/impl/xml/SimpleXmlClaimReporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/impl/xml/SimpleXmlClaimReporter.java
@@ -15,8 +15,11 @@
  * KIND, either express or implied.  See the License for the    *
  * specific language governing permissions and limitations      *
  * under the License.                                           *
- */ 
+ */
 package org.apache.rat.report.claim.impl.xml;
+
+import java.io.IOException;
+import java.util.Calendar;
 
 import org.apache.commons.lang3.time.DateFormatUtils;
 import org.apache.rat.api.Document;
@@ -24,10 +27,6 @@ import org.apache.rat.api.MetaData;
 import org.apache.rat.api.RatException;
 import org.apache.rat.report.AbstractReport;
 import org.apache.rat.report.xml.writer.IXmlWriter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
-
-import java.io.IOException;
-import java.util.Calendar;
 
 public class SimpleXmlClaimReporter extends AbstractReport {
     private static final String RAT_REPORT = "rat-report";
@@ -46,18 +45,16 @@ public class SimpleXmlClaimReporter extends AbstractReport {
         this.writer = writer;
     }
 
-
     /**
      * Writes a single claim to the XML file.
      * @param pPredicate The claims predicate.
      * @param pObject The claims object.
-     * @param pLiteral Whether to write the object as an element (true),
-     *   or an attribute (false).
+     * @param pLiteral Whether to write the object as an element (true), or an
+     * attribute (false).
      * @throws IOException An I/O error occurred while writing the claim.
      * @throws RatException Another error occurred while writing the claim.
      */
-    protected void writeClaim(String pPredicate, String pObject, boolean pLiteral)
-    throws IOException, RatException {
+    protected void writeClaim(String pPredicate, String pObject, boolean pLiteral) throws IOException, RatException {
         if (pLiteral) {
             writer.openElement(pPredicate).content(pObject).closeElement();
         } else {
@@ -76,8 +73,7 @@ public class SimpleXmlClaimReporter extends AbstractReport {
             writer.openElement("resource").attribute(NAME, subject.getName());
             writeDocumentClaims(subject);
         } catch (IOException e) {
-            throw new RatException("XML writing failure: " + e.getMessage()
-                    + " subject: " + subject, e);
+            throw new RatException("XML writing failure: " + e.getMessage() + " subject: " + subject, e);
         }
     }
 
@@ -128,10 +124,8 @@ public class SimpleXmlClaimReporter extends AbstractReport {
     @Override
     public void startReport() throws RatException {
         try {
-            writer.openElement(RAT_REPORT)
-                .attribute(TIMESTAMP,
-                           DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT
-                           .format(Calendar.getInstance()));
+            writer.openElement(RAT_REPORT).attribute(TIMESTAMP,
+                    DateFormatUtils.ISO_8601_EXTENDED_DATETIME_TIME_ZONE_FORMAT.format(Calendar.getInstance()));
         } catch (IOException e) {
             throw new RatException("Cannot open start element", e);
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/ReportingSet.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/ReportingSet.java
@@ -38,21 +38,22 @@ public class ReportingSet<T> implements SortedSet<T> {
     private Options duplicateOption = Options.IGNORE;
     private Log.Level duplicateLogLevel = Log.Level.WARN;
     private Log log = DefaultLog.INSTANCE;
-    private Function<T,String> duplicateFmt = (t) -> String.format("Duplicate %s (%s) detected %s", t.getClass(), t);
+    private Function<T, String> duplicateFmt = (t) -> String.format("Duplicate %s (%s) detected %s", t.getClass(), t);
 
-    public enum Options { OVERWRITE, IGNORE, FAIL }
-    
+    public enum Options {
+        OVERWRITE, IGNORE, FAIL
+    }
+
     /**
-     * Constructor.
-     * Creates a TreeSet of type T.
+     * Constructor. Creates a TreeSet of type T.
      */
     public ReportingSet() {
         this(new TreeSet<T>());
     }
-    
+
     /**
      * Constructs.
-     * 
+     *
      * @param delegate the SortedSet to delegate to.
      */
     public ReportingSet(SortedSet<T> delegate) {
@@ -61,16 +62,18 @@ public class ReportingSet<T> implements SortedSet<T> {
 
     /**
      * Sets the function to generate the log message.
-     * @param msgFmt A function to return the string to be displayed when a collision occurs.
+     * @param msgFmt A function to return the string to be displayed when a
+     * collision occurs.
      * @return This for chaining.
      */
-    public ReportingSet<T> setMsgFormat(Function<T,String> msgFmt) {
+    public ReportingSet<T> setMsgFormat(Function<T, String> msgFmt) {
         duplicateFmt = msgFmt;
         return this;
     }
+
     /**
-     * If set true attempts to duplicate will throw an IllegalArgumentException.
-     * The default state is false;.
+     * If set true attempts to duplicate will throw an IllegalArgumentException. The
+     * default state is false;.
      * @param state the state to set.
      * @return this for chaining.
      */
@@ -80,8 +83,8 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     /**
-     * Sets the log that the reporting set will log to.
-     * if not set the DefaultLog is used.
+     * Sets the log that the reporting set will log to. if not set the DefaultLog is
+     * used.
      * @param log the Log implementation to use.
      * @return this for chaining.
      */
@@ -91,8 +94,8 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     /**
-     * Sets the log level that the reporting set will log at.
-     * if not set the default level is WARN.
+     * Sets the log level that the reporting set will log at. if not set the default
+     * level is WARN.
      * @param level the log level to use.
      * @return this for chaining.
      */
@@ -102,35 +105,36 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     private ReportingSet<T> sameConfig(SortedSet<T> delegate) {
-        ReportingSet<T> result = delegate instanceof ReportingSet ? (ReportingSet<T>) delegate : new ReportingSet<>(delegate);
+        ReportingSet<T> result = delegate instanceof ReportingSet ? (ReportingSet<T>) delegate
+                : new ReportingSet<>(delegate);
         return result.setDuplicateOption(this.duplicateOption).setLog(this.log).setLogLevel(this.duplicateLogLevel);
     }
 
     /**
-     * Adds the item if it is not present.  Does not report collisions.
+     * Adds the item if it is not present. Does not report collisions.
      * @param e the item to add.
      * @return true if the item was added, false otherwise.
      */
     public boolean addIfNotPresent(T e) {
         return add(false, e);
     }
-    
+
     @Override
     public boolean add(T e) {
         return add(true, e);
     }
-    
+
     /**
-     * Attempts to add an item.  Report failures if reportDup is true.
+     * Attempts to add an item. Report failures if reportDup is true.
      * @param reportDup the reporting flag.
      * @param e the item to add
      * @return true if the item was added.
      */
     private boolean add(boolean reportDup, T e) {
         if (delegate.contains(e)) {
-            String msg = String.format("%s",ReportingSet.this.duplicateFmt.apply(e));
+            String msg = String.format("%s", ReportingSet.this.duplicateFmt.apply(e));
             if (reportDup) {
-                msg =  String.format( "%s (action: %s)", msg, duplicateOption);
+                msg = String.format("%s (action: %s)", msg, duplicateOption);
                 log.log(duplicateLogLevel, msg);
             }
             switch (duplicateOption) {
@@ -155,7 +159,6 @@ public class ReportingSet<T> implements SortedSet<T> {
         return updated;
     }
 
- 
     public boolean addAllIfNotPresent(Collection<? extends T> c) {
         boolean updated = false;
         for (T e : c) {
@@ -163,7 +166,7 @@ public class ReportingSet<T> implements SortedSet<T> {
         }
         return updated;
     }
-    
+
     @Override
     public void clear() {
         delegate.clear();

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/ReportingSet.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/ReportingSet.java
@@ -38,22 +38,21 @@ public class ReportingSet<T> implements SortedSet<T> {
     private Options duplicateOption = Options.IGNORE;
     private Log.Level duplicateLogLevel = Log.Level.WARN;
     private Log log = DefaultLog.INSTANCE;
-    private Function<T, String> duplicateFmt = (t) -> String.format("Duplicate %s (%s) detected %s", t.getClass(), t);
+    private Function<T,String> duplicateFmt = (t) -> String.format("Duplicate %s (%s) detected %s", t.getClass(), t);
 
-    public enum Options {
-        OVERWRITE, IGNORE, FAIL
-    }
-
+    public enum Options { OVERWRITE, IGNORE, FAIL }
+    
     /**
-     * Constructor. Creates a TreeSet of type T.
+     * Constructor.
+     * Creates a TreeSet of type T.
      */
     public ReportingSet() {
         this(new TreeSet<T>());
     }
-
+    
     /**
      * Constructs.
-     *
+     * 
      * @param delegate the SortedSet to delegate to.
      */
     public ReportingSet(SortedSet<T> delegate) {
@@ -62,18 +61,16 @@ public class ReportingSet<T> implements SortedSet<T> {
 
     /**
      * Sets the function to generate the log message.
-     * @param msgFmt A function to return the string to be displayed when a
-     * collision occurs.
+     * @param msgFmt A function to return the string to be displayed when a collision occurs.
      * @return This for chaining.
      */
-    public ReportingSet<T> setMsgFormat(Function<T, String> msgFmt) {
+    public ReportingSet<T> setMsgFormat(Function<T,String> msgFmt) {
         duplicateFmt = msgFmt;
         return this;
     }
-
     /**
-     * If set true attempts to duplicate will throw an IllegalArgumentException. The
-     * default state is false;.
+     * If set true attempts to duplicate will throw an IllegalArgumentException.
+     * The default state is false;.
      * @param state the state to set.
      * @return this for chaining.
      */
@@ -83,8 +80,8 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     /**
-     * Sets the log that the reporting set will log to. if not set the DefaultLog is
-     * used.
+     * Sets the log that the reporting set will log to.
+     * if not set the DefaultLog is used.
      * @param log the Log implementation to use.
      * @return this for chaining.
      */
@@ -94,8 +91,8 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     /**
-     * Sets the log level that the reporting set will log at. if not set the default
-     * level is WARN.
+     * Sets the log level that the reporting set will log at.
+     * if not set the default level is WARN.
      * @param level the log level to use.
      * @return this for chaining.
      */
@@ -105,36 +102,35 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     private ReportingSet<T> sameConfig(SortedSet<T> delegate) {
-        ReportingSet<T> result = delegate instanceof ReportingSet ? (ReportingSet<T>) delegate
-                : new ReportingSet<>(delegate);
+        ReportingSet<T> result = delegate instanceof ReportingSet ? (ReportingSet<T>) delegate : new ReportingSet<>(delegate);
         return result.setDuplicateOption(this.duplicateOption).setLog(this.log).setLogLevel(this.duplicateLogLevel);
     }
 
     /**
-     * Adds the item if it is not present. Does not report collisions.
+     * Adds the item if it is not present.  Does not report collisions.
      * @param e the item to add.
      * @return true if the item was added, false otherwise.
      */
     public boolean addIfNotPresent(T e) {
         return add(false, e);
     }
-
+    
     @Override
     public boolean add(T e) {
         return add(true, e);
     }
-
+    
     /**
-     * Attempts to add an item. Report failures if reportDup is true.
+     * Attempts to add an item.  Report failures if reportDup is true.
      * @param reportDup the reporting flag.
      * @param e the item to add
      * @return true if the item was added.
      */
     private boolean add(boolean reportDup, T e) {
         if (delegate.contains(e)) {
-            String msg = String.format("%s", ReportingSet.this.duplicateFmt.apply(e));
+            String msg = String.format("%s",ReportingSet.this.duplicateFmt.apply(e));
             if (reportDup) {
-                msg = String.format("%s (action: %s)", msg, duplicateOption);
+                msg =  String.format( "%s (action: %s)", msg, duplicateOption);
                 log.log(duplicateLogLevel, msg);
             }
             switch (duplicateOption) {
@@ -159,6 +155,7 @@ public class ReportingSet<T> implements SortedSet<T> {
         return updated;
     }
 
+ 
     public boolean addAllIfNotPresent(Collection<? extends T> c) {
         boolean updated = false;
         for (T e : c) {
@@ -166,7 +163,7 @@ public class ReportingSet<T> implements SortedSet<T> {
         }
         return updated;
     }
-
+    
     @Override
     public void clear() {
         delegate.clear();

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
@@ -49,7 +49,7 @@ public class ReportTest {
     public void testDefaultConfiguration() throws ParseException, IOException {
         String[] empty = {};
         CommandLine cl = new DefaultParser().parse(Report.buildOptions(), empty);
-        ReportConfiguration config = Report.createConfiguration("", cl);
+        ReportConfiguration config = Report.createConfiguration(".", cl);
         ReportConfigurationTest.validateDefault(config);
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
@@ -49,7 +49,7 @@ public class ReportTest {
     public void testDefaultConfiguration() throws ParseException, IOException {
         String[] empty = {};
         CommandLine cl = new DefaultParser().parse(Report.buildOptions(), empty);
-        ReportConfiguration config = Report.createConfiguration(".", cl);
+        ReportConfiguration config = Report.createConfiguration("", cl);
         ReportConfigurationTest.validateDefault(config);
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/AnalyserFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/AnalyserFactoryTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 import java.io.StringWriter;
 import java.util.Arrays;
 
-import org.apache.rat.analysis.IHeaderMatcher.State;
 import org.apache.rat.document.IDocumentAnalyser;
 import org.apache.rat.document.impl.MonolithicFileDocument;
 import org.apache.rat.license.ILicense;
@@ -41,13 +40,7 @@ import org.junit.jupiter.api.Test;
 
 public class AnalyserFactoryTest {
 
-    private static ILicense MATCHES_NOTHING_MATCHER = mock(ILicense.class);
-
-    static {
-            when(MATCHES_NOTHING_MATCHER.matches(any())).thenReturn(State.f);
-            when(MATCHES_NOTHING_MATCHER.currentState()).thenReturn(State.f);
-            when(MATCHES_NOTHING_MATCHER.finalizeState()).thenReturn(State.f);
-    }
+    private static ILicense MATCHES_NOTHING_MATCHER = new UnknownLicense();
 
     private StringWriter out;
     private SimpleXmlClaimReporter reporter;

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/HeaderCheckWorkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/HeaderCheckWorkerTest.java
@@ -38,8 +38,6 @@ public class HeaderCheckWorkerTest {
         final Document subject = new TestingLocation("subject");
         ILicense matcher = new TestingLicense();
         HeaderCheckWorker worker = new HeaderCheckWorker(new StringReader(""), matcher, subject);
-        assertFalse(worker.isFinished());
         worker.read();
-        assertTrue(worker.isFinished());
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/license/AbstractLicenseTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/license/AbstractLicenseTest.java
@@ -31,7 +31,8 @@ import java.io.StringReader;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.Defaults;
-import org.apache.rat.analysis.IHeaderMatcher.State;
+import org.apache.rat.analysis.HeaderCheckWorker;
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.analysis.matchers.FullTextMatcher;
 import org.apache.rat.api.MetaData;
 import org.apache.rat.license.ILicense;
@@ -115,13 +116,8 @@ abstract public class AbstractLicenseTest {
 
     private boolean processText(ILicense license, String text) throws IOException {
         try (BufferedReader in = new BufferedReader(new StringReader(text))) {
-            String line;
-            while (null != (line = in.readLine())) {
-                if (license.matches(line) == State.t) {
-                    return true;
-                }
-            }
-            return license.finalizeState().asBoolean();
+            IHeaders headers = HeaderCheckWorker.readHeader(in,HeaderCheckWorker.DEFAULT_NUMBER_OF_RETAINED_HEADER_LINES);
+            return license.matches(headers);
         }
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/license/DirectoryScanner.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/license/DirectoryScanner.java
@@ -25,7 +25,8 @@ import java.io.BufferedReader;
 import java.io.File;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.rat.analysis.IHeaderMatcher.State;
+import org.apache.rat.analysis.HeaderCheckWorker;
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.test.utils.Resources;
 import org.junit.jupiter.api.Test;
@@ -48,18 +49,12 @@ class DirectoryScanner {
             fail("No files found under " + directory);
         }
         for (File f : resourceFiles) {
-            BufferedReader br = null;
-            try {
-                boolean result = false;
-                br = Resources.getBufferedReader(f);
-                String line;
-                while (!result && (line = br.readLine()) != null) {
-                    result = license.matches(line) == State.t;
-                }
+            try (BufferedReader br = Resources.getBufferedReader(f)){
+                IHeaders headers = HeaderCheckWorker.readHeader(br, HeaderCheckWorker.DEFAULT_NUMBER_OF_RETAINED_HEADER_LINES);
+                boolean result = license.matches(headers);
                 assertEquals(expected, result, f.toString());
             } finally {
                 license.reset();
-                IOUtils.closeQuietly(br);
             }
         }
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/AbstractMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/AbstractMatcherTest.java
@@ -20,21 +20,46 @@ package org.apache.rat.analysis.matchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
+import java.util.Locale;
 
 import org.apache.rat.analysis.IHeaderMatcher;
-import org.apache.rat.testhelpers.TestingMatcher;
-import org.junit.jupiter.api.Test;
+import org.apache.rat.analysis.IHeaders;
 
-public class OrMatcherTest extends AbstractMatcherTest {
+public class AbstractMatcherTest {
 
-    
-    @Test
-    public void trueTest() {
-        IHeaderMatcher one = new TestingMatcher("one", false, false, true, true);
-        IHeaderMatcher two = new TestingMatcher("two", false, true, false, true);
-        OrMatcher target = new OrMatcher("Testing", Arrays.asList(one, two));
-        assertValues(target, false, true, true, true);
-        target.reset();
+    private IHeaders dummyHeader = makeHeaders(null, null);
+
+    protected void assertValues(IHeaderMatcher target, boolean... values) {
+        for (int i = 0; i < values.length; i++) {
+            final int idx = i;
+            assertEquals(values[i], target.matches(dummyHeader), () -> String.format("Position %s", idx));
+        }
     }
+
+    public static IHeaders makeHeaders(String raw, String pruned) {
+        return new IHeaders() {
+
+            @Override
+            public String raw() {
+                if (raw == null) {
+                    throw new UnsupportedOperationException("Should not be called");
+                }
+                return raw;
+            }
+
+            @Override
+            public String pruned() {
+                if (pruned == null) {
+                    throw new UnsupportedOperationException("Should not be called");
+                }
+                return FullTextMatcher.prune(pruned).toLowerCase(Locale.ENGLISH);
+            }
+
+            @Override
+            public String toString() {
+                return "AbstractMatcherTest";
+            }
+        };
+    }
+
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/AndMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/AndMatcherTest.java
@@ -23,56 +23,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Arrays;
 
 import org.apache.rat.analysis.IHeaderMatcher;
-import org.apache.rat.analysis.IHeaderMatcher.State;
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.testhelpers.TestingMatcher;
 import org.junit.jupiter.api.Test;
 
-
-public class AndMatcherTest {
-
-    private void assertValues(IHeaderMatcher target, State hello, State world, State finalize) {
-        assertEquals(State.i, target.currentState());
-        assertEquals(hello, target.matches("hello"));
-        assertEquals(hello, target.currentState());
-        assertEquals(world, target.matches("world"));
-        assertEquals(world, target.currentState());
-        assertEquals(finalize, target.finalizeState());
-        assertEquals(finalize, target.currentState());
-    }
+public class AndMatcherTest extends AbstractMatcherTest {
 
     @Test
     public void trueTest() {
-        IHeaderMatcher one = new TestingMatcher("one", true);
-        IHeaderMatcher two = new TestingMatcher("two", false, true);
-        AndMatcher target = new AndMatcher("Testing", Arrays.asList(one, two));
-        assertValues(target, State.i, State.t, State.t);
-        target.reset();
-        assertEquals(State.i, one.currentState());
-        assertEquals(State.i, two.currentState());
-        assertEquals(State.i, target.currentState());
-    }
 
-    @Test
-    public void falseTest() {
-        IHeaderMatcher one = new TestingMatcher("one", true);
-        IHeaderMatcher two = new TestingMatcher("two", false, false);
+        IHeaderMatcher one = new TestingMatcher("one", true, true, false, false);
+        // only need 2 entries because when one is false two test does not get called.
+        IHeaderMatcher two = new TestingMatcher("two", true, false);
         AndMatcher target = new AndMatcher("Testing", Arrays.asList(one, two));
-        assertValues(target, State.i, State.i, State.f);
+        assertValues(target, true, false, false, false);
         target.reset();
-        assertEquals(State.i, one.currentState());
-        assertEquals(State.i, two.currentState());
-        assertEquals(State.i, target.currentState());
-    }
-
-    @Test
-    public void indeterminentTest() {
-        IHeaderMatcher one = new TestingMatcher("one", false, false);
-        IHeaderMatcher two = new TestingMatcher("two", false, false);
-        AndMatcher target = new AndMatcher("Testing", Arrays.asList(one, two));
-        assertValues(target, State.i, State.i, State.f);
-        target.reset();
-        assertEquals(State.i, one.currentState());
-        assertEquals(State.i, two.currentState());
-        assertEquals(State.i, target.currentState());
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/CopyrightMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/CopyrightMatcherTest.java
@@ -20,6 +20,7 @@ package org.apache.rat.analysis.matchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +29,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.rat.analysis.IHeaderMatcher.State;
+import org.apache.rat.analysis.HeaderCheckWorker;
+import org.apache.rat.analysis.IHeaders;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -95,10 +97,9 @@ expandResults( DO, DOS, S, D, SO ) );
         verify(testName, pass, fail);
         CopyrightMatcher matcher = new CopyrightMatcher(start, stop, owner);
         for (String[] target : pass) {
-            assertEquals(State.i, matcher.currentState(), ()->String.format("%s:%s failed", testName, target[NAME]));
-            assertEquals(State.t, matcher.matches(target[TEXT]), ()->String.format("%s:%s failed", testName, target[NAME]));
+            IHeaders headers = AbstractMatcherTest.makeHeaders(target[TEXT],null);
+            assertTrue(matcher.matches(headers),  ()->String.format("%s:%s failed", testName, target[NAME]));
             matcher.reset();
-            assertEquals(State.i, matcher.currentState(),()->String.format("%s:%s failed", testName, target[NAME]));
         }
     }
 
@@ -109,11 +110,9 @@ expandResults( DO, DOS, S, D, SO ) );
         verify(testName, pass, fail);
         CopyrightMatcher matcher = new CopyrightMatcher(start, stop, owner);
         for (String[] target : fail) {
-            assertEquals( State.i, matcher.currentState(), ()->String.format("%s:%s passed", testName, target[NAME]));
-            assertEquals( State.i, matcher.matches(target[TEXT]), ()->String.format("%s:%s passed", testName, target[NAME]));
-            assertEquals( State.f, matcher.finalizeState(), ()->String.format("%s:%s passed", testName, target[NAME]));
+            IHeaders headers = AbstractMatcherTest.makeHeaders(target[TEXT],null);
+            assertFalse( matcher.matches(headers), String.format("%s:%s passed", testName, target[NAME]));
             matcher.reset();
-            assertEquals( State.i, matcher.currentState(), ()->String.format("%s:%s passed", testName, target[NAME]));
         }
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/FullTextMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/FullTextMatcherTest.java
@@ -24,7 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.rat.analysis.IHeaderMatcher.State;
+import java.util.Locale;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.rat.analysis.IHeaders;
 
 public class FullTextMatcherTest {
 
@@ -34,43 +37,11 @@ public class FullTextMatcherTest {
     public void setup() {
         target.reset();
     }
-    
+
     @Test
     public void testMatch() {
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.i, target.matches("what in the world"));
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.t, target.matches("hello world"));
-        assertEquals( State.t, target.currentState());
-        assertEquals( State.t, target.finalizeState()); 
-        assertEquals( State.t, target.currentState());
-        target.reset();
-        assertEquals( State.i, target.currentState());
-    }
-    
-    @Test
-    public void testNoMatch() {
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.i, target.matches("what in the world"));
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.i, target.matches("hello there"));
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.f, target.finalizeState());
-        assertEquals( State.f, target.currentState());
-        target.reset();
-        assertEquals( State.i, target.currentState());
-    }
-    
-    @Test
-    public void testTrueIsAlwaysTrue() {
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.t, target.matches("hello world"));
-        assertEquals( State.t, target.currentState());
-        assertEquals( State.t, target.matches("A non matching line"));
-        assertEquals( State.t, target.currentState());        
-        assertEquals( State.t, target.finalizeState()); 
-        assertEquals( State.t, target.currentState());
-        target.reset();
-        assertEquals( State.i, target.currentState());
+        assertEquals(false, target.matches(AbstractMatcherTest.makeHeaders(null, "what in the world")));
+        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders(null, "hello world")));
+        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders(null, "HELLO world")));
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/FullTextMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/FullTextMatcherTest.java
@@ -18,21 +18,16 @@
  */
 package org.apache.rat.analysis.matchers;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Locale;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.rat.analysis.IHeaders;
-
 public class FullTextMatcherTest {
 
     FullTextMatcher target = new FullTextMatcher("Hello world");
-    
+
     @BeforeEach
     public void setup() {
         target.reset();
@@ -40,8 +35,8 @@ public class FullTextMatcherTest {
 
     @Test
     public void testMatch() {
-        assertEquals(false, target.matches(AbstractMatcherTest.makeHeaders(null, "what in the world")));
-        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders(null, "hello world")));
-        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders(null, "HELLO world")));
+        assertFalse(target.matches(AbstractMatcherTest.makeHeaders(null, "what in the world")));
+        assertTrue(target.matches(AbstractMatcherTest.makeHeaders(null, "hello world")));
+        assertTrue(target.matches(AbstractMatcherTest.makeHeaders(null, "HELLO world")));
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/NotMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/NotMatcherTest.java
@@ -21,43 +21,16 @@ package org.apache.rat.analysis.matchers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.rat.analysis.IHeaderMatcher;
-import org.apache.rat.analysis.IHeaderMatcher.State;
 import org.apache.rat.testhelpers.TestingMatcher;
 import org.junit.jupiter.api.Test;
 
-public class NotMatcherTest {
-
-    private void assertValues(IHeaderMatcher target, State hello, State world, State finalize) {
-        assertEquals(State.i, target.currentState());
-        assertEquals( hello, target.matches("hello"), "hello match");
-        assertEquals( hello, target.currentState(), "hello current");
-        assertEquals(world, target.matches("world"), "world match");
-        assertEquals( world, target.currentState(), "world current");
-        assertEquals(finalize, target.finalizeState(), "finalize match");
-        assertEquals(finalize, target.currentState(), "finalize current");
-    }
+public class NotMatcherTest extends AbstractMatcherTest {
 
     @Test
-    public void testTrue() {
-        IHeaderMatcher one = new TestingMatcher("one", true);
+    public void test() {
+        IHeaderMatcher one = new TestingMatcher("one", true, false);
         NotMatcher target = new NotMatcher("Testing", one);
-        assertValues(target, State.f, State.f, State.f);
-
-        one = new TestingMatcher("one", false, true);
-        target = new NotMatcher("Testing", one);
-        assertValues(target, State.i, State.f, State.f);
-        target.reset();
-        assertEquals(State.i, target.currentState());
+        assertValues(target, false, true);
     }
 
-    @Test
-    public void testFalse() {
-        TestingMatcher one = new TestingMatcher("one", false, false);
-        one.finalState = State.t;
-        NotMatcher target = new NotMatcher("Testing", one);
-        assertValues(target, State.i, State.i, State.f);
-        target.reset();
-        assertEquals(State.i, target.currentState());
-
-    }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
@@ -21,7 +21,6 @@ package org.apache.rat.analysis.matchers;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.rat.analysis.IHeaderMatcher;
-import org.apache.rat.analysis.IHeaderMatcher.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,51 +35,8 @@ public class SPDXMatcherTest {
 
     @Test
     public void testMatch() {
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("SPDX-License-Identifier: Apache-2"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.t, target.matches("SPDX-License-Identifier: hello"));
-        assertEquals(State.t, target.currentState());
-        assertEquals(State.t, target.finalizeState());
-        assertEquals(State.t, target.currentState());
+        assertEquals(false, target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: Apache-2", null)));
+        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: hello", null)));
         target.reset();
-        assertEquals(State.i, target.currentState());
-    }
-
-    @Test
-    public void testNoMatch() {
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("SPDX-License-Identifier: Apache-2"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("SPDX-License-Identifier: MIT"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.f, target.finalizeState());
-        assertEquals(State.f, target.currentState());
-        target.reset();
-        assertEquals(State.i, target.currentState());
-    }
-
-    @Test
-    public void testTrueIsAlwaysTrue() {
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.t, target.matches("SPDX-License-Identifier: hello"));
-        assertEquals(State.t, target.currentState());
-        assertEquals(State.t, target.matches("SPDX-License-Identifier: Apache-2"));
-        assertEquals(State.t, target.currentState());
-        assertEquals(State.t, target.finalizeState());
-        assertEquals(State.t, target.currentState());
-        target.reset();
-        assertEquals(State.i, target.currentState());
-    }
-    
-    @Test
-    public void testResetClearsLastMatch() {
-        
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.t, target.matches("SPDX-License-Identifier: hello"));
-        assertEquals(State.t, target.currentState());
-        target.reset();
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("Something weird"));;
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rat.analysis.matchers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.rat.analysis.IHeaderMatcher;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,8 +36,8 @@ public class SPDXMatcherTest {
 
     @Test
     public void testMatch() {
-        assertEquals(false, target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: Apache-2", null)));
-        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: hello", null)));
+        assertFalse(target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: Apache-2", null)));
+        assertTrue(target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: hello", null)));
         target.reset();
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleCopyrightTests.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleCopyrightTests.java
@@ -18,7 +18,9 @@
  */
 package org.apache.rat.analysis.matchers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 public class SimpleCopyrightTests {
@@ -27,8 +29,8 @@ public class SimpleCopyrightTests {
     
     @Test
     public void testTrueIsAlwaysTrue() {
-        assertEquals( true, target.matches(AbstractMatcherTest.makeHeaders("hello Copyright 1999", null)));
-        assertEquals( false, target.matches(AbstractMatcherTest.makeHeaders("A non matching line",null)));
+        assertTrue(target.matches(AbstractMatcherTest.makeHeaders("hello Copyright 1999", null)));
+        assertFalse(target.matches(AbstractMatcherTest.makeHeaders("A non matching line",null)));
         target.reset();
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleCopyrightTests.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleCopyrightTests.java
@@ -19,8 +19,6 @@
 package org.apache.rat.analysis.matchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.apache.rat.analysis.IHeaderMatcher.State;
 import org.junit.jupiter.api.Test;
 
 public class SimpleCopyrightTests {
@@ -29,15 +27,8 @@ public class SimpleCopyrightTests {
     
     @Test
     public void testTrueIsAlwaysTrue() {
-        
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.t, target.matches("hello Copyright 1999"));
-        assertEquals( State.t, target.currentState());
-        assertEquals( State.t, target.matches("A non matching line"));
-        assertEquals( State.t, target.currentState());        
-        assertEquals( State.t, target.finalizeState()); 
-        assertEquals( State.t, target.currentState());
+        assertEquals( true, target.matches(AbstractMatcherTest.makeHeaders("hello Copyright 1999", null)));
+        assertEquals( false, target.matches(AbstractMatcherTest.makeHeaders("A non matching line",null)));
         target.reset();
-        assertEquals( State.i, target.currentState());
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleRegexMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleRegexMatcherTest.java
@@ -25,8 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.regex.Pattern;
 
-import org.apache.rat.analysis.IHeaderMatcher.State;
-
 public class SimpleRegexMatcherTest {
 
     SimpleRegexMatcher target = new SimpleRegexMatcher(Pattern.compile("hello\\sworld"));
@@ -37,41 +35,9 @@ public class SimpleRegexMatcherTest {
     }
     
     @Test
-    public void testMatch() {
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.i, target.matches("what in the world"));
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.t, target.matches("hello world"));
-        assertEquals( State.t, target.currentState());
-        assertEquals( State.t, target.finalizeState()); 
-        assertEquals( State.t, target.currentState());
+    public void test() {
+        assertEquals( false, target.matches(AbstractMatcherTest.makeHeaders("what in the world",null)));
+        assertEquals( true, target.matches(AbstractMatcherTest.makeHeaders("hello world",null)));
         target.reset();
-        assertEquals( State.i, target.currentState());
-    }
-
-    @Test
-    public void testNoMatch() {
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.i, target.matches("what in the world"));
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.i, target.matches("hello there"));
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.f, target.finalizeState());
-        assertEquals( State.f, target.currentState());
-        target.reset();
-        assertEquals( State.i, target.currentState());
-    }
-    
-    @Test
-    public void testTrueIsAlwaysTrue() {
-        assertEquals( State.i, target.currentState());
-        assertEquals( State.t, target.matches("hello world"));
-        assertEquals( State.t, target.currentState());
-        assertEquals( State.t, target.matches("A non matching line"));
-        assertEquals( State.t, target.currentState());        
-        assertEquals( State.t, target.finalizeState()); 
-        assertEquals( State.t, target.currentState());
-        target.reset();
-        assertEquals( State.i, target.currentState());
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleTextMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleTextMatcherTest.java
@@ -18,7 +18,8 @@
  */
 package org.apache.rat.analysis.matchers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,8 +35,8 @@ public class SimpleTextMatcherTest {
 
     @Test
     public void testMatch() {
-        assertEquals(false, target.matches(AbstractMatcherTest.makeHeaders("what in the world",null)));
-        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders("hello world",null)));
+        assertFalse(target.matches(AbstractMatcherTest.makeHeaders("what in the world",null)));
+        assertTrue(target.matches(AbstractMatcherTest.makeHeaders("hello world",null)));
         target.reset();
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleTextMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SimpleTextMatcherTest.java
@@ -20,7 +20,6 @@ package org.apache.rat.analysis.matchers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.rat.analysis.IHeaderMatcher.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,54 +34,9 @@ public class SimpleTextMatcherTest {
 
     @Test
     public void testMatch() {
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("what in the world"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.t, target.matches("hello world"));
-        assertEquals(State.t, target.currentState());
-        assertEquals(State.t, target.finalizeState());
-        assertEquals(State.t, target.currentState());
+        assertEquals(false, target.matches(AbstractMatcherTest.makeHeaders("what in the world",null)));
+        assertEquals(true, target.matches(AbstractMatcherTest.makeHeaders("hello world",null)));
         target.reset();
-        assertEquals(State.i, target.currentState());
     }
 
-    @Test
-    public void testNoMatch() {
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("what in the world"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("hell o'there"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.f, target.finalizeState());
-        assertEquals(State.f, target.currentState());
-        target.reset();
-        assertEquals(State.i, target.currentState());
-    }
-
-    @Test
-    public void testTrueIsAlwaysTrue() {
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.t, target.matches("hello world"));
-        assertEquals(State.t, target.currentState());
-        assertEquals(State.t, target.matches("A non matching line"));
-        assertEquals(State.t, target.currentState());
-        assertEquals(State.t, target.finalizeState());
-        assertEquals(State.t, target.currentState());
-        target.reset();
-        assertEquals(State.i, target.currentState());
-    }
-
-    @Test
-    public void testIndeterminent() {
-        target = new SimpleTextMatcher("not a match");
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("hello world"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.i, target.matches("A non matching line"));
-        assertEquals(State.i, target.currentState());
-        assertEquals(State.f, target.finalizeState());
-        assertEquals(State.f, target.currentState());
-        target.reset();
-        assertEquals(State.i, target.currentState());
-    }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -33,7 +33,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.filefilter.HiddenFileFilter;
 import org.apache.rat.ConfigurationException;
 import org.apache.rat.ReportConfiguration;
-import org.apache.rat.analysis.IHeaderMatcher.State;
 import org.apache.rat.api.MetaData;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
@@ -105,7 +104,7 @@ public class XmlReportFactoryTest {
     public void testNoLicense() throws Exception {
 
         final ILicense mockLicense = mock(ILicense.class);
-        when(mockLicense.matches(any())).thenReturn(State.t);
+        when(mockLicense.matches(any())).thenReturn(true);
         when(mockLicense.getLicenseFamily()).thenReturn(family);
 
         final ClaimStatistic statistic = new ClaimStatistic();

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
@@ -102,6 +102,7 @@ public class XmlReportTest {
         XPath xPath = XPathFactory.newInstance().newXPath();
         Document doc = XmlUtils.toDom(new ByteArrayInputStream(out.toByteArray()));
 
+        XmlUtils.printDocument(System.out, doc);
         XmlUtils.checkNode(doc, xPath, "src/test/resources/elements/ILoggerFactory.java", "QOS", null, "standard");
         XmlUtils.checkNode(doc, xPath, "src/test/resources/elements/Image.png", null, null, "binary");
         XmlUtils.checkNode(doc, xPath, "src/test/resources/elements/LICENSE", null, null, "notice");

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportTest.java
@@ -102,7 +102,6 @@ public class XmlReportTest {
         XPath xPath = XPathFactory.newInstance().newXPath();
         Document doc = XmlUtils.toDom(new ByteArrayInputStream(out.toByteArray()));
 
-        XmlUtils.printDocument(System.out, doc);
         XmlUtils.checkNode(doc, xPath, "src/test/resources/elements/ILoggerFactory.java", "QOS", null, "standard");
         XmlUtils.checkNode(doc, xPath, "src/test/resources/elements/Image.png", null, null, "binary");
         XmlUtils.checkNode(doc, xPath, "src/test/resources/elements/LICENSE", null, null, "notice");

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TestingLicense.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TestingLicense.java
@@ -20,6 +20,7 @@ package org.apache.rat.testhelpers;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 
@@ -135,18 +136,8 @@ public class TestingLicense implements ILicense {
     }
 
     @Override
-    public State matches(String line) {
-        return matcher.matches(line);
-    }
-
-    @Override
-    public State finalizeState() {
-        return matcher.finalizeState();
-    }
-
-    @Override
-    public State currentState() {
-        return matcher.currentState();
+    public boolean matches(IHeaders headers) {
+        return matcher.matches(headers);
     }
 
     @Override

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TestingMatcher.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TestingMatcher.java
@@ -21,16 +21,15 @@ package org.apache.rat.testhelpers;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.analysis.matchers.AbstractHeaderMatcher;
 
 /**
  * An Matcher for testing.
  */
 public class TestingMatcher extends AbstractHeaderMatcher {
-    private State lastState;
     private final boolean[] initialResults;
     private Queue<Boolean> results;
-    public State finalState = State.f;
 
     /**
      * Constructs a matcher with an ID of "dfltMtch" that does not match anyting.
@@ -70,35 +69,15 @@ public class TestingMatcher extends AbstractHeaderMatcher {
     }
 
     @Override
-    public final State matches(String line) {
-        if (lastState == State.t) {
-            return lastState;
-        }
-        if (line != null && results.poll()) {
-            lastState = State.t;
-        }
-        return lastState;
+    public final boolean matches(IHeaders headers) {
+        return results.poll();
     }
 
     @Override
     public void reset() {
-        lastState = State.i;
         results.clear();
         for (boolean b : initialResults) {
             this.results.add(b);
         }
-    }
-
-    @Override
-    public State finalizeState() {
-        if (lastState == State.i) {
-            lastState = finalState;
-        }
-        return lastState;
-    }
-
-    @Override
-    public final State currentState() {
-        return lastState;
     }
 }

--- a/apache-rat-tasks/src/test/java/org/example/Matcher.java
+++ b/apache-rat-tasks/src/test/java/org/example/Matcher.java
@@ -16,6 +16,7 @@
  */
 package org.example;
 
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.analysis.matchers.AbstractSimpleMatcher;
 
 public class Matcher extends AbstractSimpleMatcher {
@@ -24,7 +25,7 @@ public class Matcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    public boolean doMatch(String line) {
+    public boolean matches(IHeaders headers) {
         return true;
     }
 

--- a/apache-rat-tasks/src/test/resources/antunit/report-junit.xml
+++ b/apache-rat-tasks/src/test/resources/antunit/report-junit.xml
@@ -173,6 +173,7 @@
 package org.example;
 
 import org.apache.rat.analysis.matchers.AbstractSimpleMatcher;
+import org.apache.rat.analysis.IHeaders;
 
 public class InlineMatcher extends AbstractSimpleMatcher {
     public InlineMatcher() {
@@ -180,7 +181,7 @@ public class InlineMatcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    public boolean doMatch(String line) {
+    public boolean matches(IHeaders headers) {
         return true;
     }
 }

--- a/apache-rat-tasks/src/test/resources/antunit/report-normal-operation.xml
+++ b/apache-rat-tasks/src/test/resources/antunit/report-normal-operation.xml
@@ -453,6 +453,7 @@ SPDX-License-Identifier: Apache-2.0
 		<echo file="${output.dir}/src/org/example/MyMatcher.java"><![CDATA[
 package org.example;
 
+import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.analysis.matchers.AbstractSimpleMatcher;
 
 public class MyMatcher extends AbstractSimpleMatcher {
@@ -461,7 +462,7 @@ public class MyMatcher extends AbstractSimpleMatcher {
     }
 
     @Override
-    public boolean doMatch(String line) {
+    public boolean matches(IHeaders headers) {
         return true;
     }
 }


### PR DESCRIPTION
Simplification of match processing.  Minor performance improvements. Code path improvement and simplification.

This change removes the State tracking for matches and switches from a line-by-line approach to a text-block approach.  The change is that we read all the lines that we are going to process before we do any tests and then we call the matchers.

This means that this change will hit every matcher in the system as well as the match handling code.  However, the code path is significantly simplified as a result of removing the State tracking necessary for the line-by-line approach.

As you can see most of the code changes are the removal of state and some reduction in ancillary tracking of the text seen in some matchers.