### PR TITLE
RAT-362, RAT-345: Fix gitignore directory handling - switch to relative paths in underlying library

### DIFF
--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -318,7 +318,7 @@
     <dependency>
       <groupId>nl.basjes.gitignore</groupId>
       <artifactId>gitignore-reader</artifactId>
-      <version>1.4.0</version>
+      <version>1.5.1</version>
     </dependency>
   </dependencies>
   <reporting>

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/GitIgnoreMatcher.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/util/ignore/GitIgnoreMatcher.java
@@ -32,7 +32,8 @@ public class GitIgnoreMatcher implements IgnoreMatcher {
     public GitIgnoreMatcher(final Log log, final File projectBaseDir) {
         log.debug("Recursively loading .gitignore files in " + projectBaseDir);
         // This will walk the project tree and load all .gitignore files
-        gitIgnoreFileSet = new GitIgnoreFileSet(projectBaseDir);
+        gitIgnoreFileSet = new GitIgnoreFileSet(projectBaseDir)
+                .assumeQueriesAreProjectRelative();
     }
 
     @Override

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
@@ -269,6 +269,14 @@ public class RatCheckMojoTest extends BetterAbstractMojoTestCase {
         final File ratTxtFile = getRatTxtFile(mojo);
         final String dir = getDir(mojo);
 
+        if (dir.contains(":")) {
+            // The problem this is testing for cannot happen if there is
+            // a Windows drive letter in the name of the directory.
+            // Any duplication of a ':' will make it all fail always.
+            // So there is no point in continuing this test.
+            return;
+        }
+
         // Make the target directory for the test file
         File targetDirectory = new File(dir + dir);
         if (!targetDirectory.exists()) {

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
@@ -24,7 +24,9 @@ import static org.apache.rat.mp.RatTestHelpers.newArtifactRepository;
 import static org.apache.rat.mp.RatTestHelpers.newSiteRenderer;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.rat.ReportConfiguration;
@@ -254,4 +256,53 @@ public class RatCheckMojoTest extends BetterAbstractMojoTestCase {
             ensureRatReportIsCorrect(ratTxtFile, expected, TextUtils.EMPTY);
         }
     }
+
+    /**
+     * Tests verifying gitignore parsing under a special edge case condition
+     * The problem occurs when '/foo.md' is to be ignored and a file with that name exists
+     * in a directory which is the project base directory twice concatenated.
+     * So for this test we must create such a file which is specific for the current
+     * working directory.
+     */
+    public void testRAT362GitIgnore() throws Exception {
+        final RatCheckMojo mojo = newRatCheckMojo("RAT-362-GitIgnore");
+        final File ratTxtFile = getRatTxtFile(mojo);
+        final String dir = getDir(mojo);
+
+        // Make the target directory for the test file
+        File targetDirectory = new File(dir + dir);
+        if (!targetDirectory.exists()) {
+            assertTrue(targetDirectory.mkdirs());
+        }
+        assertTrue(targetDirectory.isDirectory());
+
+        // Create the test file with a content on which it must fail
+        File generatedFile = new File(targetDirectory + "/foo.md");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(generatedFile));
+        writer.write("File without a valid license\n");
+        writer.close();
+
+        final String[] expected = {
+                "Notes: 0",
+                "Binaries: 0",
+                "Archives: 0",
+                "Standards: 3$",
+                "Apache Licensed: 2$",
+                "Generated Documents: 0",
+                "^1 Unknown Licenses",
+                "^== File: \\Q" + generatedFile + "\\E$",
+        };
+        try {
+            mojo.execute();
+            fail("Expected RatCheckException: This check should have failed on the invalid test file");
+        } catch (RatCheckException e) {
+            final String msg = e.getMessage();
+            assertTrue("report filename was not contained in '" + msg + "'", msg.contains(ratTxtFile.getName()));
+            assertFalse("no null allowed in '" + msg + "'", (msg.toUpperCase().contains("NULL")));
+            ensureRatReportIsCorrect(ratTxtFile, expected, TextUtils.EMPTY);
+        }
+        // Cleanup
+        assertTrue(generatedFile.delete());
+    }
+
 }

--- a/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/.gitignore
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/.gitignore
@@ -1,0 +1,2 @@
+/foo.md
+target

--- a/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/foo.md
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/foo.md
@@ -1,0 +1,1 @@
+File without a valid license

--- a/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/invoker.properties
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/invoker.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals = clean apache-rat:check

--- a/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/pom.xml
+++ b/apache-rat-plugin/src/test/resources/unit/RAT-362-GitIgnore/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.rat.test</groupId>
-  <artifactId>RAT-335</artifactId>
+  <artifactId>RAT-362</artifactId>
   <version>1.0</version>
   <build>
     <plugins>


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/RAT-362