### PR TITLE
RAT-394: fix to make all code use DefaultLog (Harmonize - Part 4)

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/Defaults.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Defaults.java
@@ -40,7 +40,6 @@ import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.utils.DefaultLog;
-import org.apache.rat.utils.Log;
 import org.apache.rat.walker.NameBasedHiddenFileFilter;
 
 /**
@@ -101,11 +100,10 @@ public final class Defaults {
 
     /**
      * Builder constructs instances.
-     * @param log The log to write messages to.
      * @param uris The set of URIs to read.
      */
-    private Defaults(final Log log, final Set<URI> uris) {
-        this.setFactory = Defaults.readConfigFiles(log, uris);
+    private Defaults(final Set<URI> uris) {
+        this.setFactory = Defaults.readConfigFiles(uris);
     }
 
     /**
@@ -118,10 +116,9 @@ public final class Defaults {
 
     /**
      * Reads the configuration files.
-     * @param log The log to write messages to.
      * @param uris the URIs to read.
      */
-    private static LicenseSetFactory readConfigFiles(final Log log, final Collection<URI> uris) {
+    private static LicenseSetFactory readConfigFiles(final Collection<URI> uris) {
 
         SortedSet<ILicense> licenses = new TreeSet<>();
 
@@ -137,7 +134,6 @@ public final class Defaults {
 
             LicenseReader lReader = fmt.licenseReader();
             if (lReader != null) {
-                lReader.setLog(log);
                 lReader.addLicenses(uri);
                 licenses.addAll(lReader.readLicenses());
                 lReader.approvedLicenseId().stream().map(ILicenseFamily::makeCategory).forEach(approvedLicenseCategories::add);
@@ -242,11 +238,10 @@ public final class Defaults {
 
         /**
          * Builds the defaults object.
-         * @param log the Log to use to report errors when building the defaults.
          * @return the current defaults object.
          */
-        public Defaults build(final Log log) {
-            return new Defaults(log, fileNames);
+        public Defaults build() {
+            return new Defaults(fileNames);
         }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/DeprecationReporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/DeprecationReporter.java
@@ -41,6 +41,10 @@ public final class DeprecationReporter {
      * Deprecated Command line option consumer.
      */
 
+    /**
+     * Creates the consumer that will log usage of deprecated operations to the default log.
+     * @return The consumer that will log usage of deprecated operations to the default log.
+     */
     public static Consumer<Option> getLogReporter() {
         return  o -> {
             StringBuilder buff = new StringBuilder();

--- a/apache-rat-core/src/main/java/org/apache/rat/DeprecationReporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/DeprecationReporter.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 
 import org.apache.commons.cli.Option;
 import org.apache.rat.utils.DefaultLog;
-import org.apache.rat.utils.Log;
 
 /**
  * Reporting methods for deprecated objects.
@@ -42,7 +41,7 @@ public final class DeprecationReporter {
      * Deprecated Command line option consumer.
      */
 
-    public static Consumer<Option> getLogReporter(final Log log) {
+    public static Consumer<Option> getLogReporter() {
         return  o -> {
             StringBuilder buff = new StringBuilder();
             if (o.getOpt() != null) {
@@ -53,7 +52,7 @@ public final class DeprecationReporter {
             } else {
                 buff.append("--").append(o.getLongOpt());
             }
-            log.warn(format("Option [%s] used.  %s", buff, o.getDeprecated().toString()));
+            DefaultLog.getInstance().warn(format("Option [%s] used.  %s", buff, o.getDeprecated().toString()));
         };
     }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -62,7 +62,7 @@ public final class OptionCollection {
         // do not instantiate
     }
 
-    public static final  Comparator<Option> optionComparator = new OptionComparator();
+    public static final Comparator<Option> optionComparator = new OptionComparator();
 
     /**
      * Produce help

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -62,6 +62,8 @@ public final class OptionCollection {
         // do not instantiate
     }
 
+    public static final  Comparator<Option> optionComparator = new OptionComparator();
+
     /**
      * Produce help
      */
@@ -223,7 +225,7 @@ public final class OptionCollection {
     /**
      * This class implements the {@code Comparator} interface for comparing Options.
      */
-    public static class OptionComparator implements Comparator<Option>, Serializable {
+    private static class OptionComparator implements Comparator<Option>, Serializable {
         /** The serial version UID.  */
         private static final long serialVersionUID = 5305467873966684014L;
 

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -48,7 +48,7 @@ import org.apache.rat.document.impl.FileDocument;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.report.IReportable;
 import org.apache.rat.utils.DefaultLog;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.Log.Level;
 import org.apache.rat.walker.ArchiveWalker;
 import org.apache.rat.walker.DirectoryWalker;
 
@@ -78,7 +78,7 @@ public final class OptionCollection {
         ARGUMENT_TYPES.put("Expression", () -> "A wildcard file matching pattern. example: *-test-*.txt");
         ARGUMENT_TYPES.put("LicenseFilter", () -> format("A defined filter for the licenses to include. Valid values: %s.",
                 asString(LicenseSetFactory.LicenseFilter.values())));
-        ARGUMENT_TYPES.put("LogLevel", () -> format("The log level to use. Valid values %s.", asString(Log.Level.values())));
+        ARGUMENT_TYPES.put("LogLevel", () -> format("The log level to use. Valid values %s.", asString(Level.values())));
         ARGUMENT_TYPES.put("ProcessingType", () -> format("Specifies how to process file types. Valid values are: %s",
                 Arrays.stream(ReportConfiguration.Processing.values())
                         .map(v -> format("\t%s: %s", v.name(), v.desc()))
@@ -132,19 +132,18 @@ public final class OptionCollection {
     public static ReportConfiguration parseCommands(final String[] args, final Consumer<Options> helpCmd, final boolean noArgs) throws IOException {
         Options opts = buildOptions();
         CommandLine commandLine;
-        Log log = DefaultLog.getInstance();
         try {
-            commandLine = DefaultParser.builder().setDeprecatedHandler(DeprecationReporter.getLogReporter(log))
+            commandLine = DefaultParser.builder().setDeprecatedHandler(DeprecationReporter.getLogReporter())
                     .setAllowPartialMatching(true).build().parse(opts, args);
         } catch (ParseException e) {
-            log.error(e.getMessage());
-            log.error("Please use the \"--help\" option to see a list of valid commands and options", e);
+            DefaultLog.getInstance().error(e.getMessage());
+            DefaultLog.getInstance().error("Please use the \"--help\" option to see a list of valid commands and options", e);
             System.exit(1);
             return null; // dummy return (won't be reached) to avoid Eclipse complaint about possible NPE
             // for "commandLine"
         }
 
-        Arg.processLogLevel(commandLine, log);
+        Arg.processLogLevel(commandLine);
 
         if (commandLine.hasOption(HELP)) {
             helpCmd.accept(opts);
@@ -166,13 +165,12 @@ public final class OptionCollection {
         if (!lst.isEmpty()) {
             clArgs[0] = lst.get(0);
         }
-        return createConfiguration(log, clArgs[0], commandLine);
+        return createConfiguration(clArgs[0], commandLine);
     }
 
     /**
      * Create the report configuration.
      * Note: this method is package private for testing. You probably want one of the {@code ParseCommands} methods.
-     * @param log The log to log errors to.
      * @param baseDirectory the base directory where files will be found.
      * @param cl the parsed command line.
      * @return a ReportConfiguration
@@ -180,8 +178,8 @@ public final class OptionCollection {
      * @see #parseCommands(String[], Consumer)
      * @see #parseCommands(String[], Consumer, boolean)
      */
-    static ReportConfiguration createConfiguration(final Log log, final String baseDirectory, final CommandLine cl) throws IOException {
-        final ReportConfiguration configuration = new ReportConfiguration(log);
+    static ReportConfiguration createConfiguration(final String baseDirectory, final CommandLine cl) throws IOException {
+        final ReportConfiguration configuration = new ReportConfiguration();
         new ArgumentContext(configuration, cl).processArgs();
         if (StringUtils.isNotBlank(baseDirectory)) {
             configuration.setReportable(getDirectory(baseDirectory, configuration));
@@ -210,7 +208,7 @@ public final class OptionCollection {
         File base = new File(baseDirectory);
 
         if (!base.exists()) {
-            config.getLog().log(Log.Level.ERROR, "Directory '" + baseDirectory + "' does not exist");
+            DefaultLog.getInstance().error( "Directory '" + baseDirectory + "' does not exist");
             return null;
         }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/Report.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Report.java
@@ -113,7 +113,7 @@ public final class Report {
     static void printUsage(final PrintWriter writer, final Options opts) {
         HelpFormatter helpFormatter = new HelpFormatter.Builder().setShowDeprecated(DEPRECATED_MSG).get();
         helpFormatter.setWidth(HELP_WIDTH);
-        helpFormatter.setOptionComparator(new OptionCollection.OptionComparator());
+        helpFormatter.setOptionComparator(OptionCollection.optionComparator);
         VersionInfo versionInfo = new VersionInfo();
         String syntax = format("java -jar apache-rat/target/apache-rat-%s.jar [options] [DIR|ARCHIVE]", versionInfo.getVersion());
         helpFormatter.printHelp(writer, helpFormatter.getWidth(), syntax, header("Available options"), opts,

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -46,7 +46,8 @@ import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.report.IReportable;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.DefaultLog;
+import org.apache.rat.utils.Log.Level;
 import org.apache.rat.utils.ReportingSet;
 
 /**
@@ -131,10 +132,7 @@ public class ReportConfiguration {
      * A file filter that matches directories to ignore.
      */
     private IOFileFilter directoriesToIgnore;
-    /**
-     * the log to write messages to.
-     */
-    private final Log log;
+
     /**
      * The default filter for displaying families.
      */
@@ -158,13 +156,11 @@ public class ReportConfiguration {
 
     /**
      * Constructor
-     * @param log The Log implementation that messages will be written to.
      */
-    public ReportConfiguration(final Log log) {
-        this.log = log;
-        families = new ReportingSet<>(new TreeSet<ILicenseFamily>()).setLog(log)
+    public ReportConfiguration() {
+        families = new ReportingSet<>(new TreeSet<ILicenseFamily>())
                 .setMsgFormat(s -> String.format("Duplicate LicenseFamily category: %s", s.getFamilyCategory()));
-        licenses = new ReportingSet<>(new TreeSet<ILicense>()).setLog(log)
+        licenses = new ReportingSet<>(new TreeSet<ILicense>())
                 .setMsgFormat(s -> String.format("Duplicate License %s (%s) of type %s", s.getName(), s.getId(), s.getLicenseFamily().getFamilyCategory()));
         licenseSetFactory = new LicenseSetFactory(families, licenses);
         listFamilies = Defaults.LIST_FAMILIES;
@@ -205,18 +201,11 @@ public class ReportConfiguration {
     }
 
     /**
-     * Retrieves the Log that was provided in the constructor.
-     * @return the Log for the system.
-     */
-    public Log getLog() {
-        return log;
-    }
-    /**
      * Set the log level for reporting collisions in the set of license families.
      * <p>NOTE: should be set before licenses or license families are added.</p>
      * @param level The log level to use.
      */
-    public void logFamilyCollisions(final Log.Level level) {
+    public void logFamilyCollisions(final Level level) {
         families.setLogLevel(level);
     }
 
@@ -232,7 +221,7 @@ public class ReportConfiguration {
      * Sets the log level for reporting license collisions.
      * @param level The log level.
      */
-    public void logLicenseCollisions(final Log.Level level) {
+    public void logLicenseCollisions(final Level level) {
         licenses.setLogLevel(level);
     }
 
@@ -440,11 +429,11 @@ public class ReportConfiguration {
             try {
                 Files.delete(file.toPath());
             } catch (IOException e) {
-                log.warn("Unable to delete file: " + file);
+                DefaultLog.getInstance().warn("Unable to delete file: " + file);
             }
         }
         if (!file.getParentFile().mkdirs()) {
-            log.warn("Unable to create directory: " + file.getParentFile());
+            DefaultLog.getInstance().warn("Unable to create directory: " + file.getParentFile());
         }
         setOut(() -> new FileOutputStream(file, true));
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/DocumentHeaderAnalyser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/DocumentHeaderAnalyser.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import org.apache.rat.api.Document;
 import org.apache.rat.document.IDocumentAnalyser;
 import org.apache.rat.license.ILicense;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.DefaultLog;
 
 /**
  * A Document analyzer that analyses document headers for a license.
@@ -36,32 +36,28 @@ class DocumentHeaderAnalyser implements IDocumentAnalyser {
 
     /** The license to analyse */
     private final Collection<ILicense> licenses;
-    /** the logger to use */
-    private final Log log;
+
 
     /**
      * Constructs the HeaderAnalyser for the specific license.
-     *
-     * @param log The log to write message to.
      * @param licenses The licenses to analyse
      */
-    public DocumentHeaderAnalyser(final Log log, final Collection<ILicense> licenses) {
+    public DocumentHeaderAnalyser(final Collection<ILicense> licenses) {
         super();
         this.licenses = licenses;
-        this.log = log;
     }
 
     @Override
     public void analyse(Document document) {
         try (Reader reader = document.reader()) {
-            log.debug(format("Processing: %s", document));
+            DefaultLog.getInstance().debug(format("Processing: %s", document));
             HeaderCheckWorker worker = new HeaderCheckWorker(reader, licenses, document);
             worker.read();
         } catch (IOException e) {
-            log.warn(String.format("Cannot read header of %s", document));
+            DefaultLog.getInstance().warn(String.format("Cannot read header of %s", document));
             document.getMetaData().setDocumentType(Document.Type.UNKNOWN);
         } catch (RatHeaderAnalysisException e) {
-            log.warn(String.format("Cannot process header of %s", document));
+            DefaultLog.getInstance().warn(String.format("Cannot process header of %s", document));
             document.getMetaData().setDocumentType(Document.Type.UNKNOWN);
         }
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/TikaProcessor.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/TikaProcessor.java
@@ -21,7 +21,6 @@ package org.apache.rat.analysis;
 import org.apache.rat.api.Document;
 import org.apache.rat.document.RatDocumentAnalysisException;
 import org.apache.rat.document.impl.guesser.NoteGuesser;
-import org.apache.rat.utils.Log;
 import org.apache.tika.Tika;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.metadata.TikaCoreProperties;
@@ -104,12 +103,11 @@ public class TikaProcessor {
 
     /**
      * Process the input document.
-     * @param log the log for messages.
      * @param document the Document to process.
      * @return the mimetype as a string.
      * @throws RatDocumentAnalysisException on error.
      */
-    public static String process(final Log log, final Document document) throws RatDocumentAnalysisException {
+    public static String process(final Document document) throws RatDocumentAnalysisException {
         Metadata metadata = new Metadata();
         try (InputStream stream = document.inputStream()) {
             metadata.set(TikaCoreProperties.RESOURCE_NAME_KEY, document.getName());
@@ -118,7 +116,7 @@ public class TikaProcessor {
             MediaType mediaType = new MediaType(parts[0], parts[1]);
             document.getMetaData().setMediaType(mediaType);
             document.getMetaData()
-                    .setDocumentType(fromMediaType(mediaType, log));
+                    .setDocumentType(fromMediaType(mediaType));
             if (Document.Type.STANDARD == document.getMetaData().getDocumentType()) {
                 if (NoteGuesser.isNote(document)) {
                     document.getMetaData().setDocumentType(Document.Type.NOTICE);
@@ -131,7 +129,7 @@ public class TikaProcessor {
         }
     }
 
-    public static Document.Type fromMediaType(final MediaType mediaType, final Log log) {
+    public static Document.Type fromMediaType(final MediaType mediaType) {
         if ("text".equals(mediaType.getType())) {
             return Document.Type.STANDARD;
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/annotation/AbstractLicenseAppender.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/annotation/AbstractLicenseAppender.java
@@ -201,11 +201,10 @@ public abstract class AbstractLicenseAppender {
         EXT2TYPE.put("yml", TYPE_YAML);
     }
 
-    private boolean isForced;
+    private boolean isOverwrite;
 
     /**
      * Constructor
-     * @param log The log to use.
      */
     public AbstractLicenseAppender() {
         super();
@@ -252,7 +251,7 @@ public abstract class AbstractLicenseAppender {
             }
         } 
 
-        if (isForced) {
+        if (isOverwrite) {
             try {
                 Path docPath = document.toPath();
                 boolean isExecutable = Files.isExecutable(docPath);
@@ -388,13 +387,14 @@ public abstract class AbstractLicenseAppender {
      * to true then files will be modified directly, otherwise
      * new files will be created alongside the existing files.
      *
-     * @param force force flag.
+     * @param overwrite force flag.
      */
-    public void setForce(boolean force) {
-        isForced = force;
+    public void setOverwrite(boolean overwrite) {
+        isOverwrite = overwrite;
     }
 
     /**
+     * Gets the header text to insert into the file.
      * @param document document to extract from.
      * @return Get the license header of a document.
      */

--- a/apache-rat-core/src/main/java/org/apache/rat/annotation/AbstractLicenseAppender.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/annotation/AbstractLicenseAppender.java
@@ -19,7 +19,7 @@
 package org.apache.rat.annotation;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.DefaultLog;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -202,16 +202,13 @@ public abstract class AbstractLicenseAppender {
     }
 
     private boolean isForced;
-    /** The log to use */
-    private final Log log;
 
     /**
      * Constructor
      * @param log The log to use.
      */
-    public AbstractLicenseAppender(final Log log) {
+    public AbstractLicenseAppender() {
         super();
-        this.log = log;
     }
 
     /**
@@ -261,10 +258,10 @@ public abstract class AbstractLicenseAppender {
                 boolean isExecutable = Files.isExecutable(docPath);
                 Files.move(newDocument.toPath(), docPath, StandardCopyOption.REPLACE_EXISTING);
                 if (isExecutable && !document.setExecutable(true)) {
-                    log.warn(String.format("Could not set %s as executable.", document));
+                    DefaultLog.getInstance().warn(String.format("Could not set %s as executable.", document));
                 }
             } catch (InvalidPathException | IOException e) {
-                log.error(String.format("Failed to rename new file to %s, Original file is unchanged.", document), e);
+                DefaultLog.getInstance().error(String.format("Failed to rename new file to %s, Original file is unchanged.", document), e);
             }
         }
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/annotation/ApacheV2LicenseAppender.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/annotation/ApacheV2LicenseAppender.java
@@ -20,9 +20,6 @@ package org.apache.rat.annotation;
 
 import java.io.File;
 
-import org.apache.rat.utils.Log;
-
-
 /**
  * Add an Apache License V2 license header to a
  * document. This appender does not check for the
@@ -36,21 +33,18 @@ public class ApacheV2LicenseAppender extends AbstractLicenseAppender {
 
     /**
      * Create a license appender with the standard ASF license header.
-     * @param log The log to use during processing.
      */
-    public ApacheV2LicenseAppender(final Log log) {
-        super(log);
+    public ApacheV2LicenseAppender() {
+        super();
     }
 
     /**
      * Create a license appender with the given copyright line. This should be of
      * the form &quot;Copyright 2008 Foo&quot;
-     *
-     * @param log The log to use during processing.
      * @param copyright copyright line to add to the headers.
      */
-    public ApacheV2LicenseAppender(final Log log, String copyright) {
-        super(log);
+    public ApacheV2LicenseAppender(String copyright) {
+        super();
         this.copyright = copyright;
     }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -682,10 +682,12 @@ public enum Arg {
      * @return The Arg or {@code null} if no Arg is found.
      */
     public static Arg findArg(Option optionToFind) {
-        for (Arg arg : Arg.values()) {
-            for (Option candidate : arg.group.getOptions()) {
-                if (optionToFind.equals(candidate)) {
-                    return arg;
+        if (optionToFind != null) {
+            for (Arg arg : Arg.values()) {
+                for (Option candidate : arg.group.getOptions()) {
+                    if (optionToFind.equals(candidate)) {
+                        return arg;
+                    }
                 }
             }
         }
@@ -698,10 +700,12 @@ public enum Arg {
      * @return The Arg or {@code null} if no Arg is found.
      */
     public static Arg findArg(String key) {
-        for (Arg arg : Arg.values()) {
-            for (Option candidate : arg.group.getOptions()) {
-                if (key.equals(candidate.getKey()) || key.equals(candidate.getLongOpt())) {
-                    return arg;
+        if (key != null) {
+            for (Arg arg : Arg.values()) {
+                for (Option candidate : arg.group.getOptions()) {
+                    if (key.equals(candidate.getKey()) || key.equals(candidate.getLongOpt())) {
+                        return arg;
+                    }
                 }
             }
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -124,7 +124,7 @@ public enum Arg {
             .build())
             .addOption(Option.builder().longOpt("licenses").hasArgs().argName("File")
             .desc("File names for system configuration.")
-            .deprecated(DeprecatedAttributes.builder().setSince("0.17.0").setForRemoval(true).setDescription(StdMsgs.useMsg("--config")).get())
+            .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--config")).get())
             .build())),
 
     /** Group of options that skip the default configuration file */

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -138,7 +138,7 @@ public enum Arg {
 
     /** Option that adds approved licenses to the list */
     LICENSES_APPROVED(new OptionGroup().addOption(Option.builder().longOpt("licenses-approved").hasArgs().argName("LicenseID")
-            .desc("The approved License IDs.  These licenses will be added to the list of approved licenses.")
+            .desc("The approved License IDs. These licenses will be added to the list of approved licenses.")
             .build())),
 
     /** Option that adds approved licenses from a file */
@@ -149,7 +149,7 @@ public enum Arg {
 
     /** Option that specifies approved license families */
     FAMILIES_APPROVED(new OptionGroup().addOption(Option.builder().longOpt("license-families-approved").hasArgs().argName("FamilyID")
-            .desc("The approved License Family IDs.  These licenses families will be added to the list of approved licenses families.")
+            .desc("The approved License Family IDs. These licenses families will be added to the list of approved licenses families.")
             .build())),
 
     /** Option that specifies approved license families from a file */
@@ -160,7 +160,7 @@ public enum Arg {
 
     /** Option to remove licenses from the approved list */
     LICENSES_DENIED(new OptionGroup().addOption(Option.builder().longOpt("licenses-denied").hasArgs().argName("LicenseID")
-            .desc("The denied License IDs.  These licenses will be removed to the list of approved licenses. " +
+            .desc("The denied License IDs. These licenses will be removed to the list of approved licenses. " +
                     "Once licenses are removed they can not be added back.")
             .build())),
 
@@ -172,7 +172,7 @@ public enum Arg {
 
     /** Option to list license families to remove from the approved list */
     FAMILIES_DENIED(new OptionGroup().addOption(Option.builder().longOpt("license-families-denied").hasArgs().argName("FamilyID")
-            .desc("The denied License family IDs.  These license families will be removed from the list of approved licenses.")
+            .desc("The denied License family IDs. These license families will be removed from the list of approved licenses.")
             .build())),
 
     /** Option to read a list of license families to remove from the approved list */
@@ -277,7 +277,7 @@ public enum Arg {
     OUTPUT_FILE(new OptionGroup()
             .addOption(Option.builder().option("o").longOpt("out").hasArg().argName("File")
                     .desc("Define the output file where to write a report to.")
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17.0").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-file")).get())
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-file")).get())
                     .type(File.class).build())
             .addOption(Option.builder().longOpt("output-file").hasArg().argName("File")
                     .desc("Define the output file where to write a report to.")

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -584,9 +584,10 @@ public enum Arg {
     }
 
     /**
-    * Process the arguments.
-    * @param ctxt the context in which to process the args.
-    */
+     * Process the arguments.
+     * @param ctxt the context in which to process the args.
+     * @throws IOException if input files can not be read.
+     */
     public static void processArgs(final ArgumentContext ctxt) throws IOException {
         processOutputArgs(ctxt);
         processEditArgs(ctxt);
@@ -662,6 +663,9 @@ public enum Arg {
         }
     }
 
+    /**
+     * Resets the groups in the Args so that they are unused and ready to detect the next set of arguments.
+     */
     public static void reset() {
         for (Arg a : Arg.values()) {
             try {
@@ -708,6 +712,15 @@ public enum Arg {
      * Standard messages used in descriptions.
      */
     public static class StdMsgs {
+        private StdMsgs() {
+            // do not instantiate
+        }
+
+        /**
+         * Gets the standard "use instead" message for the specific name.
+         * @param name the name of the option to use instead.
+         * @return
+         */
         public static String useMsg(String name) {
             return format("Use %s instead.", name);
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -719,7 +719,7 @@ public enum Arg {
         /**
          * Gets the standard "use instead" message for the specific name.
          * @param name the name of the option to use instead.
-         * @return
+         * @return combined "use instead" message.
          */
         public static String useMsg(String name) {
             return format("Use %s instead.", name);
@@ -735,6 +735,5 @@ public enum Arg {
        DEFAULT_VALUES.put(OUTPUT_STANDARD, Defaults.STANDARD_PROCESSING.name());
        DEFAULT_VALUES.put(OUTPUT_LICENSES, Defaults.LIST_LICENSES.name());
        DEFAULT_VALUES.put(OUTPUT_FAMILIES, Defaults.LIST_FAMILIES.name());
-
    }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -28,7 +28,9 @@ import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.PatternSyntaxException;
 
@@ -71,10 +73,11 @@ public enum Arg {
             .addOption(Option.builder("c")
                             .longOpt("copyright").hasArg()
                             .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                                    .setDescription("Use '--edit-copyright' instead.").get())
+                                    .setDescription(StdMsgs.useMsg("--edit-copyright")).get())
+                            .desc("The copyright message to use in the license headers.")
                             .build())
                     .addOption(Option.builder().longOpt("edit-copyright").hasArg()
-                            .desc("The copyright message to use in the license headers, usually in the form of \"Copyright 2008 Foo\".  "
+                            .desc("The copyright message to use in the license headers. Usually in the form of \"Copyright 2008 Foo\".  "
                                     + "Only valid with --edit-license")
                             .build())),
 
@@ -84,10 +87,11 @@ public enum Arg {
     EDIT_OVERWRITE(new OptionGroup()
             .addOption(Option.builder("f").longOpt("force")
                             .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                                    .setDescription("Use '--edit-overwrite' instead.").get())
+                                    .setDescription(StdMsgs.useMsg("--edit-overwrite")).get())
+                    .desc("Forces any changes in files to be written directly to the source files (i.e. new files are not created).")
                             .build())
                     .addOption(Option.builder().longOpt("edit-overwrite")
-                            .desc("Forces any changes in files to be written directly to the source files (i.e. new files are not created).  "
+                            .desc("Forces any changes in files to be written directly to the source files (i.e. new files are not created). "
                                     + "Only valid with --edit-license")
                             .build())),
 
@@ -97,11 +101,12 @@ public enum Arg {
     EDIT_ADD(new OptionGroup()
             .addOption(Option.builder("a")
                             .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                                    .setDescription("Use '--edit-license' instead.").get())
+                                    .setDescription(StdMsgs.useMsg("--edit-license")).get())
                             .build())
                     .addOption(Option.builder("A").longOpt("addLicense")
                             .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                                    .setDescription("Use '--edit-license' instead.").get())
+                                    .setDescription(StdMsgs.useMsg("--edit-license")).get())
+                            .desc("Add the default license header to any file with an unknown license that is not in the exclusion list.")
                             .build())
                     .addOption(Option.builder().longOpt("edit-license").desc(
                             "Add the default license header to any file with an unknown license that is not in the exclusion list. "
@@ -115,13 +120,11 @@ public enum Arg {
     /** Group of options that read a configuration file */
     CONFIGURATION(new OptionGroup()
             .addOption(Option.builder().longOpt("config").hasArgs().argName("File")
-            .desc("File names for system configuration.  May be followed by multiple arguments. "
-                          + "Note that '--' or a following option is required when using this parameter.")
+            .desc("File names for system configuration.")
             .build())
             .addOption(Option.builder().longOpt("licenses").hasArgs().argName("File")
-            .desc("File names for system configuration.  May be followed by multiple arguments. "
-                          + "Note that '--' or a following option is required when using this parameter.")
-            .deprecated(DeprecatedAttributes.builder().setSince("0.17.0").setForRemoval(true).setDescription("Use --config").get())
+            .desc("File names for system configuration.")
+            .deprecated(DeprecatedAttributes.builder().setSince("0.17.0").setForRemoval(true).setDescription(StdMsgs.useMsg("--config")).get())
             .build())),
 
     /** Group of options that skip the default configuration file */
@@ -129,13 +132,13 @@ public enum Arg {
             .addOption(Option.builder().longOpt("configuration-no-defaults")
                     .desc("Ignore default configuration.").build())
             .addOption(Option.builder().longOpt("no-default-licenses")
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription("Use --configuration-no-defaults").get())
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--configuration-no-defaults")).get())
+                    .desc("Ignore default configuration.")
                     .build())),
 
     /** Option that adds approved licenses to the list */
     LICENSES_APPROVED(new OptionGroup().addOption(Option.builder().longOpt("licenses-approved").hasArgs().argName("LicenseID")
-            .desc("The approved License IDs.  These licenses will be added to the list of approved licenses. "
-                    + "May be followed by multiple arguments. Note that '--' or a following option is required when using this parameter.")
+            .desc("The approved License IDs.  These licenses will be added to the list of approved licenses.")
             .build())),
 
     /** Option that adds approved licenses from a file */
@@ -146,8 +149,7 @@ public enum Arg {
 
     /** Option that specifies approved license families */
     FAMILIES_APPROVED(new OptionGroup().addOption(Option.builder().longOpt("license-families-approved").hasArgs().argName("FamilyID")
-            .desc("The approved License Family IDs.  These licenses families will be added to the list of approved licenses families "
-                    + "May be followed by multiple arguments. Note that '--' or a following option is required when using this parameter.")
+            .desc("The approved License Family IDs.  These licenses families will be added to the list of approved licenses families.")
             .build())),
 
     /** Option that specifies approved license families from a file */
@@ -158,8 +160,8 @@ public enum Arg {
 
     /** Option to remove licenses from the approved list */
     LICENSES_DENIED(new OptionGroup().addOption(Option.builder().longOpt("licenses-denied").hasArgs().argName("LicenseID")
-            .desc("The approved License IDs.  These licenses will be added to the list of approved licenses. "
-                    + "May be followed by multiple arguments. Note that '--' or a following option is required when using this parameter.")
+            .desc("The denied License IDs.  These licenses will be removed to the list of approved licenses. " +
+                    "Once licenses are removed they can not be added back.")
             .build())),
 
     /** Option to read a file licenses to be removed from the approved list */
@@ -170,8 +172,7 @@ public enum Arg {
 
     /** Option to list license families to remove from the approved list */
     FAMILIES_DENIED(new OptionGroup().addOption(Option.builder().longOpt("license-families-denied").hasArgs().argName("FamilyID")
-            .desc("The denied License family IDs.  These license families will be removed from the list of approved licenses. "
-                    + "May be followed by multiple arguments. Note that '--' or a following option is required when using this parameter.")
+            .desc("The denied License family IDs.  These license families will be removed from the list of approved licenses.")
             .build())),
 
     /** Option to read a list of license families to remove from the approved list */
@@ -186,11 +187,11 @@ public enum Arg {
     EXCLUDE(new OptionGroup()
             .addOption(Option.builder("e").longOpt("exclude").hasArgs().argName("Expression")
                     .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                            .setDescription("Use '--input-exclude' instead.").get())
+                            .setDescription(StdMsgs.useMsg("--input-exclude")).get())
+                    .desc("Excludes files matching wildcard <Expression>.")
             .build())
             .addOption(Option.builder().longOpt("input-exclude").hasArgs().argName("Expression")
-                    .desc("Excludes files matching wildcard <Expression>. May be followed by multiple arguments. "
-                                  + "Note that '--' or a following option is required when using this parameter.")
+                    .desc("Excludes files matching wildcard <Expression>.")
                     .build())),
 
     /** Excludes files based on content of file */
@@ -199,7 +200,8 @@ public enum Arg {
                     .argName("File")
                     .hasArg()
                     .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                            .setDescription("Use '--input-exclude-file' instead.").get())
+                            .setDescription(StdMsgs.useMsg("--input-exclude-file")).get())
+                    .desc("Excludes files matching regular expression in the input file.")
                     .build())
             .addOption(Option.builder().longOpt("input-exclude-file")
                     .argName("File")
@@ -208,13 +210,13 @@ public enum Arg {
 
     /** Scan hidden directories */
     SCAN_HIDDEN_DIRECTORIES(new OptionGroup().addOption(new Option(null, "scan-hidden-directories", false,
-            "Scan hidden directories"))),
+            "Scans hidden directories."))),
 
     /** Stop processing an input stream and declare an input file */
     DIR(new OptionGroup().addOption(Option.builder().option("d").longOpt("dir").hasArg()
-            .desc("Used to indicate end of list when using --exclude.").argName("DirOrArchive")
+            .desc("Used to indicate end of list when using options that take multiple arguments.").argName("DirOrArchive")
             .deprecated(DeprecatedAttributes.builder().setForRemoval(true).setSince("0.17")
-                    .setDescription("Use '--'").get()).build())),
+                    .setDescription("Use the standard '--' to signal the end of arguments.").get()).build())),
 
     /////////////// OUTPUT OPTIONS
 
@@ -226,34 +228,36 @@ public enum Arg {
                             + "Either an external xsl file may be specified or one of the internal named sheets.")
                     .build())
             .addOption(Option.builder("s").longOpt("stylesheet").hasArg().argName("StyleSheet")
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription("Use --output-style").get())
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-style")).get())
+                    .desc("XSLT stylesheet to use when creating the report.")
                     .build())
             .addOption(Option.builder("x").longOpt("xml")
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription("Use --output-style xml").get())
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-style with the 'xml' argument")).get())
+                    .desc("forces XML output rather than the report.")
                     .build())),
 
     /** Specifies the license definitions that should be included in the output */
     OUTPUT_LICENSES(new OptionGroup()
             .addOption(Option.builder().longOpt("output-licenses").hasArg().argName("LicenseFilter")
-                    .desc("List the defined licenses (default is NONE).")
+                    .desc("List the defined licenses.")
                     .converter(s -> LicenseSetFactory.LicenseFilter.valueOf(s.toUpperCase()))
                     .build())
             .addOption(Option.builder().longOpt("list-licenses").hasArg().argName("LicenseFilter")
-                    .desc("List the defined licenses (default is NONE).")
+                    .desc("List the defined licenses.")
                     .converter(s -> LicenseSetFactory.LicenseFilter.valueOf(s.toUpperCase()))
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription("Use --output-licenses").get())
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-licenses")).get())
                     .build())),
 
     /** Specifies the license families that should be included in the output */
     OUTPUT_FAMILIES(new OptionGroup()
             .addOption(Option.builder().longOpt("output-families").hasArg().argName("LicenseFilter")
-                    .desc("List the defined license families (default is NONE).")
+                    .desc("List the defined license families.")
                     .converter(s -> LicenseSetFactory.LicenseFilter.valueOf(s.toUpperCase()))
                     .build())
             .addOption(Option.builder().longOpt("list-families").hasArg().argName("LicenseFilter")
-                    .desc("List the defined license families (default is NONE).")
+                    .desc("List the defined license families.")
                     .converter(s -> LicenseSetFactory.LicenseFilter.valueOf(s.toUpperCase()))
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription("Use --output-families").get())
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-families")).get())
                     .build())),
 
     /** Specifies the log level to log messages at. */
@@ -272,32 +276,38 @@ public enum Arg {
     /** Specifies where the output should be written. */
     OUTPUT_FILE(new OptionGroup()
             .addOption(Option.builder().option("o").longOpt("out").hasArg().argName("File")
-                    .desc("Define the output file where to write a report to (default is System.out).")
-                    .deprecated(DeprecatedAttributes.builder().setSince("0.17.0").setForRemoval(true).setDescription("Use --output-file").get())
+                    .desc("Define the output file where to write a report to.")
+                    .deprecated(DeprecatedAttributes.builder().setSince("0.17.0").setForRemoval(true).setDescription(StdMsgs.useMsg("--output-file")).get())
                     .type(File.class).build())
             .addOption(Option.builder().longOpt("output-file").hasArg().argName("File")
-                    .desc("Define the output file where to write a report to (default is System.out).")
+                    .desc("Define the output file where to write a report to.")
                     .type(File.class).build())),
 
     /** Specifies the level of reporting detail for archive files. */
     OUTPUT_ARCHIVE(new OptionGroup()
             .addOption(Option.builder().longOpt("output-archive").hasArg().argName("ProcessingType")
-                    .desc(format("Specifies the level of detail in ARCHIVE file reporting. (default is %s)",
-                            Defaults.ARCHIVE_PROCESSING))
+                    .desc("Specifies the level of detail in ARCHIVE file reporting.")
                     .converter(s -> ReportConfiguration.Processing.valueOf(s.toUpperCase()))
                     .build())),
 
     /** Specifies the level of reporting detail for standard files. */
     OUTPUT_STANDARD(new OptionGroup()
             .addOption(Option.builder().longOpt("output-standard").hasArg().argName("ProcessingType")
-                    .desc(format("Specifies the level of detail in STANDARD file reporting. (default is %s)",
-                            Defaults.STANDARD_PROCESSING))
+                    .desc("Specifies the level of detail in STANDARD file reporting.")
                     .converter(s -> ReportConfiguration.Processing.valueOf(s.toUpperCase()))
-                    .build()));
+                    .build())),
+
+    /** Provide license definition listing */
+    HELP_LICENSES(new OptionGroup()
+    .addOption(Option.builder().longOpt("help-licenses").desc("Print information about registered licenses.").build()));
 
     /** The option group for the argument */
     private final OptionGroup group;
 
+    /**
+     * Creates an Arg from an Option group.
+     * @param group The option group.
+     */
     Arg(final OptionGroup group) {
         this.group = group;
     }
@@ -339,6 +349,10 @@ public enum Arg {
             }
         }
         throw new IllegalArgumentException("Can not find " + key);
+    }
+
+    public String defaultValue() {
+        return DEFAULT_VALUES.get(this);
     }
 
     /**
@@ -408,7 +422,7 @@ public enum Arg {
             ctxt.getCommandLine().hasOption(CONFIGURATION.getSelected());
             defaultBuilder.noDefault();
         }
-        ctxt.getConfiguration().setFrom(defaultBuilder.build(ctxt.getLog()));
+        ctxt.getConfiguration().setFrom(defaultBuilder.build());
 
         if (FAMILIES_APPROVED.isSelected()) {
             for (String cat : ctxt.getCommandLine().getOptionValues(FAMILIES_APPROVED.getSelected())) {
@@ -476,11 +490,10 @@ public enum Arg {
     /**
      * Creates a filename filter from patterns to exclude.
      * Package provide for use in testing.
-     * @param log the Logger to use.
      * @param excludes the list of patterns to exclude.
      * @return the FilenameFilter tht excludes the patterns or an empty optional.
      */
-    static Optional<IOFileFilter> parseExclusions(final Log log, final List<String> excludes) {
+    static Optional<IOFileFilter> parseExclusions(final List<String> excludes) {
         final OrFileFilter orFilter = new OrFileFilter();
         int ignoredLines = 0;
         for (String exclude : excludes) {
@@ -505,7 +518,7 @@ public enum Arg {
             }
         }
         if (ignoredLines > 0) {
-            log.info("Ignored " + ignoredLines + " lines in your exclusion files as comments or empty lines.");
+            DefaultLog.getInstance().info("Ignored " + ignoredLines + " lines in your exclusion files as comments or empty lines.");
         }
         return orFilter.getFileFilters().isEmpty() ? Optional.empty() : Optional.of(orFilter);
     }
@@ -525,13 +538,13 @@ public enum Arg {
         if (EXCLUDE.isSelected()) {
             String[] excludes = ctxt.getCommandLine().getOptionValues(EXCLUDE.getSelected());
             if (excludes != null) {
-                parseExclusions(ctxt.getConfiguration().getLog(), Arrays.asList(excludes)).ifPresent(ctxt.getConfiguration()::setFilesToIgnore);
+                parseExclusions(Arrays.asList(excludes)).ifPresent(ctxt.getConfiguration()::setFilesToIgnore);
             }
         }
         if (EXCLUDE_FILE.isSelected()) {
             String excludeFileName = ctxt.getCommandLine().getOptionValue(EXCLUDE_FILE.getSelected());
             if (excludeFileName != null) {
-                parseExclusions(ctxt.getConfiguration().getLog(), FileUtils.readLines(new File(excludeFileName), StandardCharsets.UTF_8))
+                parseExclusions(FileUtils.readLines(new File(excludeFileName), StandardCharsets.UTF_8))
                         .ifPresent(ctxt.getConfiguration()::setFilesToIgnore);
             }
         }
@@ -554,19 +567,18 @@ public enum Arg {
     /**
      * Process the log level setting.
      * @param commandLine The command line to process.
-     * @param log The log to set.
      */
-    public static void processLogLevel(final CommandLine commandLine, final Log log) {
+    public static void processLogLevel(final CommandLine commandLine) {
         if (LOG_LEVEL.getSelected() != null) {
-            if (log instanceof DefaultLog) {
-                DefaultLog dLog = (DefaultLog) log;
+            if (DefaultLog.getInstance() instanceof DefaultLog) {
+                DefaultLog dLog = (DefaultLog) DefaultLog.getInstance();
                 try {
                     dLog.setLevel(commandLine.getParsedOptionValue(LOG_LEVEL.getSelected()));
                 } catch (ParseException e) {
-                    logParseException(log, e, LOG_LEVEL.getSelected(), commandLine, dLog.getLevel());
+                    logParseException(DefaultLog.getInstance(), e, LOG_LEVEL.getSelected(), commandLine, dLog.getLevel());
                 }
             } else {
-                log.error("Given log was not a DefaultLog instance. LogLevel not set.");
+                DefaultLog.getInstance().error("log was not a DefaultLog instance. LogLevel not set.");
             }
         }
     }
@@ -625,7 +637,7 @@ public enum Arg {
             try {
                 File f = ctxt.getCommandLine().getParsedOptionValue(OUTPUT_FILE.getSelected());
                 if (f.getParentFile().mkdirs() && !f.isDirectory()) {
-                    ctxt.getLog().error("Could not create report parent directory " + f);
+                    DefaultLog.getInstance().error("Could not create report parent directory " + f);
                 }
                 ctxt.getConfiguration().setOut(f);
             } catch (ParseException e) {
@@ -642,7 +654,7 @@ public enum Arg {
             } else {
                 String[] style = ctxt.getCommandLine().getOptionValues(OUTPUT_STYLE.getSelected());
                 if (style.length != 1) {
-                    ctxt.getLog().error("Please specify a single stylesheet");
+                    DefaultLog.getInstance().error("Please specify a single stylesheet");
                     throw new ConfigurationException("Please specify a single stylesheet");
                 }
                 ctxt.getConfiguration().setStyleSheet(StyleSheets.getStyleSheet(style[0]));
@@ -659,4 +671,57 @@ public enum Arg {
             }
         }
     }
+
+    /**
+     * Finds the Arg that an Option is in.
+     * @param optionToFind the Option to locate.
+     * @return The Arg or {@code null} if no Arg is found.
+     */
+    public static Arg findArg(Option optionToFind) {
+        for (Arg arg : Arg.values()) {
+            for (Option candidate : arg.group.getOptions()) {
+                if (optionToFind.equals(candidate)) {
+                    return arg;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the Arg that contains an Option with the specified key.
+     * @param key the key for the Option to locate.
+     * @return The Arg or {@code null} if no Arg is found.
+     */
+    public static Arg findArg(String key) {
+        for (Arg arg : Arg.values()) {
+            for (Option candidate : arg.group.getOptions()) {
+                if (key.equals(candidate.getKey()) || key.equals(candidate.getLongOpt())) {
+                    return arg;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Standard messages used in descriptions.
+     */
+    public static class StdMsgs {
+        public static String useMsg(String name) {
+            return format("Use %s instead.", name);
+        }
+    }
+
+   private static final Map<Arg, String> DEFAULT_VALUES = new HashMap<>();
+
+   static {
+       DEFAULT_VALUES.put(OUTPUT_FILE, "System.out");
+       DEFAULT_VALUES.put(LOG_LEVEL, Log.Level.WARN.name());
+       DEFAULT_VALUES.put(OUTPUT_ARCHIVE, Defaults.ARCHIVE_PROCESSING.name());
+       DEFAULT_VALUES.put(OUTPUT_STANDARD, Defaults.STANDARD_PROCESSING.name());
+       DEFAULT_VALUES.put(OUTPUT_LICENSES, Defaults.LIST_LICENSES.name());
+       DEFAULT_VALUES.put(OUTPUT_FAMILIES, Defaults.LIST_FAMILIES.name());
+
+   }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
@@ -26,7 +26,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.ParseException;
 import org.apache.rat.ReportConfiguration;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.DefaultLog;
 
 /**
  * Provides the context necessary to process various arguments.
@@ -69,23 +69,15 @@ public class ArgumentContext {
     }
 
     /**
-     * Gets the log.
-     * @return The log to write messages to.
-     */
-    public Log getLog() {
-        return configuration.getLog();
-    }
-
-    /**
      * Logs a ParseException as a warning.
      * @param exception the parse exception to log
      * @param opt the option being processed
      * @param dflt The default value the option is being set to.
      */
     public void logParseException(final ParseException exception, final String opt, final Object dflt) {
-        configuration.getLog().warn(format("Invalid %s specified: %s ", opt, commandLine.getOptionValue(opt)));
-        configuration.getLog().warn(format("%s set to: %s", opt, dflt));
-        configuration.getLog().debug(exception);
+        DefaultLog.getInstance().warn(format("Invalid %s specified: %s ", opt, commandLine.getOptionValue(opt)));
+        DefaultLog.getInstance().warn(format("%s set to: %s", opt, dflt));
+        DefaultLog.getInstance().debug(exception);
     }
 
     /**
@@ -95,8 +87,8 @@ public class ArgumentContext {
      * @param dflt The default value the option is being set to.
      */
     public void logParseException(final ParseException exception, final Option opt, final Object dflt) {
-        configuration.getLog().warn(format("Invalid %s specified: %s ", opt, commandLine.getOptionValue(opt)));
-        configuration.getLog().warn(format("%s set to: %s", opt, dflt));
-        configuration.getLog().debug(exception);
+        DefaultLog.getInstance().warn(format("Invalid %s specified: %s ", opt, commandLine.getOptionValue(opt)));
+        DefaultLog.getInstance().warn(format("%s set to: %s", opt, dflt));
+        DefaultLog.getInstance().debug(exception);
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
@@ -48,6 +48,10 @@ public class ArgumentContext {
         this.configuration = configuration;
     }
 
+    /**
+     * Process the arguments specified in this context.
+     * @throws IOException if files can not be read.
+     */
     public void processArgs() throws IOException {
         Arg.processArgs(this);
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/config/parameters/Description.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/parameters/Description.java
@@ -59,8 +59,8 @@ public class Description {
     private final Map<String, Description> children;
 
     /**
-     * A predicate to filter Descriptions by the component type.
-     * @param type The component type require in the filter.
+     * A predicate to filter Descriptions by component type.
+     * @param type The component type required in the filter.
      * @return a predicate that will only return Descriptions with the specified component type.
      */
     public static Predicate<Description> typePredicate(ComponentType type) {
@@ -77,7 +77,7 @@ public class Description {
      * @param childClass the class for expected for the getter/setter.
      * @param children the collection of descriptions for all the components that
      * are children of the described component.
-     * @param required If true the component is required.
+     * @param required If {@code true} the component is required.
      */
     public Description(ComponentType type, String name, String desc, boolean isCollection, Class<?> childClass,
             Collection<Description> children, boolean required) {

--- a/apache-rat-core/src/main/java/org/apache/rat/config/parameters/Description.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/parameters/Description.java
@@ -58,6 +58,11 @@ public class Description {
      */
     private final Map<String, Description> children;
 
+    /**
+     * A predicate to filter Descriptions by the component type.
+     * @param type The component type require in the filter.
+     * @return a predicate that will only return Descriptions with the specified component type.
+     */
     public static Predicate<Description> typePredicate(ComponentType type) {
         return (d) -> d.getType() == type;
     }
@@ -72,6 +77,7 @@ public class Description {
      * @param childClass the class for expected for the getter/setter.
      * @param children the collection of descriptions for all the components that
      * are children of the described component.
+     * @param required If true the component is required.
      */
     public Description(ComponentType type, String name, String desc, boolean isCollection, Class<?> childClass,
             Collection<Description> children, boolean required) {

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/LicenseReader.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/LicenseReader.java
@@ -23,7 +23,6 @@ import java.util.SortedSet;
 
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
-import org.apache.rat.utils.Log;
 
 /**
  * An interface describing the methods of a LicenseReader.
@@ -54,9 +53,4 @@ public interface LicenseReader {
      */
     SortedSet<String> approvedLicenseId();
 
-    /**
-     * Sets the logger to use during parsing.
-     * @param log the log to use.
-     */
-    void setLog(Log log);
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationReader.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationReader.java
@@ -54,7 +54,6 @@ import org.apache.rat.configuration.builders.AbstractBuilder;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.utils.DefaultLog;
-import org.apache.rat.utils.Log;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -68,8 +67,7 @@ import org.xml.sax.SAXException;
  * A class that reads the XML configuration file format.
  */
 public final class XMLConfigurationReader implements LicenseReader, MatcherReader {
-    /** The log to write to */
-    private Log log;
+
     /** The document we are building */
     private Document document;
     /** The root element in the document */
@@ -127,19 +125,6 @@ public final class XMLConfigurationReader implements LicenseReader, MatcherReade
                 return licenseFamilies;
             }
         };
-    }
-
-    @Override
-    public void setLog(final Log log) {
-        this.log = log;
-    }
-
-    /**
-     * Returns the log the reader.
-     * @return the log if set, if not set {@link DefaultLog#getInstance()} is returned.
-     */
-    public Log getLog() {
-        return log == null ? DefaultLog.getInstance() : log;
     }
 
     @Override
@@ -377,7 +362,7 @@ public final class XMLConfigurationReader implements LicenseReader, MatcherReade
             processBuilderParams(description, builder);
 
             // process the attributes
-            description.setChildren(getLog(), builder, attributes(matcherNode));
+            description.setChildren(builder, attributes(matcherNode));
 
             // check XML child nodes.
             Pair<Boolean, List<Node>> pair = processChildNodes(description, matcherNode,
@@ -419,7 +404,7 @@ public final class XMLConfigurationReader implements LicenseReader, MatcherReade
             }
 
             if (!children.isEmpty()) {
-                children.forEach(n -> getLog().warn(String.format("unrecognised child node '%s' in node '%s'%n",
+                children.forEach(n -> DefaultLog.getInstance().warn(String.format("unrecognised child node '%s' in node '%s'%n",
                         n.getNodeName(), matcherNode.getNodeName())));
             }
 
@@ -467,7 +452,7 @@ public final class XMLConfigurationReader implements LicenseReader, MatcherReade
         // set the BUILDER_PARAM options from the description
         processBuilderParams(description, builder);
         // set the children from attributes.
-        description.setChildren(getLog(), builder, attributes(licenseNode));
+        description.setChildren(builder, attributes(licenseNode));
         // set children from the child nodes
         Pair<Boolean, List<Node>> pair = processChildNodes(description, licenseNode,
                 licenseChildNodeProcessor(builder, description));
@@ -485,7 +470,7 @@ public final class XMLConfigurationReader implements LicenseReader, MatcherReade
         }
 
         if (!children.isEmpty()) {
-            children.forEach(n -> getLog().warn(String.format("unrecognised child node '%s' in node '%s'%n",
+            children.forEach(n -> DefaultLog.getInstance().warn(String.format("unrecognised child node '%s' in node '%s'%n",
                     n.getNodeName(), licenseNode.getNodeName())));
         }
         return builder.build();

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationWriter.java
@@ -187,7 +187,7 @@ public class XMLConfigurationWriter {
 
     private void writeAttribute(final IXmlWriter writer, final Description description, final IHeaderMatcher component)
             throws IOException {
-        String paramValue = description.getParamValue(configuration.getLog(), component);
+        String paramValue = description.getParamValue(component);
         if (paramValue != null) {
             writer.attribute(description.getCommonName(), paramValue);
         }
@@ -207,13 +207,13 @@ public class XMLConfigurationWriter {
 
                 // id will not be present in matcherRef
                 if (id.isPresent()) {
-                    String matcherId = id.get().getParamValue(configuration.getLog(), component);
+                    String matcherId = id.get().getParamValue(component);
                     // if we have seen the ID before just put a reference to the other one.
-                    if (matchers.contains(matcherId.toString())) {
-                        component = new MatcherRefBuilder.IHeaderMatcherProxy(matcherId.toString(), null);
+                    if (matchers.contains(matcherId)) {
+                        component = new MatcherRefBuilder.IHeaderMatcherProxy(matcherId, null);
                         description = component.getDescription();
                     } else {
-                        matchers.add(matcherId.toString());
+                        matchers.add(matcherId);
                     }
                     // remove the matcher id if it is a UUID
                     try {
@@ -230,7 +230,7 @@ public class XMLConfigurationWriter {
                 Optional<Description> resource = description.childrenOfType(ComponentType.PARAMETER).stream()
                         .filter(i -> XMLConfig.ATT_RESOURCE.equals(i.getCommonName())).findFirst();
                 if (resource.isPresent()) {
-                    String resourceStr = resource.get().getParamValue(configuration.getLog(), component);
+                    String resourceStr = resource.get().getParamValue(component);
                     if (StringUtils.isNotBlank(resourceStr)) {
                         description.getChildren().remove("enclosed");
                     }
@@ -248,10 +248,10 @@ public class XMLConfigurationWriter {
             case PARAMETER:
                 if ("id".equals(description.getCommonName())) {
                     try {
-                        String paramId = description.getParamValue(configuration.getLog(), component);
+                        String paramId = description.getParamValue(component);
                         // if a UUID skip it.
                         if (paramId != null) {
-                            UUID.fromString(paramId.toString());
+                            UUID.fromString(paramId);
                             return;
                         }
                     } catch (IllegalArgumentException expected) {
@@ -262,12 +262,12 @@ public class XMLConfigurationWriter {
 
                     boolean inline = XMLConfig.isInlineNode(component.getDescription().getCommonName(),
                             description.getCommonName());
-                    String s = description.getParamValue(configuration.getLog(), component);
+                    String s = description.getParamValue(component);
                     if (StringUtils.isNotBlank(s)) {
                         if (!inline) {
                             writer.openElement(description.getCommonName());
                         }
-                        writer.content(description.getParamValue(configuration.getLog(), component));
+                        writer.content(description.getParamValue(component));
                         if (!inline) {
                             writer.closeElement();
                         }

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
@@ -27,13 +27,21 @@ import org.apache.rat.annotation.ApacheV2LicenseAppender;
 import org.apache.rat.api.RatException;
 import org.apache.rat.report.AbstractReport;
 
+/**
+ * A Report that adds licenses text to files.
+ */
 public class LicenseAddingReport extends AbstractReport {
     private final AbstractLicenseAppender appender;
 
-    public LicenseAddingReport(String pCopyrightMsg, boolean pForced) {
-        appender = pCopyrightMsg == null ? new ApacheV2LicenseAppender()
-                : new ApacheV2LicenseAppender(pCopyrightMsg);
-        appender.setForce(pForced);
+    /**
+     * Creates a LicenseAddingReport that inserts the copyright message and may overwrite the files.
+     * @param copyrightMsg The message to insert into the files.  May be {@code null}.
+     * @param overwrite if {@code true} will overwrite the files rather than create {@code .new} files.
+     */
+    public LicenseAddingReport(String copyrightMsg, boolean overwrite) {
+        appender = copyrightMsg == null ? new ApacheV2LicenseAppender()
+                : new ApacheV2LicenseAppender(copyrightMsg);
+        appender.setForce(overwrite);
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
@@ -41,7 +41,7 @@ public class LicenseAddingReport extends AbstractReport {
     public LicenseAddingReport(String copyrightMsg, boolean overwrite) {
         appender = copyrightMsg == null ? new ApacheV2LicenseAppender()
                 : new ApacheV2LicenseAppender(copyrightMsg);
-        appender.setForce(overwrite);
+        appender.setOverwrite(overwrite);
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
@@ -26,14 +26,13 @@ import org.apache.rat.annotation.AbstractLicenseAppender;
 import org.apache.rat.annotation.ApacheV2LicenseAppender;
 import org.apache.rat.api.RatException;
 import org.apache.rat.report.AbstractReport;
-import org.apache.rat.utils.Log;
 
 public class LicenseAddingReport extends AbstractReport {
     private final AbstractLicenseAppender appender;
 
-    public LicenseAddingReport(final Log log, String pCopyrightMsg, boolean pForced) {
-        appender = pCopyrightMsg == null ? new ApacheV2LicenseAppender(log)
-                : new ApacheV2LicenseAppender(log, pCopyrightMsg);
+    public LicenseAddingReport(String pCopyrightMsg, boolean pForced) {
+        appender = pCopyrightMsg == null ? new ApacheV2LicenseAppender()
+                : new ApacheV2LicenseAppender(pCopyrightMsg);
         appender.setForce(pForced);
     }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/XmlReportFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/XmlReportFactory.java
@@ -67,7 +67,7 @@ public final class XmlReportFactory {
             reporters.add(new ClaimAggregator(statistic));
         }
         if (configuration.isAddingLicenses() && !configuration.isDryRun()) {
-            reporters.add(new LicenseAddingReport(configuration.getLog(), configuration.getCopyrightMessage(), configuration.isAddingLicensesForced()));
+            reporters.add(new LicenseAddingReport(configuration.getCopyrightMessage(), configuration.isAddingLicensesForced()));
         }
 
         if (configuration.listFamilies() != LicenseFilter.NONE || configuration.listLicenses() != LicenseFilter.NONE) {

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/DefaultLog.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/DefaultLog.java
@@ -21,60 +21,72 @@ package org.apache.rat.utils;
 /**
  * A default implementation of Log that writes to System.out and System.err
  */
-public class DefaultLog implements Log {
+public final class DefaultLog implements Log {
 
     /**
      * The instance of the default log.
      */
-    private static Log INSTANCE = new DefaultLog();
+    private static Log instance = new DefaultLog();
 
     /**
      * Retrieves teh DefaultLog instance.
      * @return the Default log instance.
      */
     public static Log getInstance() {
-        return INSTANCE;
+        return instance;
     }
 
     /**
      * Sets the default log instance.
      * If not set an instance of DefaultLog will be returned
-     * @param instance a Log to use as the defult.
+     * @param newInstance a Log to use as the default.
+     * @return the old instance.
      */
-    public static void setInstance(final Log instance) {
-        INSTANCE = instance == null ? new DefaultLog() : instance;
+    public static Log setInstance(final Log newInstance) {
+        Log result = instance;
+        instance = newInstance == null ? new DefaultLog() : newInstance;
+        return result;
     }
-    
+
+    /** The level at which we will write messages */
     private Level level;
 
     private DefaultLog() {
         level = Level.WARN;
     }
 
-    public void setLevel(Level level) {
+    /**
+     * Sets the level.
+     * @param level the level to use when writing messages.
+     */
+    public void setLevel(final Level level) {
         this.level = level;
     }
-    
+
+    /**
+     * Gets the level we are writing at.
+     * @return the level we are writing at.
+     */
     public Level getLevel() {
         return level;
     }
-    
+
     @Override
-    public void log(Level level, String msg) {
-        if (this.level.ordinal() <= level.ordinal())
+    public void log(final Level level, final String msg) {
+        if (this.level.ordinal() <= level.ordinal()) {
             switch (level) {
-            case DEBUG:
-            case INFO:
-            case WARN:
-                System.out.format("%s: %s%n", level, msg);
-                break;
-            case ERROR:
-                System.err.format("%s: %s%n", level, msg);
-                break;
-            case OFF:
-                break;
-            default:
-                break;
+                case DEBUG:
+                case INFO:
+                case WARN:
+                    System.out.format("%s: %s%n", level, msg);
+                    break;
+                case ERROR:
+                    System.err.format("%s: %s%n", level, msg);
+                    break;
+                case OFF:
+                default:
+                    break;
             }
+        }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/ReportingSet.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/ReportingSet.java
@@ -37,7 +37,6 @@ public class ReportingSet<T> implements SortedSet<T> {
     private final SortedSet<T> delegate;
     private Options duplicateOption = Options.IGNORE;
     private Log.Level duplicateLogLevel = Log.Level.WARN;
-    private Log log = DefaultLog.getInstance();
     private Function<T,String> duplicateFmt = (t) -> String.format("Duplicate %s (%s) detected %s", t.getClass(), t);
 
     public enum Options { OVERWRITE, IGNORE, FAIL }
@@ -80,17 +79,6 @@ public class ReportingSet<T> implements SortedSet<T> {
     }
 
     /**
-     * Sets the log that the reporting set will log to.
-     * if not set the DefaultLog is used.
-     * @param log the Log implementation to use.
-     * @return this for chaining.
-     */
-    public ReportingSet<T> setLog(Log log) {
-        this.log = log;
-        return this;
-    }
-
-    /**
      * Sets the log level that the reporting set will log at.
      * if not set the default level is WARN.
      * @param level the log level to use.
@@ -103,7 +91,7 @@ public class ReportingSet<T> implements SortedSet<T> {
 
     private ReportingSet<T> sameConfig(SortedSet<T> delegate) {
         ReportingSet<T> result = delegate instanceof ReportingSet ? (ReportingSet<T>) delegate : new ReportingSet<>(delegate);
-        return result.setDuplicateOption(this.duplicateOption).setLog(this.log).setLogLevel(this.duplicateLogLevel);
+        return result.setDuplicateOption(this.duplicateOption).setLogLevel(this.duplicateLogLevel);
     }
 
     /**
@@ -131,7 +119,7 @@ public class ReportingSet<T> implements SortedSet<T> {
             String msg = String.format("%s",ReportingSet.this.duplicateFmt.apply(e));
             if (reportDup) {
                 msg =  String.format( "%s (action: %s)", msg, duplicateOption);
-                log.log(duplicateLogLevel, msg);
+                DefaultLog.getInstance().log(duplicateLogLevel, msg);
             }
             switch (duplicateOption) {
             case FAIL:

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/ArchiveWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/ArchiveWalker.java
@@ -38,13 +38,13 @@ import org.apache.rat.api.Document;
 import org.apache.rat.api.RatException;
 import org.apache.rat.document.impl.ArchiveEntryDocument;
 import org.apache.rat.report.RatReport;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.DefaultLog;
 
 /**
  * Walks various kinds of archives files
  */
 public class ArchiveWalker extends Walker {
-    private final Log log;
+
 
     /**
      * Constructs a walker.
@@ -53,7 +53,6 @@ public class ArchiveWalker extends Walker {
      */
     public ArchiveWalker(final ReportConfiguration config, final Document document) {
         super(document, config.getFilesToIgnore());
-        this.log = config.getLog();
     }
 
     /**
@@ -64,7 +63,7 @@ public class ArchiveWalker extends Walker {
      *
      */
     public void run(final RatReport report) throws RatException {
-        for (Document document : getDocuments(log)) {
+        for (Document document : getDocuments()) {
             report.report(document);
         }
     }
@@ -79,11 +78,10 @@ public class ArchiveWalker extends Walker {
     }
     /**
      * Retrieves the documents from the archive.
-     * @param log The log to write messages to.
      * @return A collection of documents that pass the file filter.
      * @throws RatException on error.
      */
-    public Collection<Document> getDocuments(final Log log) throws RatException {
+    public Collection<Document> getDocuments() throws RatException {
         List<Document> result = new ArrayList<>();
         try (ArchiveInputStream<? extends ArchiveEntry> input = new ArchiveStreamFactory().createArchiveInputStream(createInputStream())) {
             ArchiveEntry entry = null;
@@ -96,7 +94,7 @@ public class ArchiveWalker extends Walker {
                 }
             }
         } catch (ArchiveException e) {
-            log.warn(String.format("Unable to process %s: %s", getDocument().getName(), e.getMessage()));
+            DefaultLog.getInstance().warn(String.format("Unable to process %s: %s", getDocument().getName(), e.getMessage()));
         } catch (IOException e) {
             throw RatException.asRatException(e);
         }

--- a/apache-rat-core/src/test/java/org/apache/rat/DefaultsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/DefaultsTest.java
@@ -29,7 +29,6 @@ import java.util.TreeSet;
 
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
-import org.apache.rat.utils.DefaultLog;
 import org.junit.jupiter.api.Test;
 
 
@@ -39,7 +38,7 @@ public class DefaultsTest {
 
     @Test
     public void defaultConfigTest() {
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
 
         Set<ILicense> licenses = defaults.getLicenseSetFactory().getLicenses(LicenseFilter.ALL);
 

--- a/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
@@ -99,8 +99,8 @@ public class OptionCollectionTest {
         } finally {
             DefaultLog.setInstance(null);
         }
-        log.assertContainsExactly(1, "WARN: Option [-d, --dir] used.  Deprecated for removal since 0.17: Use '--'");
-        log.assertContainsExactly(1, "WARN: Option [-a] used.  Deprecated for removal since 0.17: Use '--edit-license'");
+        log.assertContainsExactly(1, "WARN: Option [-d, --dir] used.  Deprecated for removal since 0.17: Use the standard '--'");
+        log.assertContainsExactly(1, "WARN: Option [-a] used.  Deprecated for removal since 0.17: Use --edit-license");
     }
 
     @Test
@@ -116,7 +116,7 @@ public class OptionCollectionTest {
             DefaultLog.setInstance(null);
         }
         assertThat(config).isNotNull();
-        log.assertContainsExactly(1,"WARN: Option [-d, --dir] used.  Deprecated for removal since 0.17: Use '--'");
+        log.assertContainsExactly(1,"WARN: Option [-d, --dir] used.  Deprecated for removal since 0.17: Use the standard '--'");
     }
 
     @Test
@@ -132,7 +132,7 @@ public class OptionCollectionTest {
     public void testDefaultConfiguration() throws ParseException, IOException {
         String[] empty = {};
         CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), empty);
-        ReportConfiguration config = OptionCollection.createConfiguration(DefaultLog.getInstance(), "", cl);
+        ReportConfiguration config = OptionCollection.createConfiguration("", cl);
         ReportConfigurationTest.validateDefault(config);
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
@@ -63,6 +63,7 @@ import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
 import org.apache.rat.utils.ReportingSet.Options;
 import org.apache.rat.walker.NameBasedHiddenFileFilter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -75,7 +76,13 @@ public class ReportConfigurationTest {
     @BeforeEach
     public void setup() {
         log = new TestingLog();
-        underTest = new ReportConfiguration(log);
+        DefaultLog.setInstance(log);
+        underTest = new ReportConfiguration();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        DefaultLog.setInstance(null);
     }
 
     @Test
@@ -207,8 +214,8 @@ public class ReportConfigurationTest {
     }
 
     /**
-     * Sets up underTest to have a set of licenses named after cartoon cats.
-     * {@link https://en.wikipedia.org/wiki/List_of_fictional_cats_in_comics}
+     * Sets up underTest to have a set of licenses named after
+     * <a href="https://en.wikipedia.org/wiki/List_of_fictional_cats_in_comics"></a>cartoon cats</a>
      * all in the license family catz
      */
     private void addCatz() {
@@ -222,8 +229,8 @@ public class ReportConfigurationTest {
     }
 
     /**
-     * Sets up underTest to have a set of licenses named after cartoon dogs.
-     * {@link https://en.wikipedia.org/wiki/List_of_fictional_dogs_in_comics}
+     * Sets up underTest to have a set of licenses named after
+     * <a href="https://en.wikipedia.org/wiki/List_of_fictional_dogs_in_comics"></a>cartoon cats</a>cartoon dogs</a>
      * all in the license family dogz
      */
     private void addDogz() {
@@ -330,7 +337,7 @@ public class ReportConfigurationTest {
 
         assertThat(underTest.getFilesToIgnore()).isExactlyInstanceOf(FalseFileFilter.class);
 
-        underTest.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        underTest.setFrom(Defaults.builder().build());
         assertThat(underTest.getFilesToIgnore()).isExactlyInstanceOf(FalseFileFilter.class);
 
         IOFileFilter filter = mock(IOFileFilter.class);
@@ -342,7 +349,7 @@ public class ReportConfigurationTest {
     public void directoriesToIgnoreTest() {
         assertThat(underTest.getDirectoriesToIgnore()).isExactlyInstanceOf(NameBasedHiddenFileFilter.class);
 
-        underTest.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        underTest.setFrom(Defaults.builder().build());
         assertThat(underTest.getDirectoriesToIgnore()).isExactlyInstanceOf(NameBasedHiddenFileFilter.class);
 
         underTest.setDirectoriesToIgnore(DirectoryFileFilter.DIRECTORY);
@@ -357,7 +364,7 @@ public class ReportConfigurationTest {
     public void archiveProcessingTest() {
         assertThat(underTest.getArchiveProcessing()).isEqualTo(ReportConfiguration.Processing.NOTIFICATION);
 
-        underTest.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        underTest.setFrom(Defaults.builder().build());
         assertThat(underTest.getArchiveProcessing()).isEqualTo(ReportConfiguration.Processing.NOTIFICATION);
 
         underTest.setArchiveProcessing(ReportConfiguration.Processing.ABSENCE);
@@ -505,7 +512,7 @@ public class ReportConfigurationTest {
     
     @Test
     public void testSetOut() throws IOException {
-        ReportConfiguration config = new ReportConfiguration(log);
+        ReportConfiguration config = new ReportConfiguration();
         try (OutputStreamInterceptor osi = new OutputStreamInterceptor()) {
             config.setOut(() -> osi);
             assertThat(osi.closeCount).isEqualTo(0);

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportTest.java
@@ -42,7 +42,7 @@ public class ReportTest {
     public void testOutputOption() throws Exception {
         File output = new File(tempDirectory, "test");
         CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{"-o", output.getCanonicalPath()});
-        ReportConfiguration config = OptionCollection.createConfiguration(DefaultLog.getInstance(), "target/test-classes/elements", cl);
+        ReportConfiguration config = OptionCollection.createConfiguration("target/test-classes/elements", cl);
         new Reporter(config).output();
         assertTrue(output.exists());
         String content = FileUtils.readFileToString(output, StandardCharsets.UTF_8);

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
@@ -61,7 +61,7 @@ public class ReporterTest {
     public void testOutputOption() throws Exception {
         File output = new File(tempDirectory, "test");
         CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), new String[] { "-o", output.getCanonicalPath()});
-        ReportConfiguration config = OptionCollection.createConfiguration(DefaultLog.getInstance(), "target/test-classes/elements", cl);
+        ReportConfiguration config = OptionCollection.createConfiguration("target/test-classes/elements", cl);
         new Reporter(config).output();
         assertTrue(output.exists());
         String content = FileUtils.readFileToString(output, StandardCharsets.UTF_8);
@@ -78,7 +78,7 @@ public class ReporterTest {
         try (PrintStream out = new PrintStream(output)){
             System.setOut(out);
             CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), new String[] {});
-            ReportConfiguration config = OptionCollection.createConfiguration(DefaultLog.getInstance(), "target/test-classes/elements", cl);
+            ReportConfiguration config = OptionCollection.createConfiguration("target/test-classes/elements", cl);
             new Reporter(config).output();
         } finally {
             System.setOut(origin);
@@ -114,7 +114,7 @@ public class ReporterTest {
         PrintStream origin = System.out;
 
         CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), new String[] { "--output-style", "xml", "--output-file", output.getPath() });
-        ReportConfiguration config = OptionCollection.createConfiguration(DefaultLog.getInstance(), "target/test-classes/elements", cl);
+        ReportConfiguration config = OptionCollection.createConfiguration("target/test-classes/elements", cl);
         new Reporter(config).output();
 
         assertTrue(output.exists());
@@ -204,11 +204,11 @@ public class ReporterTest {
 
     @Test
     public void xmlReportTest() throws Exception {
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
-        final ReportConfiguration configuration = new ReportConfiguration(DefaultLog.getInstance());
+        final ReportConfiguration configuration = new ReportConfiguration();
         configuration.setStyleSheet(StyleSheets.XML.getStyleSheet());
         configuration.setFrom(defaults);
         configuration.setDirectoriesToIgnore(HiddenFileFilter.HIDDEN);
@@ -256,11 +256,11 @@ public class ReporterTest {
 
     @Test
     public void plainReportTest() throws Exception {
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
-        final ReportConfiguration configuration = new ReportConfiguration(DefaultLog.getInstance());
+        final ReportConfiguration configuration = new ReportConfiguration();
         configuration.setFrom(defaults);
         configuration.setDirectoriesToIgnore(HiddenFileFilter.HIDDEN);
         configuration.setReportable(new DirectoryWalker(configuration, new FileDocument(new File(elementsPath))));
@@ -315,11 +315,11 @@ public class ReporterTest {
 
     @Test
     public void UnapprovedLicensesReportTest() throws Exception {
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
-        final ReportConfiguration configuration = new ReportConfiguration(DefaultLog.getInstance());
+        final ReportConfiguration configuration = new ReportConfiguration();
         configuration.setFrom(defaults);
         configuration.setDirectoriesToIgnore(HiddenFileFilter.HIDDEN);
         configuration.setReportable(new DirectoryWalker(configuration, new FileDocument(new File(elementsPath))));

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/DefaultAnalyserFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/DefaultAnalyserFactoryTest.java
@@ -48,7 +48,7 @@ public class DefaultAnalyserFactoryTest {
     public void setUp() throws Exception {
         out = new StringWriter();
         reporter = new SimpleXmlClaimReporter(new XmlWriter(out));
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        ReportConfiguration config = new ReportConfiguration();
         config.addLicense(UnknownLicense.INSTANCE);
         analyser = DefaultAnalyserFactory.createDefaultAnalyser(config);
     }
@@ -107,8 +107,8 @@ public class DefaultAnalyserFactoryTest {
     public void archiveTypeAnalyserTest() throws Exception {
         final Document document = new FileDocument(
                 Resources.getResourceFile("/elements/dummy.jar"));
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
+        ReportConfiguration config = new ReportConfiguration();
         config.setFrom(defaults);
         config.setFilesToIgnore(FalseFileFilter.FALSE);
         analyser = DefaultAnalyserFactory.createDefaultAnalyser(config);
@@ -121,8 +121,8 @@ public class DefaultAnalyserFactoryTest {
     public void archivesAbsenceTest() throws Exception {
         final Document document = new FileDocument(
                 Resources.getResourceFile("/elements/dummy.jar"));
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
+        ReportConfiguration config = new ReportConfiguration();
         config.setFrom(defaults);
         config.setFilesToIgnore(FalseFileFilter.FALSE);
         config.setArchiveProcessing(ReportConfiguration.Processing.ABSENCE);
@@ -139,8 +139,8 @@ public class DefaultAnalyserFactoryTest {
     public void archivesPresenceTest() throws Exception {
         final Document document = new FileDocument(
                 Resources.getResourceFile("/elements/dummy.jar"));
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
+        ReportConfiguration config = new ReportConfiguration();
         config.setFrom(defaults);
         config.setFilesToIgnore(FalseFileFilter.FALSE);
         config.setArchiveProcessing(ReportConfiguration.Processing.PRESENCE);
@@ -217,8 +217,8 @@ public class DefaultAnalyserFactoryTest {
     @Test
     public void standardNotificationTest() throws Exception {
 
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
+        ReportConfiguration config = new ReportConfiguration();
         config.setFrom(defaults);
         config.setFilesToIgnore(FalseFileFilter.FALSE);
         config.setStandardProcessing(ReportConfiguration.Processing.NOTIFICATION);
@@ -238,8 +238,8 @@ public class DefaultAnalyserFactoryTest {
     @Test
     public void standardAbsenceTest() throws Exception {
 
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
+        ReportConfiguration config = new ReportConfiguration();
         config.setFrom(defaults);
         config.setFilesToIgnore(FalseFileFilter.FALSE);
         config.setStandardProcessing(ReportConfiguration.Processing.ABSENCE);
@@ -258,8 +258,8 @@ public class DefaultAnalyserFactoryTest {
 
     @Test
     public void standardPresenceTest() throws Exception {
-        Defaults defaults = Defaults.builder().build(DefaultLog.getInstance());
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
+        Defaults defaults = Defaults.builder().build();
+        ReportConfiguration config = new ReportConfiguration();
         config.setFrom(defaults);
         config.setFilesToIgnore(FalseFileFilter.FALSE);
         config.setStandardProcessing(ReportConfiguration.Processing.PRESENCE);

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/TikaProcessorTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/TikaProcessorTest.java
@@ -57,27 +57,27 @@ public class TikaProcessorTest {
                 throw new MalformedInputException(0);
             }
         });
-        assertThrows(RatDocumentAnalysisException.class, () -> TikaProcessor.process(DefaultLog.getInstance(), doc));
+        assertThrows(RatDocumentAnalysisException.class, () -> TikaProcessor.process(doc));
     }
 
     @Test
     public void UTF16_input() throws Exception {
         Document doc = getDocument(Resources.getResourceStream("/binaries/UTF16_with_signature.xml"));
-        TikaProcessor.process(DefaultLog.getInstance(), doc);
+        TikaProcessor.process(doc);
         assertEquals(Document.Type.STANDARD, doc.getMetaData().getDocumentType());
     }
 
     @Test
     public void UTF8_input() throws Exception {
         FileDocument doc = new FileDocument(Resources.getResourceFile("/binaries/UTF8_with_signature.xml"));
-        TikaProcessor.process(DefaultLog.getInstance(), doc);
+        TikaProcessor.process(doc);
         assertEquals(Document.Type.STANDARD, doc.getMetaData().getDocumentType());
     }
 
     @Test
     public void missNamedBinaryTest() throws Exception {
         FileDocument doc = new FileDocument(Resources.getResourceFile("/binaries/Image-png.not"));
-        TikaProcessor.process(DefaultLog.getInstance(), doc);
+        TikaProcessor.process(doc);
         assertEquals(Document.Type.BINARY, doc.getMetaData().getDocumentType());
     }
 
@@ -85,21 +85,21 @@ public class TikaProcessorTest {
     @Test
     public void plainTextTest() throws Exception {
         FileDocument doc = new FileDocument(Resources.getResourceFile("/elements/Text.txt"));
-        TikaProcessor.process(DefaultLog.getInstance(), doc);
+        TikaProcessor.process(doc);
         assertEquals(Document.Type.STANDARD, doc.getMetaData().getDocumentType());
     }
 
     @Test
     public void emptyFileTest() throws Exception {
         FileDocument doc = new FileDocument(Resources.getResourceFile("/elements/sub/Empty.txt"));
-        TikaProcessor.process(DefaultLog.getInstance(), doc);
+        TikaProcessor.process(doc);
         assertEquals(Document.Type.STANDARD, doc.getMetaData().getDocumentType());
     }
 
     @Test
     public void javaFileWithChineseCharacters_RAT301() throws Exception {
         FileDocument doc = new FileDocument(Resources.getResourceFile("/tikaFiles/standard/ChineseCommentsJava.java"));
-        TikaProcessor.process(DefaultLog.getInstance(), doc);
+        TikaProcessor.process(doc);
         assertEquals(Document.Type.STANDARD, doc.getMetaData().getDocumentType());
     }
 
@@ -113,7 +113,7 @@ public class TikaProcessorTest {
             if (typeDir.isDirectory()) {
                 for (File file : Objects.requireNonNull(typeDir.listFiles())) {
                     Document doc = new FileDocument(file);
-                    String mimeType = TikaProcessor.process(DefaultLog.getInstance(), doc);
+                    String mimeType = TikaProcessor.process(doc);
                     statistic.incCounter(doc.getMetaData().getDocumentType(), 1);
                     assertEquals( docType, doc.getMetaData().getDocumentType(), () -> "Wrong type for "+file.toString());
                     unseenMime.remove(mimeType);

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/TikaProcessorTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/TikaProcessorTest.java
@@ -115,7 +115,7 @@ public class TikaProcessorTest {
                     Document doc = new FileDocument(file);
                     String mimeType = TikaProcessor.process(doc);
                     statistic.incCounter(doc.getMetaData().getDocumentType(), 1);
-                    assertEquals( docType, doc.getMetaData().getDocumentType(), () -> "Wrong type for "+file.toString());
+                    assertEquals( docType, doc.getMetaData().getDocumentType(), () -> "Wrong type for " +file.toString());
                     unseenMime.remove(mimeType);
                 }
             }

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/license/AbstractLicenseTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/license/AbstractLicenseTest.java
@@ -57,7 +57,7 @@ abstract public class AbstractLicenseTest {
     @BeforeEach
     public void setup() {
         data = new MetaData();
-        defaults = Defaults.builder().build(DefaultLog.getInstance());
+        defaults = Defaults.builder().build();
     }
 
     protected ILicense extractCategory(String famId, String id) {

--- a/apache-rat-core/src/test/java/org/apache/rat/annotation/TestLicenseAppender.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/annotation/TestLicenseAppender.java
@@ -72,7 +72,7 @@ public class TestLicenseAppender {
 
         createTestFile(name, creator);
 
-        ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender(DefaultLog.getInstance());
+        ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
         appender.append(new File(name));
 
         try (BufferedReader r = new BufferedReader(new FileReader(name + ".new"))) {
@@ -106,7 +106,7 @@ public class TestLicenseAppender {
 
         File file = new File(filename);
         file.deleteOnExit();
-        ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender(DefaultLog.getInstance());
+        ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
         appender.append(file);
 
         File newFile = new File(filename + ".new");
@@ -470,7 +470,7 @@ public class TestLicenseAppender {
     public void fileWithBOM() throws IOException {
         File f = Resources.getResourceFile("violations/FilterTest.cs");
 
-        ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender(DefaultLog.getInstance());
+        ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
         appender.append(f);
 
         try (BufferedReader r = new BufferedReader(new FileReader(f.getAbsolutePath() + ".new"))) {
@@ -651,7 +651,7 @@ public class TestLicenseAppender {
         try {
             createTestFile(name, phpCreator);
 
-            ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender(DefaultLog.getInstance());
+            ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
             appender.setForce(true);
             appender.append(new File(name));
 
@@ -684,7 +684,7 @@ public class TestLicenseAppender {
             createTestFile(name, phpCreator);
             assertTrue(new File(name).setExecutable(true), "Unable to set executable flag");
 
-            ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender(DefaultLog.getInstance());
+            ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
             appender.setForce(true);
             appender.append(new File(name));
 

--- a/apache-rat-core/src/test/java/org/apache/rat/annotation/TestLicenseAppender.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/annotation/TestLicenseAppender.java
@@ -637,7 +637,7 @@ public class TestLicenseAppender {
     }
 
     @Test
-    public void TestOverwrite() throws IOException {
+    public void testOverwrite() throws IOException {
         String filename = "tmp.php";
         final String firstLine = "<?php";
 

--- a/apache-rat-core/src/test/java/org/apache/rat/annotation/TestLicenseAppender.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/annotation/TestLicenseAppender.java
@@ -637,7 +637,7 @@ public class TestLicenseAppender {
     }
 
     @Test
-    public void testForced() throws IOException {
+    public void TestOverwrite() throws IOException {
         String filename = "tmp.php";
         final String firstLine = "<?php";
 
@@ -652,7 +652,7 @@ public class TestLicenseAppender {
             createTestFile(name, phpCreator);
 
             ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
-            appender.setForce(true);
+            appender.setOverwrite(true);
             appender.append(new File(name));
 
             assertFalse(new File(name + ".new").exists());
@@ -685,7 +685,7 @@ public class TestLicenseAppender {
             assertTrue(new File(name).setExecutable(true), "Unable to set executable flag");
 
             ApacheV2LicenseAppender appender = new ApacheV2LicenseAppender();
-            appender.setForce(true);
+            appender.setOverwrite(true);
             appender.append(new File(name));
 
             assertFalse(new File(name + ".new").exists());

--- a/apache-rat-core/src/test/java/org/apache/rat/commandline/InputArgsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/commandline/InputArgsTest.java
@@ -54,7 +54,7 @@ public class InputArgsTest {
 
     @Test
     public void parseExclusionsTest() {
-        final Optional<IOFileFilter> filter = Arg.parseExclusions(DefaultLog.getInstance(), Arrays.asList("", " # foo/bar", "foo", "##", " ./foo/bar"));
+        final Optional<IOFileFilter> filter = Arg.parseExclusions(Arrays.asList("", " # foo/bar", "foo", "##", " ./foo/bar"));
         assertThat(filter).isPresent();
         assertThat(filter.get()).isExactlyInstanceOf(OrFileFilter.class);
         assertTrue(filter.get().accept(baseDir, "./foo/bar" ), "./foo/bar");
@@ -73,20 +73,25 @@ public class InputArgsTest {
     @MethodSource("exclusionsProvider")
     public void testParseExclusions(String pattern, List<IOFileFilter> expectedPatterns, List<String> logEntries) {
         TestingLog log = new TestingLog();
-        Optional<IOFileFilter> filter = Arg.parseExclusions(log, Collections.singletonList(pattern));
-        if (expectedPatterns.isEmpty()) {
-            assertThat(filter).isEmpty();
-        } else {
-            assertThat(filter).isNotEmpty();
-            assertInstanceOf(OrFileFilter.class, filter.get());
-            String result = filter.toString();
-            for (IOFileFilter expectedFilter : expectedPatterns) {
-                TextUtils.assertContains(expectedFilter.toString(), result);
+        DefaultLog.setInstance(log);
+        try {
+            Optional<IOFileFilter> filter = Arg.parseExclusions(Collections.singletonList(pattern));
+            if (expectedPatterns.isEmpty()) {
+                assertThat(filter).isEmpty();
+            } else {
+                assertThat(filter).isNotEmpty();
+                assertInstanceOf(OrFileFilter.class, filter.get());
+                String result = filter.toString();
+                for (IOFileFilter expectedFilter : expectedPatterns) {
+                    TextUtils.assertContains(expectedFilter.toString(), result);
+                }
             }
-        }
-        assertEquals(log.isEmpty(), logEntries.isEmpty());
-        for (String logEntry : logEntries) {
-            log.assertContains(logEntry);
+            assertEquals(log.isEmpty(), logEntries.isEmpty());
+            for (String logEntry : logEntries) {
+                log.assertContains(logEntry);
+            }
+        } finally {
+            DefaultLog.setInstance(null);
         }
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/configuration/XMLConfigurationWriterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/configuration/XMLConfigurationWriterTest.java
@@ -46,8 +46,8 @@ public class XMLConfigurationWriterTest {
 
     @Test
     public void roundTrip() throws RatException {
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
-        config.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        ReportConfiguration config = new ReportConfiguration();
+        config.setFrom(Defaults.builder().build());
         config.listFamilies(LicenseFilter.ALL);
         config.listLicenses(LicenseFilter.ALL);
         XMLConfigurationWriter underTest = new XMLConfigurationWriter(config);
@@ -63,8 +63,8 @@ public class XMLConfigurationWriterTest {
     
     @Test
     public void testGen() throws Exception {
-        ReportConfiguration config = new ReportConfiguration(DefaultLog.getInstance());
-        config.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        ReportConfiguration config = new ReportConfiguration();
+        config.setFrom(Defaults.builder().build());
         config.listFamilies(LicenseFilter.ALL);
         config.listLicenses(LicenseFilter.ALL);
         XMLConfigurationWriter underTest = new XMLConfigurationWriter(config);

--- a/apache-rat-core/src/test/java/org/apache/rat/configuration/builders/TextBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/configuration/builders/TextBuilderTest.java
@@ -54,8 +54,8 @@ public class TextBuilderTest {
         attributes.put("id", "IDValue");
 
         Description description = DescriptionBuilder.buildMap(underTest.builtClass());
-        description.setChildren(DefaultLog.getInstance(), underTest, attributes);
-        description.setChild(DefaultLog.getInstance(), underTest, "simpleText", "example text");
+        description.setChildren(underTest, attributes);
+        description.setChild(underTest, "simpleText", "example text");
 
         SimpleTextMatcher m = underTest.build();
         assertEquals("example text", m.getSimpleText());
@@ -84,8 +84,8 @@ public class TextBuilderTest {
         TextBuilder underTest = new TextBuilder();
 
         Description description = DescriptionBuilder.buildMap(underTest.builtClass());
-        description.setChildren(DefaultLog.getInstance(), underTest, attributes);
-        description.setChild(DefaultLog.getInstance(), underTest, "simpleText", "exampletext");
+        description.setChildren(underTest, attributes);
+        description.setChild(underTest, "simpleText", "exampletext");
 
         SimpleTextMatcher m = underTest.build();
         assertEquals("exampletext", m.getSimpleText());

--- a/apache-rat-core/src/test/java/org/apache/rat/license/SimpleLicenseTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/license/SimpleLicenseTest.java
@@ -48,11 +48,11 @@ public class SimpleLicenseTest {
         Map<String, Description> children = underTest.getChildren();
         assertEquals(6, children.size());
         assertTrue(children.containsKey("id"));
-        assertEquals("TestingId", children.get("id").getParamValue(DefaultLog.getInstance(), lic));
+        assertEquals("TestingId", children.get("id").getParamValue(lic));
         assertTrue(children.containsKey("name"));
-        assertEquals("My testing license", children.get("name").getParamValue(DefaultLog.getInstance(), lic));
+        assertEquals("My testing license", children.get("name").getParamValue(lic));
         assertTrue(children.containsKey("note"));
-        assertEquals("These are the notes", children.get("note").getParamValue(DefaultLog.getInstance(), lic));
+        assertEquals("These are the notes", children.get("note").getParamValue(lic));
 
         assertTrue(children.containsKey("matcher"));
         assertEquals(ComponentType.PARAMETER, children.get("matcher").getType());

--- a/apache-rat-core/src/test/java/org/apache/rat/policy/DefaultPolicyTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/policy/DefaultPolicyTest.java
@@ -62,7 +62,7 @@ public class DefaultPolicyTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        defaults = Defaults.builder().build(DefaultLog.getInstance());
+        defaults = Defaults.builder().build();
         policy = new DefaultPolicy(defaults.getLicenseSetFactory().getLicenseFamilies(LicenseFilter.APPROVED));
         document = new TestingDocument("subject");
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/report/ConfigurationReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/ConfigurationReportTest.java
@@ -44,7 +44,6 @@ import org.w3c.dom.Node;
 public class ConfigurationReportTest {
 
     private ConfigurationReport report;
-    private ReportConfiguration reportConfiguration;
     private StringWriter sw;
     private IXmlWriter writer;
 
@@ -52,10 +51,10 @@ public class ConfigurationReportTest {
 
     @BeforeEach
     public void setup() {
-        reportConfiguration = new ReportConfiguration(DefaultLog.getInstance());
+        ReportConfiguration reportConfiguration = new ReportConfiguration();
         reportConfiguration.listFamilies(LicenseFilter.ALL);
         reportConfiguration.listLicenses(LicenseFilter.ALL);
-        reportConfiguration.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        reportConfiguration.setFrom(Defaults.builder().build());
 
         sw = new StringWriter();
         writer = new XmlWriter(sw);

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -71,9 +71,9 @@ public class XmlReportFactoryTest {
     @Test
     public void standardReport() throws Exception {
         final String elementsPath = Resources.getResourceDirectory("elements/Source.java");
-        final ReportConfiguration configuration = new ReportConfiguration(DefaultLog.getInstance());
+        final ReportConfiguration configuration = new ReportConfiguration();
         final TestingLicense testingLicense = new TestingLicense("TEST", new TestingMatcher(true), family);
-        configuration.setFrom(Defaults.builder().build(DefaultLog.getInstance()));
+        configuration.setFrom(Defaults.builder().build());
         configuration.setDirectoriesToIgnore(HiddenFileFilter.HIDDEN);
         DirectoryWalker directory = new DirectoryWalker(configuration, new FileDocument(new File(elementsPath)));
         final ClaimStatistic statistic = new ClaimStatistic();
@@ -103,7 +103,7 @@ public class XmlReportFactoryTest {
         when(mockLicense.getLicenseFamily()).thenReturn(family);
 
         final ClaimStatistic statistic = new ClaimStatistic();
-        final ReportConfiguration configuration = new ReportConfiguration(DefaultLog.getInstance());
+        final ReportConfiguration configuration = new ReportConfiguration();
         // configuration.addLicense(mockLicense);
         try {
             XmlReportFactory.createStandardReport(writer, statistic, configuration);

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
@@ -34,7 +34,7 @@ import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.utils.DefaultLog;
-import org.apache.rat.utils.Log;
+import org.apache.rat.utils.Log.Level;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 
@@ -438,9 +438,9 @@ public abstract class AbstractOptionsProvider {
     protected void logLevelTest() {
         Option option = Arg.LOG_LEVEL.find("log-level");
         String[] args = {null};
-        Log.Level logLevel = ((DefaultLog) DefaultLog.getInstance()).getLevel();
+        Level logLevel = ((DefaultLog) DefaultLog.getInstance()).getLevel();
         try {
-            for (Log.Level level : Log.Level.values()) {
+            for (Level level : Level.values()) {
                 try {
                     args[0] = level.name();
                     ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));

--- a/apache-rat-core/src/test/java/org/apache/rat/walker/DirectoryWalkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/walker/DirectoryWalkerTest.java
@@ -54,7 +54,7 @@ public class DirectoryWalkerTest {
 
     @BeforeEach
     public void beforeEach() {
-        reportConfiguration = new ReportConfiguration(DefaultLog.getInstance());
+        reportConfiguration = new ReportConfiguration();
     }
 
     @BeforeAll

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatReportMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/RatReportMojo.java
@@ -392,7 +392,7 @@ public class RatReportMojo extends AbstractRatMojo implements MavenMultiPageRepo
         sink.verbatim(SinkEventAttributeSet.BOXED);
         try {
             ReportConfiguration config = getConfiguration();
-            config.setFrom(getDefaultsBuilder().build(config.getLog()));
+            config.setFrom(getDefaultsBuilder().build());
             logLicenses(config.getLicenses(LicenseFilter.ALL));
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             config.setOut(() -> baos);

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
@@ -96,8 +96,7 @@ public class Report extends BaseAntTask {
      * Constructor.
      */
     public Report() {
-        Logger log = new Logger();
-        DefaultLog.setInstance(log);
+        DefaultLog.setInstance(new Logger());
     }
 
     /**

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/Documentation.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/Documentation.java
@@ -144,7 +144,7 @@ public final class Documentation {
 
     private static void printUsage(final Options opts) {
         HelpFormatter f = new HelpFormatter();
-        f.setOptionComparator(new OptionCollection.OptionComparator());
+        f.setOptionComparator(OptionCollection.optionComparator);
         f.setWidth(PAGE_WIDTH);
         String header = "\nAvailable options";
         String footer = "";


### PR DESCRIPTION
Part of RAT-323

Remove most passing of LOG instances in favour of using DefaultLog.getInstance() to retrieve it where necessary.
