### PR TITLE
RAT-377: Create a STANDARD process filter like the  ARCHIVE process switch in RAT-372

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/Defaults.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Defaults.java
@@ -68,6 +68,8 @@ public final class Defaults {
 
     public static final ReportConfiguration.Processing ARCHIVE_PROCESSING = ReportConfiguration.Processing.NOTIFICATION;
 
+    public static final ReportConfiguration.Processing STANDARD_PROCESSING = ReportConfiguration.Processing.ABSENCE;
+
     public static final LicenseFilter LIST_FAMILIES = LicenseFilter.NONE;
 
     public static final LicenseFilter LIST_LICENSES = LicenseFilter.NONE;

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -252,8 +252,17 @@ public class Report {
      * @since 0.17.0
      */
     static final Option ARCHIVE = Option.builder().longOpt("archive").hasArg().argName("ProcessingType")
-            .desc(format("Specifies the level of detail in ARCHIVE reporting. (default is %s)",
+            .desc(format("Specifies the level of detail in ARCHIVE file reporting. (default is %s)",
                     ReportConfiguration.Processing.NOTIFICATION))
+            .converter(s -> ReportConfiguration.Processing.valueOf(s.toUpperCase()))
+            .build();
+
+    /**
+     * Specify the processing of STANDARD files.
+     */
+    static final Option STANDARD = Option.builder().longOpt("standard").hasArg().argName("ProcessingType")
+            .desc(format("Specifies the level of detail in STANDARD file reporting.. (default is %s)",
+                    Defaults.STANDARD_PROCESSING))
             .converter(s -> ReportConfiguration.Processing.valueOf(s.toUpperCase()))
             .build();
 
@@ -367,6 +376,14 @@ public class Report {
             }
         }
 
+        if (cl.hasOption(STANDARD)) {
+            try {
+                configuration.setStandardProcessing(cl.getParsedOptionValue(STANDARD));
+            } catch (ParseException e) {
+                logParseException(e, STANDARD, cl, Defaults.STANDARD_PROCESSING);
+            }
+        }
+
         if (cl.hasOption(OUT)) {
             try {
                 configuration.setOut((File) cl.getParsedOptionValue(OUT));
@@ -411,7 +428,6 @@ public class Report {
                 }
 
                 URL url = Report.class.getClassLoader().getResource(String.format("org/apache/rat/%s.xsl", style[0]));
-
                 IOSupplier<InputStream> ioSupplier = (url == null) ?
                         () -> Files.newInputStream(Paths.get(style[0])) :
                         url::openStream;
@@ -470,6 +486,7 @@ public class Report {
     static Options buildOptions() {
         return new Options()
                 .addOption(ARCHIVE)
+                .addOption(STANDARD)
                 .addOption(DRY_RUN)
                 .addOption(LIST_FAMILIES)
                 .addOption(LIST_LICENSES)

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -261,7 +261,7 @@ public class Report {
      * Specify the processing of STANDARD files.
      */
     static final Option STANDARD = Option.builder().longOpt("standard").hasArg().argName("ProcessingType")
-            .desc(format("Specifies the level of detail in STANDARD file reporting.. (default is %s)",
+            .desc(format("Specifies the level of detail in STANDARD file reporting. (default is %s)",
                     Defaults.STANDARD_PROCESSING))
             .converter(s -> ReportConfiguration.Processing.valueOf(s.toUpperCase()))
             .build();

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -531,7 +531,7 @@ public class Report {
 
         String argumentPadding = createPadding(helpFormatter.getLeftPadding() + 5);
         for (Map.Entry<String, Supplier<String>> argInfo : ARGUMENT_TYPES.entrySet()) {
-            writer.format("\n<%s>\n", argInfo.getKey());
+            writer.format("%n<%s>%n", argInfo.getKey());
             helpFormatter.printWrapped(writer, helpFormatter.getWidth(), helpFormatter.getLeftPadding() + 10,
                     argumentPadding + argInfo.getValue().get());
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -58,7 +58,13 @@ import org.apache.rat.utils.ReportingSet;
  */
 public class ReportConfiguration {
 
-    public enum Processing {NOTIFICATION("List file as present"), PRESENCE("List any licenses found"), ABSENCE("List licenses found and any unknown licences");
+    public enum Processing {
+        /** List file as present only */
+        NOTIFICATION("List file as present"),
+        /** List all present licenses */
+        PRESENCE("List any licenses found"),
+        /** List all present licenses and unknown licenses */
+        ABSENCE("List licenses found and any unknown licences");
 
     private final String description;
     Processing(String description) {
@@ -86,7 +92,7 @@ public class ReportConfiguration {
     private LicenseFilter listLicenses;
     private boolean dryRun;
     private Processing archiveProcessing;
-   
+    private Processing standardProcessing;
     /**
      * Constructor
      * @param log The Log implementation that messages will be written to.
@@ -119,6 +125,22 @@ public class ReportConfiguration {
      */
     public void setArchiveProcessing(Processing archiveProcessing) {
         this.archiveProcessing = archiveProcessing;
+    }
+
+    /**
+     * Retrieves the archive processing type.
+     * @return The archive processing type.
+     */
+    public Processing getStandardProcessing() {
+        return standardProcessing == null ? Defaults.STANDARD_PROCESSING : standardProcessing;
+    }
+
+    /**
+     * Sets the archive processing type.  If not set will default to NOTIFICATION.
+     * @param standardProcessing the type of processing archives should have.
+     */
+    public void setStandardProcessing(Processing standardProcessing) {
+        this.standardProcessing = standardProcessing;
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
@@ -114,8 +114,6 @@ public class DefaultAnalyserFactory {
                 licensePredicate = licenseFilter(configuration.getArchiveProcessing());
                 if (configuration.getArchiveProcessing() != ReportConfiguration.Processing.NOTIFICATION) {
                     ArchiveWalker archiveWalker = new ArchiveWalker(configuration, document);
-                    Predicate<ILicense> filter = configuration.getArchiveProcessing() == ReportConfiguration.Processing.ABSENCE ?
-                            l -> Boolean.TRUE : lic -> !lic.getLicenseFamily().equals(UnknownLicense.INSTANCE.getLicenseFamily());
                     try {
                         for (Document doc : archiveWalker.getDocuments(configuration.getLog())) {
                             analyse(doc);

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/DefaultAnalyserFactory.java
@@ -79,7 +79,7 @@ public class DefaultAnalyserFactory {
         }
 
         /**
-         * Generates a predicateo to filter out licnses that should not be reported.
+         * Generates a predicate to filter out licenses that should not be reported.
          * @param proc the processing status to filter.
          * @return a Predicate to do the filtering.
          */
@@ -94,8 +94,8 @@ public class DefaultAnalyserFactory {
                         return false;
                 }
             };
-
         }
+
         @Override
         public void analyse(Document document) throws RatDocumentAnalysisException {
 

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
@@ -22,6 +22,8 @@ import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.ILicenseFamilyBuilder;
 
+import java.util.Objects;
+
 /**
  * An ILicense implementation that represents an unknown license.
  * <p>
@@ -29,7 +31,7 @@ import org.apache.rat.license.ILicenseFamilyBuilder;
  * license can not be determined.
  * </p>
  */
-public class UnknownLicense implements ILicense {
+public final class UnknownLicense implements ILicense {
 
     /**
      * The single instance of this class.
@@ -57,13 +59,18 @@ public class UnknownLicense implements ILicense {
     }
 
     @Override
-    public boolean matches(IHeaders headers) {
+    public boolean matches(final IHeaders headers) {
         return false;
     }
 
     @Override
-    public int compareTo(ILicense arg0) {
-        return getLicenseFamily().compareTo(arg0.getLicenseFamily());
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(ILicenseFamily.UNKNOWN_CATEGORY);
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SPDXMatcherFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SPDXMatcherFactory.java
@@ -55,11 +55,13 @@ public class SPDXMatcherFactory {
      */
     public static final SPDXMatcherFactory INSTANCE = new SPDXMatcherFactory();
 
+    static final String LICENSE_IDENTIFIER = "SPDX-License-Identifier:";
+
     /**
      * The regular expression to locate the SPDX license identifier in the text
      * stream
      */
-    private static Pattern groupSelector = Pattern.compile(".*SPDX-License-Identifier:\\s([A-Za-z0-9\\.\\-]+)");
+    private static Pattern groupSelector = Pattern.compile(".*"+LICENSE_IDENTIFIER+"\\s([A-Za-z0-9\\.\\-]+)");
 
     /**
      * The last matcer to match the line.
@@ -103,21 +105,20 @@ public class SPDXMatcherFactory {
      * @return true if the caller matches the text.
      */
     private boolean check(String line, Match caller) {
-        // if the line has not been seen yet see if we can extract the SPDX id from the
-        // line.
-        // if so then see if that name has been registered. If so then we have a match
-        // and set
-        // lastMatch.
+        /*
+        If the line has not been seen yet see if we can extract the SPDX id from the line.
+        If so then see for each match extract and add the name to lastMatch
+        */
         if (!checked) {
             checked = true;
-            if (line.contains("SPDX-License-Identifier")) {
+            if (line.contains(LICENSE_IDENTIFIER)) {
                 Matcher matcher = groupSelector.matcher(line);
                 while (matcher.find()) {
                     lastMatch.add(matcher.group(1));
                 }
             }
         }
-        // see if the caller matches lastMatch.
+        // see if the caller is in the lastMatch.
         return lastMatch.contains(caller.spdxId);
     }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/api/MetaData.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/api/MetaData.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.rat.license.ILicense;
@@ -154,6 +156,10 @@ public class MetaData {
      */
     public void reportOnLicense(ILicense license) {
         this.matchedLicenses.add(license);
+    }
+
+    public void removeLicenses(Predicate<ILicense> filter) {
+        this.matchedLicenses.removeIf(filter);
     }
     
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/MatcherBuilderTracker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/MatcherBuilderTracker.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.WordUtils;
 import org.apache.rat.ConfigurationException;
 import org.apache.rat.Defaults;
 import org.apache.rat.configuration.builders.AbstractBuilder;
@@ -34,7 +35,7 @@ import org.apache.rat.configuration.builders.AbstractBuilder;
  * A class to track the Matcher Builders as they are defined.  Matchers may be defined in multiple configuration files
  * this method tracks them so that they can be referenced across the configuration files.
  */
-public class MatcherBuilderTracker {
+public final class MatcherBuilderTracker {
 
     /** The instance of the BuildTracker. */
     public static MatcherBuilderTracker INSTANCE;
@@ -55,7 +56,7 @@ public class MatcherBuilderTracker {
      * @param className the Class name for the builder.
      * @param name the short name for the builder. 
      */
-    public static void addBuilder(String className, String name) {
+    public static void addBuilder(final String className, final String name) {
         instance().addBuilderImpl(className, name);
     }
 
@@ -64,7 +65,7 @@ public class MatcherBuilderTracker {
      * @param name The name of the builder.
      * @return the builder for that name.
      */
-    public static AbstractBuilder getMatcherBuilder(String name) {
+    public static AbstractBuilder getMatcherBuilder(final String name) {
         Class<? extends AbstractBuilder> clazz = instance().matcherBuilders.get(name);
         if (clazz == null) {
             StringBuilder sb = new StringBuilder(System.lineSeparator()).append("Valid builders").append(System.lineSeparator());
@@ -94,7 +95,7 @@ public class MatcherBuilderTracker {
         return Collections.unmodifiableCollection(matcherBuilders.values());
     }
 
-    private void addBuilderImpl(String className, String name) {
+    private void addBuilderImpl(final String className, String name) {
         Objects.requireNonNull(className, "className may not be null");
         Class<?> clazz;
         try {
@@ -116,7 +117,7 @@ public class MatcherBuilderTracker {
                     throw new ConfigurationException("Last segment of " + candidate.getName()
                             + " may not be 'Builder', but must end in 'Builder'");
                 }
-                name = name.replaceFirst(".", StringUtils.lowerCase(name.substring(0, 1)));
+                name = WordUtils.uncapitalize(name);
             }
             matcherBuilders.put(name, candidate);
         } else {

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/builders/ChildContainerBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/builders/ChildContainerBuilder.java
@@ -59,8 +59,8 @@ public abstract class ChildContainerBuilder extends AbstractBuilder {
      */
     public AbstractBuilder setResource(String resourceName) {
         URL url = this.getClass().getResource(resourceName);
-        try (final InputStream in = url.openStream()) {
-            BufferedReader buffer = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+        try (final InputStream in = url.openStream();
+             BufferedReader buffer = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));) {
             String txt;
             while (null != (txt = buffer.readLine())) {
                 txt = txt.trim();

--- a/apache-rat-core/src/main/java/org/apache/rat/license/ILicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/ILicense.java
@@ -19,8 +19,10 @@
 package org.apache.rat.license;
 
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.SortedSet;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.rat.analysis.IHeaderMatcher;
 
 /**
@@ -65,6 +67,34 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
      */
     IHeaderMatcher getMatcher();
 
+    @Override
+    default int compareTo(ILicense other) {
+        int result = getLicenseFamily().compareTo(other.getLicenseFamily());
+            return result == 0 ? getId().compareTo(other.getId()) : result;
+    }
+
+    /**
+     * A default implementatin of a License hash
+     * @param license the license to hash
+     * @return the license hash value
+     */
+    static int hash(ILicense license) {
+        return Objects.hash(license.getLicenseFamily(), license.getId());
+    }
+
+    /**
+     * A default implementation of equals.
+     * @param license1 The license to check for equality.
+     * @param o the object to check for equality to.
+     * @return true if the object is equal to the license1.
+     */
+    static boolean equals(ILicense license1, Object o) {
+        if (license1 == o) return true;
+        if (!(o instanceof ILicense)) return false;
+        ILicense that = (ILicense) o;
+        return license1.compareTo(that) == 0;
+    }
+
     /**
      * Gets a builder for licenses.
      * 
@@ -72,15 +102,6 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
      */
     static ILicense.Builder builder() {
         return new SimpleLicense.Builder();
-    }
-
-    /**
-     * Gets the comparator for comparing licenses.
-     * 
-     * @return The comparator for used for sorting Licenses.
-     */
-    static Comparator<ILicense> getComparator() {
-        return Comparator.comparing(IHeaderMatcher::getId);
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
@@ -20,6 +20,8 @@ package org.apache.rat.license;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -75,7 +77,8 @@ public class LicenseSetFactory {
      * @return An empty sorted set of ILicense objects.
      */
     public static SortedSet<ILicense> emptyLicenseSet() {
-        return new TreeSet<>(ILicense.getComparator());
+        //return new TreeSet<>((a,b) -> a.getLicenseFamily().compareTo(b.getLicenseFamily()));
+        return new TreeSet<>();
     }
 
     /**
@@ -161,8 +164,9 @@ public class LicenseSetFactory {
      * @param licenses the SortedSet of licenses to search.
      * @return the matching license or {@code null} if not found.
      */
-    public static ILicense search(String licenseId, SortedSet<ILicense> licenses) {
-        ILicenseFamily searchFamily = ILicenseFamily.builder().setLicenseFamilyCategory(licenseId)
+    public static Optional<ILicense> search(String familyId, String licenseId, SortedSet<ILicense> licenses) {
+       // return licenses.stream().filter( l -> l.getId().equals(licenseId)).findFirst();
+        ILicenseFamily searchFamily = ILicenseFamily.builder().setLicenseFamilyCategory(familyId)
                 .setLicenseFamilyName("searching proxy").build();
         ILicense target = new ILicense() {
 
@@ -182,8 +186,13 @@ public class LicenseSetFactory {
             }
 
             @Override
-            public int compareTo(ILicense arg0) {
-                return searchFamily.compareTo(arg0.getLicenseFamily());
+            public boolean equals(Object o) {
+                return ILicense.equals(this, o);
+            }
+
+            @Override
+            public int hashCode() {
+                return ILicense.hash(this);
             }
 
             @Override
@@ -212,13 +221,14 @@ public class LicenseSetFactory {
 
     /**
      * Search a SortedSet of licenses for the matching license.
+     * License must mach both family code, and license id.
      *
      * @param target the license to search for. Must not be null.
      * @param licenses the SortedSet of licenses to search.
      * @return the matching license or {@code null} if not found.
      */
-    public static ILicense search(ILicense target, SortedSet<ILicense> licenses) {
+    public static Optional<ILicense> search(ILicense target, SortedSet<ILicense> licenses) {
         SortedSet<ILicense> part = licenses.tailSet(target);
-        return (!part.isEmpty() && part.first().compareTo(target) == 0) ? part.first() : null;
+        return Optional.ofNullable((!part.isEmpty() && part.first().compareTo(target) == 0) ? part.first() : null);
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
@@ -77,7 +77,6 @@ public class LicenseSetFactory {
      * @return An empty sorted set of ILicense objects.
      */
     public static SortedSet<ILicense> emptyLicenseSet() {
-        //return new TreeSet<>((a,b) -> a.getLicenseFamily().compareTo(b.getLicenseFamily()));
         return new TreeSet<>();
     }
 
@@ -165,7 +164,6 @@ public class LicenseSetFactory {
      * @return the matching license or {@code null} if not found.
      */
     public static Optional<ILicense> search(String familyId, String licenseId, SortedSet<ILicense> licenses) {
-       // return licenses.stream().filter( l -> l.getId().equals(licenseId)).findFirst();
         ILicenseFamily searchFamily = ILicenseFamily.builder().setLicenseFamilyCategory(familyId)
                 .setLicenseFamilyName("searching proxy").build();
         ILicense target = new ILicense() {

--- a/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicense.java
@@ -97,8 +97,13 @@ public class SimpleLicense implements ILicense {
     }
 
     @Override
-    public int compareTo(ILicense other) {
-        return ILicense.getComparator().compare(this, other);
+    public boolean equals(Object o) {
+        return ILicense.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return ILicense.hash(this);
     }
 
     @Override

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
@@ -57,6 +57,7 @@ import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.report.IReportable;
 import org.apache.rat.testhelpers.TestingLicense;
+import org.apache.rat.testhelpers.TestingMatcher;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log;
 import org.apache.rat.utils.Log.Level;
@@ -157,7 +158,7 @@ public class ReportConfigurationTest {
     private ILicense testingLicense(String category, String name) {
         ILicenseFamily family = ILicenseFamily.builder().setLicenseFamilyCategory(category).setLicenseFamilyName(name)
                 .build();
-        return new TestingLicense( family );
+        return new TestingLicense( category, new TestingMatcher(), family );
     }
 
     @Test

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.SortedSet;
 
 import org.apache.commons.cli.CommandLine;
@@ -133,11 +134,12 @@ public class ReportTest {
 
     @Test
     public void LicensesOptionTest() throws Exception {
-        CommandLine cl = new DefaultParser().parse(Report.buildOptions(), new String[] {"-licenses", "target/test-classes/report/LicenseOne.xml"});
+        CommandLine cl = new DefaultParser().parse(Report.buildOptions(), new String[]{"-licenses", "target/test-classes/report/LicenseOne.xml"});
         ReportConfiguration config = Report.createConfiguration("", cl);
         SortedSet<ILicense> set = config.getLicenses(LicenseSetFactory.LicenseFilter.ALL);
-        ILicense found = LicenseSetFactory.search("LiOne", set);
-        assertNotNull(found);
+        assertTrue(LicenseSetFactory.search("LiOne", "LiOne", set).isPresent());
+        assertFalse(LicenseSetFactory.search("LiOne", "LiTwo", set).isPresent(),"LiOne/LiTwo");
+        assertFalse(LicenseSetFactory.search("LiTwo", "LiTwo", set).isPresent(), "LiTwo");
     }
 
     @Test
@@ -146,7 +148,8 @@ public class ReportTest {
         ReportConfiguration config = Report.createConfiguration("", cl);
         SortedSet<ILicense> set = config.getLicenses(LicenseSetFactory.LicenseFilter.ALL);
         assertEquals(2, set.size());
-        assertNotNull(LicenseSetFactory.search("LiOne", set), "LiOne");
-        assertNotNull(LicenseSetFactory.search("LiTwo", set), "LiTwo");
+        assertTrue(LicenseSetFactory.search("LiOne", "LiOne", set).isPresent(), "LiOne");
+        assertFalse(LicenseSetFactory.search("LiOne", "LiTwo", set).isPresent(), "LiOne/LiTwo");
+        assertTrue(LicenseSetFactory.search("LiTwo", "LiTwo", set).isPresent(), "LiTwo");
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/DefaultAnalyserFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/DefaultAnalyserFactoryTest.java
@@ -19,6 +19,7 @@
 package org.apache.rat.analysis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringWriter;
@@ -153,7 +154,7 @@ public class DefaultAnalyserFactoryTest {
     }
 
     @Test
-    public void archiveTypeAnalyserIntelliJ() throws Exception {
+    public void archiveTypeAnalyser() throws Exception {
         final Document document = new FileDocument(
                 Resources.getResourceFile("/elements/dummy.jar"));
         analyser.analyse(document);
@@ -212,4 +213,67 @@ public class DefaultAnalyserFactoryTest {
         TextUtils.assertPatternInTarget("^sentence 3.$", result);
         TextUtils.assertPatternInTarget("^sentence 4.$", result);
     }
+
+    @Test
+    public void standardNotificationTest() throws Exception {
+
+        Defaults defaults = Defaults.builder().build(DefaultLog.INSTANCE);
+        ReportConfiguration config = new ReportConfiguration(DefaultLog.INSTANCE);
+        config.setFrom(defaults);
+        config.setFilesToIgnore(FalseFileFilter.FALSE);
+        config.setStandardProcessing(ReportConfiguration.Processing.NOTIFICATION);
+        analyser = DefaultAnalyserFactory.createDefaultAnalyser(config);
+
+        Document document = new FileDocument(
+                Resources.getResourceFile("/elements/Text.txt"));
+        analyser.analyse(document);
+        assertFalse(document.getMetaData().detectedLicense());
+
+        document = new FileDocument(
+                Resources.getResourceFile("/elements/sub/Empty.txt"));
+        analyser.analyse(document);
+        assertFalse(document.getMetaData().detectedLicense());
+    }
+
+    @Test
+    public void standardAbsenceTest() throws Exception {
+
+        Defaults defaults = Defaults.builder().build(DefaultLog.INSTANCE);
+        ReportConfiguration config = new ReportConfiguration(DefaultLog.INSTANCE);
+        config.setFrom(defaults);
+        config.setFilesToIgnore(FalseFileFilter.FALSE);
+        config.setStandardProcessing(ReportConfiguration.Processing.ABSENCE);
+        analyser = DefaultAnalyserFactory.createDefaultAnalyser(config);
+
+        Document document = new FileDocument(
+                Resources.getResourceFile("/elements/Text.txt"));
+        analyser.analyse(document);
+        assertTrue(document.getMetaData().detectedLicense());
+
+        document = new FileDocument(
+                Resources.getResourceFile("/elements/sub/Empty.txt"));
+        analyser.analyse(document);
+        assertTrue(document.getMetaData().detectedLicense());
+    }
+
+    @Test
+    public void standardPresenceTest() throws Exception {
+        Defaults defaults = Defaults.builder().build(DefaultLog.INSTANCE);
+        ReportConfiguration config = new ReportConfiguration(DefaultLog.INSTANCE);
+        config.setFrom(defaults);
+        config.setFilesToIgnore(FalseFileFilter.FALSE);
+        config.setStandardProcessing(ReportConfiguration.Processing.PRESENCE);
+        analyser = DefaultAnalyserFactory.createDefaultAnalyser(config);
+
+        Document document = new FileDocument(
+                Resources.getResourceFile("/elements/Text.txt"));
+        analyser.analyse(document);
+        assertTrue(document.getMetaData().detectedLicense());
+
+        document = new FileDocument(
+                Resources.getResourceFile("/elements/sub/Empty.txt"));
+        analyser.analyse(document);
+        assertFalse(document.getMetaData().detectedLicense());
+    }
+
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/HeaderCheckWorkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/HeaderCheckWorkerTest.java
@@ -34,7 +34,7 @@ public class HeaderCheckWorkerTest {
     @Test
     public void isFinished() throws Exception {
         final Document subject = new TestingDocument("subject");
-        ILicense matcher = new TestingLicense();
+        ILicense matcher = new TestingLicense("test", "test");
         HeaderCheckWorker worker = new HeaderCheckWorker(new StringReader(""), Arrays.asList(matcher), subject);
         worker.read();
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/license/AbstractLicenseTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/license/AbstractLicenseTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Optional;
 
 import org.apache.rat.Defaults;
 import org.apache.rat.analysis.HeaderCheckWorker;
@@ -59,21 +60,19 @@ abstract public class AbstractLicenseTest {
         defaults = Defaults.builder().build(DefaultLog.INSTANCE);
     }
 
-    protected ILicense extractCategory(String id) {
-        TestingLicense testingLicense = new TestingLicense();
-        testingLicense.setId(id);
-        ILicense result = LicenseSetFactory.search(testingLicense, defaults.getLicenses(LicenseFilter.ALL));
-        if (result == null) {
-            fail("No licenses for id: " + id);
+    protected ILicense extractCategory(String famId, String id) {
+        Optional<ILicense> result = LicenseSetFactory.search(famId, id, defaults.getLicenses(LicenseFilter.ALL));
+        if (!result.isPresent()) {
+            fail(String.format("No licenses for id: f:%s l:%s", famId, id));
         }
-        return result;
+        return result.get();
     }
 
     @ParameterizedTest
     @MethodSource("parameterProvider")
     public void testMatchProcessing(String id, String familyPattern, String name, String notes, String[][] targets)
             throws IOException {
-        ILicense license = extractCategory(id);
+        ILicense license = extractCategory(familyPattern, id);
         try {
             for (String[] target : targets) {
                 if (processText(license, target[TEXT])) {
@@ -105,7 +104,7 @@ abstract public class AbstractLicenseTest {
         String formats[] = { "%s", "now is not the time %s for copyright", "#%s", "##%s", "## %s", "##%s##", "## %s ##",
                 "/*%s*/", "/* %s */" };
 
-        ILicense license = extractCategory(id);
+        ILicense license = extractCategory(family, id);
         try {
             for (String[] target : targets) {
                 for (String fmt : formats) {

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
@@ -40,8 +40,8 @@ public class SPDXMatcherTest {
     @Test
     public void testMatch() {
         StringBuilder sb = new StringBuilder()
-                .append("SPDX-License-Identifier: world").append(System.lineSeparator())
-                .append("SPDX-License-Identifier: hello").append(System.lineSeparator());
+                .append(SPDXMatcherFactory.LICENSE_IDENTIFIER).append(" world").append(System.lineSeparator())
+                .append(SPDXMatcherFactory.LICENSE_IDENTIFIER).append(" hello").append(System.lineSeparator());
 
         IHeaders headers =  AbstractMatcherTest.makeHeaders(sb.toString(),null);
 

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/matchers/SPDXMatcherTest.java
@@ -22,22 +22,32 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.rat.analysis.IHeaderMatcher;
+import org.apache.rat.analysis.IHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class SPDXMatcherTest {
 
-    IHeaderMatcher target = SPDXMatcherFactory.INSTANCE.create("hello");
+    IHeaderMatcher target1 = SPDXMatcherFactory.INSTANCE.create("hello");
+    IHeaderMatcher target2 = SPDXMatcherFactory.INSTANCE.create("world");
+    IHeaderMatcher target3 = SPDXMatcherFactory.INSTANCE.create("goodbye");
 
     @BeforeEach
     public void setup() {
-        target.reset();
+        target1.reset();
     }
 
     @Test
     public void testMatch() {
-        assertFalse(target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: Apache-2", null)));
-        assertTrue(target.matches(AbstractMatcherTest.makeHeaders("SPDX-License-Identifier: hello", null)));
-        target.reset();
+        StringBuilder sb = new StringBuilder()
+                .append("SPDX-License-Identifier: world").append(System.lineSeparator())
+                .append("SPDX-License-Identifier: hello").append(System.lineSeparator());
+
+        IHeaders headers =  AbstractMatcherTest.makeHeaders(sb.toString(),null);
+
+        assertTrue(target1.matches(headers));
+        assertTrue(target2.matches(headers));
+        assertFalse(target3.matches(headers));
+        target1.reset();
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/configuration/XMLConfigurationReaderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/configuration/XMLConfigurationReaderTest.java
@@ -47,8 +47,8 @@ public class XMLConfigurationReaderTest {
     public static final String[] EXPECTED_IDS = { "AL", "BSD-3", "CDDL1", "GEN", "GPL1", "GPL2", "GPL3", "MIT", "OASIS",
             "W3C", "W3CD" };
 
-    public static final String[] EXPECTED_LICENSES = { "AL", "ASL", "BSD-3", "CDDL1", "DOJO", "GEN", "GPL1", "GPL2",
-            "GPL3", "ILLUMOS", "MIT", "OASIS", "TMF", "W3C", "W3CD" };
+    public static final String[] EXPECTED_LICENSES = { "AL", "ASL", "BSD-3", "DOJO", "TMF", "CDDL1", "ILLUMOS", "GEN", "GPL1", "GPL2",
+            "GPL3", "MIT", "OASIS", "W3C", "W3CD" };
 
     @Test
     public void approvedLicenseIdTest() {

--- a/apache-rat-core/src/test/java/org/apache/rat/license/SimpleLicenseTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/license/SimpleLicenseTest.java
@@ -62,4 +62,6 @@ public class SimpleLicenseTest {
         assertEquals(ComponentType.MATCHER, matcherDesc.getType());
         assertEquals("TestingMatcher", matcherDesc.getCommonName());
     }
+
+
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/policy/DefaultPolicyTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/policy/DefaultPolicyTest.java
@@ -31,6 +31,7 @@ import org.apache.rat.license.LicenseFamilySetFactory;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.testhelpers.TestingLicense;
 import org.apache.rat.testhelpers.TestingDocument;
+import org.apache.rat.testhelpers.TestingMatcher;
 import org.apache.rat.utils.DefaultLog;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +72,7 @@ public class DefaultPolicyTest {
     }
 
     private void setMetadata(ILicenseFamily family) {
-        document.getMetaData().reportOnLicense(new TestingLicense(family));
+        document.getMetaData().reportOnLicense(new TestingLicense(family.getFamilyCategory().trim(), new TestingMatcher(), family));
     }
 
     private static ILicenseFamily makeFamily(String category, String name) {

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -73,7 +73,7 @@ public class XmlReportFactoryTest {
     public void standardReport() throws Exception {
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
         final ReportConfiguration configuration = new ReportConfiguration(DefaultLog.INSTANCE);
-        final TestingLicense testingLicense = new TestingLicense(new TestingMatcher(true), family);
+        final TestingLicense testingLicense = new TestingLicense("TEST", new TestingMatcher(true), family);
         configuration.setFrom(Defaults.builder().build(DefaultLog.INSTANCE));
         configuration.setDirectoriesToIgnore(HiddenFileFilter.HIDDEN);
         DirectoryWalker directory = new DirectoryWalker(configuration, new FileDocument(new File(elementsPath)));

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TestingLicense.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TestingLicense.java
@@ -24,6 +24,8 @@ import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 
+import java.util.Objects;
+
 /**
  * A class to quickly build testing licenses.
  */
@@ -33,16 +35,7 @@ public class TestingLicense implements ILicense {
     private IHeaderMatcher matcher;
     private String note;
     private String name;
-    private String id;
-
-    /**
-     * Creates a testing license named "DfltTst" with category of "DfltT" and a
-     * default TestingMatcher.
-     * @see TestingMatcher
-     */
-    public TestingLicense() {
-        this("DfltTst", new TestingMatcher());
-    }
+    private final String id;
 
     /**
      * Creates a testing license with the specified id and a default TestingMatcher
@@ -50,7 +43,17 @@ public class TestingLicense implements ILicense {
      * @see TestingMatcher
      */
     public TestingLicense(String id) {
-        this(id, new TestingMatcher());
+        this(id, id, new TestingMatcher());
+    }
+
+    /**
+     * Creates a testing license with the specified id and a default TestingMatcher
+     * @param family the Fmaily id
+     * @param id The ID to use.
+     * @see TestingMatcher
+     */
+    public TestingLicense(String family, String id) {
+        this(family, id, new TestingMatcher());
     }
 
     /**
@@ -58,35 +61,22 @@ public class TestingLicense implements ILicense {
      * @param id the ID to use
      * @param matcher the matcher to execute.
      */
-    public TestingLicense(String id, IHeaderMatcher matcher) {
-        this(matcher, ILicenseFamily.builder().setLicenseFamilyCategory(id)
-                .setLicenseFamilyName("TestingLicense: " + id).build());
+    public TestingLicense(String family, String id, IHeaderMatcher matcher) {
+        this(id, matcher, ILicenseFamily.builder().setLicenseFamilyCategory(family)
+                .setLicenseFamilyName("TestingLicense: " + family).build());
     }
 
     /**
      * Creates a testing license with the specified matcher and family.
+     * @param id the license id
      * @param matcher the matcher to use.
      * @param family the family for this license.
      */
-    public TestingLicense(IHeaderMatcher matcher, ILicenseFamily family) {
+    public TestingLicense(String id, IHeaderMatcher matcher, ILicenseFamily family) {
         this.family = family;
         this.matcher = matcher;
         this.note = null;
-    }
-
-    /**
-     * Create a testing license for the specified family using a default
-     * TestingMatcher
-     * @param family the family for the license.
-     * @see TestingMatcher
-     */
-    public TestingLicense(ILicenseFamily family) {
-        this(new TestingMatcher(), family);
-    }
-
-    @Override
-    public String toString() {
-        return family.toString();
+        this.id = id;
     }
 
     /**
@@ -114,13 +104,9 @@ public class TestingLicense implements ILicense {
         this.name = name;
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
-
     @Override
     public String getId() {
-        return StringUtils.defaultIfBlank(id, family.getFamilyCategory().trim());
+        return id;
     }
 
     @Override
@@ -139,11 +125,6 @@ public class TestingLicense implements ILicense {
     }
 
     @Override
-    public int compareTo(ILicense other) {
-        return ILicense.getComparator().compare(this, other);
-    }
-
-    @Override
     public String getNote() {
         return note;
     }
@@ -151,5 +132,15 @@ public class TestingLicense implements ILicense {
     @Override
     public String getName() {
         return StringUtils.defaultIfBlank(name, family.getFamilyName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return ILicense.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return ILicense.hash(this);
     }
 }

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
@@ -200,7 +200,7 @@ public class RatCheckMojoTest extends BetterAbstractMojoTestCase {
         assertNotNull(LicenseFamilySetFactory.search("YAL", config.getLicenseFamilies(LicenseFilter.ALL)));
         ReportConfigurationTest.validateDefaultLicenses(config, "MyLicense", "CpyrT", "RegxT", "SpdxT", "TextT", 
                 "Not", "All", "Any");
-        assertNotNull(LicenseSetFactory.search("MyLicense", config.getLicenses(LicenseFilter.ALL)));
+        assertTrue(LicenseSetFactory.search("YAL", "MyLicense", config.getLicenses(LicenseFilter.ALL)).isPresent());
         assertNotNull("Should have filesToIgnore", config.getFilesToIgnore());
         assertThat(config.getFilesToIgnore()).isExactlyInstanceOf(FalseFileFilter.class);
         assertNotNull("Should have directoriesToIgnore", config.getDirectoriesToIgnore());

--- a/apache-rat/src/site/apt/index.apt.vm
+++ b/apache-rat/src/site/apt/index.apt.vm
@@ -104,7 +104,7 @@ usage: java -jar apache-rat/target/apache-rat-${project.version}.jar [options] [
                                       external xsl file may be specified or one of the internal named sheets: plain-rat (default),
                                       missing-headers, or unapproved-licenses
     --scan-hidden-directories         Scan hidden directories
-    --standard <ProcessingType>       Specifies the level of detail in STANDARD file reporting.. (default is ABSENCE)
+    --standard <ProcessingType>       Specifies the level of detail in STANDARD file reporting. (default is ABSENCE)
  -x,--xml                             Output the report in raw XML format.  Not compatible with -s
 
 ====== Argument Types ======

--- a/apache-rat/src/site/apt/index.apt.vm
+++ b/apache-rat/src/site/apt/index.apt.vm
@@ -75,9 +75,7 @@ java -jar apache-rat/target/apache-rat-${project.version}.jar
 
 
 +------------------------------------------+
-usage: java -jar apache-rat/target/apache-rat-${project.version}.jar
-            [options] [DIR|TARBALL]
-
+usage: java -jar apache-rat/target/apache-rat-${project.version}.jar [options] [DIR|TARBALL]
 
 ====== Available Options ======
  -a                                   (deprecated) Add the default license header to any file with an unknown license.  Use '-A'
@@ -85,7 +83,7 @@ usage: java -jar apache-rat/target/apache-rat-${project.version}.jar
  -A,--addLicense                      Add the default license header to any file with an unknown license that is not in the
                                       exclusion list. By default new files will be created with the license header, to force the
                                       modification of existing files use the --force option.
-    --archive <ProcessingType>        Specifies the level of detail in ARCHIVE reporting. (default is NOTIFICATION)
+    --archive <ProcessingType>        Specifies the level of detail in ARCHIVE file reporting. (default is NOTIFICATION)
  -c,--copyright <arg>                 The copyright message to use in the license headers, usually in the form of "Copyright 2008
                                       Foo"
  -d,--dir <DirOrArchive>              (deprecated, use '--') Used to indicate source when using --exclude.
@@ -106,6 +104,7 @@ usage: java -jar apache-rat/target/apache-rat-${project.version}.jar
                                       external xsl file may be specified or one of the internal named sheets: plain-rat (default),
                                       missing-headers, or unapproved-licenses
     --scan-hidden-directories         Scan hidden directories
+    --standard <ProcessingType>       Specifies the level of detail in STANDARD file reporting.. (default is ABSENCE)
  -x,--xml                             Output the report in raw XML format.  Not compatible with -s
 
 ====== Argument Types ======
@@ -143,6 +142,7 @@ usage: java -jar apache-rat/target/apache-rat-${project.version}.jar
 2. Rat reports require interpretation.
 3. Rat often requires some tuning before it runs well against a project.
 4. Rat relies on heuristics: it may miss issues
+
 
 +------------------------------------------+
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,15 @@ https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd
     </release>
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-377" type="add" dev="claudenw">
+        Added ability to specify the leverl of reporting on STANDARD files within a project.  This necessitated an addition
+        of a command line option "standard" to limit specify the level of detail in the STANDARD file reporting.  See command line
+        help for more details.  By default, there is no change in the reporting and only the presence of archives are reported.
+      </action>
+      <action issue="RAT-190" type="fix" dev="claudenw">
+        Javascript (.js) files not processed as text.
+        Fixed as part of the Tika change.
+      </action>
       <action issue="RAT-372" type="add" dev="claudenw">
         Added ability to process archive files within a project to look for license files.  This necessitated an addition
         of a command line option "archive" to limit specify the level of detail in the archive report.  See command line

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -73,7 +73,7 @@ https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
       <action issue="RAT-377" type="add" dev="claudenw">
-        Added ability to specify the leverl of reporting on STANDARD files within a project.  This necessitated an addition
+        Added ability to specify the level of reporting on STANDARD files within a project.  This necessitated an addition
         of a command line option "standard" to limit specify the level of detail in the STANDARD file reporting.  See command line
         help for more details.  By default, there is no change in the reporting and only the presence of archives are reported.
       </action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -76,6 +76,9 @@ https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd
         Added ability to specify the level of reporting on STANDARD files within a project.  This necessitated an addition
         of a command line option "standard" to limit specify the level of detail in the STANDARD file reporting.  See command line
         help for more details.  By default, there is no change in the reporting and only the presence of archives are reported.
+
+        Change also fixed a major issue in license sorting.  Resulting in a change in order and expanding the name space for licenses.
+        Licenses now must have a unique id within the family name space. (e.g. family1/one is different from family2/one).
       </action>
       <action issue="RAT-190" type="fix" dev="claudenw">
         Javascript (.js) files not processed as text.


### PR DESCRIPTION
Fixes RAT-377

This change is dependent upon RAT-372 and should not be considered for merged until after that change has been accepted.

The solution for process archive files (RAT-372) introduces a command line switch to change from just reporting the presence of archive files to reporting what licenses they contain or reporting licenses contains as well as missing licenses.

This request is for a similar change in STANDARD reporting.

The use case is for non-ASF projects that don't require a license header in every file but do require licensing to be declared within the project.

Using `--standard PRESENCE`  would cause Rat to list all the declared licenses in the scan, without the overhead noise of 'missing license headers'