### PR TITLE
RAT-355, RAT-366: Fixed closed output issue

### DIFF
--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
@@ -223,7 +223,7 @@ public class Report extends Task {
     public void execute() {
         try {
             Reporter r = new Reporter(validate(getConfiguration()));
-            r.output(null, ()->System.out);
+            r.output(null, () -> new ReportConfiguration.NoCloseOutputStream(System.out));
             r.output();
         } catch (BuildException e) {
             throw e;


### PR DESCRIPTION
This fixes an issue detected in the build output where the tail end of the output disappears, though the build appears to work correctly.

The issue is that the ant report test manages to close System.out.  This change ensures that System.out does not get closed.
