### PR TITLE
RAT-369: Let the build fail in case of new violations/spotbugs errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,8 @@ agnostic home for software distribution comprehension and audit tools.
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.8.5.0</version>
           <configuration>
-            <maxAllowedViolations>63</maxAllowedViolations>
+            <!-- RAT-369: JDK21 finds 67 errors, while older releases find 63 -->
+            <maxAllowedViolations>67</maxAllowedViolations>
             <failOnError>true</failOnError>
             <!-- we only want to see our own problems and in all subpackages -->
             <onlyAnalyze>org.apache.rat.-</onlyAnalyze>

--- a/pom.xml
+++ b/pom.xml
@@ -320,8 +320,8 @@ agnostic home for software distribution comprehension and audit tools.
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.8.5.0</version>
           <configuration>
-            <!-- RAT-369: as spotbugs does not allow setting a global (numeric) threshold of currently accepted errors/bugs we do not fail the build -->
-            <failOnError>false</failOnError>
+            <maxAllowedViolations>63</maxAllowedViolations>
+            <failOnError>true</failOnError>
             <!-- we only want to see our own problems and in all subpackages -->
             <onlyAnalyze>org.apache.rat.-</onlyAnalyze>
             <!-- in order to have a global spotbugs configuration an exclusion file needs to exist in all submodules -->

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -85,8 +85,8 @@ https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd
       <action issue="RAT-314" type="add" dev="pottlinger">
         Add integration test for new default exclude .mvn, that was introduced with v0.16.
       </action>
-      <action issue="RAT-366" type="add" dev="pottlinger">
-        Integrate checkstyle and spotbugs into the build and webpage generation. Most charset-related errors cannot be fixed until we break JDK8-compliance and move to newer versions.
+      <action issue="RAT-369" type="add" dev="pottlinger">
+        Integrate checkstyle and spotbugs into the build and webpage generation. Most charset-related errors cannot be fixed until we break JDK8-compliance and move to newer versions. Configured a maximum of allowed bugs to fail the build if new errors are introduced.
       </action>
       <action issue="RAT-301" type="fix" dev="pottlinger" due-to="claudenw">
         Chinese characters in comments are not classified as binary anymore (due to Tika integration).


### PR DESCRIPTION
@Claudenw I was unable to read the docs properly - there is a solution that I`ve added that lets the build fail if new errors are added. At the moment there are 63 open issues within RAT.

Feel free to hit the merge button if that is fine with you.