### PR TITLE
RAT-430: fixed checkstyle issues in report/xml

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/IXmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/IXmlWriter.java
@@ -15,7 +15,7 @@
  * KIND, either express or implied.  See the License for the    *
  * specific language governing permissions and limitations      *
  * under the License.                                           *
- */ 
+ */
 package org.apache.rat.report.xml.writer;
 
 import java.io.IOException;
@@ -32,61 +32,61 @@ public interface IXmlWriter extends AutoCloseable {
      * Calling this method is optional.
      * When writing a document fragment, it should <em>not</em> be called.
      * @return this object
-     * @throws OperationNotAllowedException 
+     * @throws OperationNotAllowedException
      * if called after the first element has been written
      * or once a prolog has already been written
      */
     IXmlWriter startDocument() throws IOException;
-    
+
     /**
      * Writes the start of an element.
-     * 
+     *
      * @param elementName the name of the element, not null
-     * @return this object 
+     * @return this object
      * @throws InvalidXmlException if the name is not valid for an xml element
-     * @throws OperationNotAllowedException 
+     * @throws OperationNotAllowedException
      * if called after the first element has been closed
      */
     IXmlWriter openElement(CharSequence elementName) throws IOException;
-    
+
     /**
      * Writes a comment
-     * 
+     *
      * @param text the comment text
-     * @return this object 
-     * @throws OperationNotAllowedException 
+     * @return this object
+     * @throws OperationNotAllowedException
      * if called after the first element has been closed
      */
     IXmlWriter comment(CharSequence text) throws IOException;
-    
+
     /**
      * Writes an attribute of an element.
      * Note that this is only allowed directly after {@link #openElement(CharSequence)}
      * or {@link #attribute}.
-     * 
+     *
      * @param name the attribute name, not null
      * @param value the attribute value, not null
      * @return this object
-     * @throws InvalidXmlException if the name is not valid for an xml attribute 
+     * @throws InvalidXmlException if the name is not valid for an xml attribute
      * or if a value for the attribute has already been written
-     * @throws OperationNotAllowedException if called after {@link #content(CharSequence)} 
+     * @throws OperationNotAllowedException if called after {@link #content(CharSequence)}
      * or {@link #closeElement()} or before any call to {@link #openElement(CharSequence)}
      */
     IXmlWriter attribute(CharSequence name, CharSequence value) throws IOException;
-    
+
     /**
      * Writes content.
      * Note that this method does not support CDATA.
      * This method automatically escapes characters.
-     * 
+     *
      * @param content the content to write
      * @return this object
-     * @throws OperationNotAllowedException 
-     * if called before any call to {@link #openElement} 
+     * @throws OperationNotAllowedException
+     * if called before any call to {@link #openElement}
      * or after the first element has been closed
      */
     IXmlWriter content(CharSequence content) throws IOException;
-    
+
     /**
      * Writes CDATA content.
      * This method DOES NOT automatically escape characters.
@@ -94,18 +94,18 @@ public interface IXmlWriter extends AutoCloseable {
      *
      * @param content the content to write
      * @return this object
-     * @throws OperationNotAllowedException 
-     * if called before any call to {@link #openElement} 
+     * @throws OperationNotAllowedException
+     * if called before any call to {@link #openElement}
      * or after the first element has been closed
      */
     IXmlWriter cdata(CharSequence content) throws IOException;
-    
+
     /**
      * Closes the last element written.
-     * 
+     *
      * @return this object
-     * @throws OperationNotAllowedException 
-     * if called before any call to {@link #openElement} 
+     * @throws OperationNotAllowedException
+     * if called before any call to {@link #openElement}
      * or after the first element has been closed
      */
     IXmlWriter closeElement() throws IOException;
@@ -126,10 +126,10 @@ public interface IXmlWriter extends AutoCloseable {
      * When appropriate, resources are also flushed and closed.
      * No exception is raised when called upon a document whose
      * root element has already been closed.
-     * 
+     *
      * @return this object
-     * @throws OperationNotAllowedException 
-     * if called before any call to {@link #openElement} 
+     * @throws OperationNotAllowedException
+     * if called before any call to {@link #openElement}
      */
     IXmlWriter closeDocument() throws IOException;
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/OperationNotAllowedException.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/OperationNotAllowedException.java
@@ -15,7 +15,7 @@
  * KIND, either express or implied.  See the License for the    *
  * specific language governing permissions and limitations      *
  * under the License.                                           *
- */ 
+ */
 package org.apache.rat.report.xml.writer;
 
 import java.io.IOException;
@@ -28,9 +28,7 @@ public class OperationNotAllowedException extends IOException {
 
     private static final long serialVersionUID = 1L;
 
-    public OperationNotAllowedException(String message) {
+    public OperationNotAllowedException(final String message) {
         super(message);
     }
-
-    
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/impl/base/XmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/impl/base/XmlWriter.java
@@ -48,7 +48,7 @@ public final class XmlWriter implements IXmlWriter {
     private static final byte NAME_BODY_CHAR = NAME_MASK;
     private static final byte NAME_START_OR_BODY_CHAR = NAME_MASK | NAME_START_MASK;
 
-    private final static boolean[] ALLOWED_CHARACTERS = new boolean[1 << 16];
+    private static final boolean[] ALLOWED_CHARACTERS = new boolean[1 << 16];
 
     static {
         Arrays.fill(ALLOWED_CHARACTERS, false);
@@ -59,7 +59,7 @@ public final class XmlWriter implements IXmlWriter {
         Arrays.fill(ALLOWED_CHARACTERS, 0xE000, 0xFFFD, true);
     }
 
-    private final static byte[] CHARACTER_CODES = new byte[1 << 16];
+    private static final byte[] CHARACTER_CODES = new byte[1 << 16];
 
     static {
         // Name ::= (Letter | '_' | ':') (NameChar)*
@@ -408,9 +408,9 @@ public final class XmlWriter implements IXmlWriter {
     private final ArrayDeque<CharSequence> elementNames;
     private final Set<CharSequence> currentAttributes = new HashSet<>();
 
-    boolean elementsWritten = false;
-    boolean inElement = false;
-    boolean prologWritten = false;
+    private boolean elementsWritten;
+    private boolean inElement;
+    private boolean prologWritten;
 
     /**
      * Constructs an XmlWriter with the specified writer for output.
@@ -470,7 +470,7 @@ public final class XmlWriter implements IXmlWriter {
         currentAttributes.clear();
         return this;
     }
-    
+
     @Override
     public IXmlWriter comment(final CharSequence text) throws IOException {
         if (inElement) {
@@ -497,7 +497,7 @@ public final class XmlWriter implements IXmlWriter {
      * to {@link #openElement(CharSequence)}
      */
     @Override
-    public IXmlWriter attribute(CharSequence name, CharSequence value) throws IOException {
+    public IXmlWriter attribute(final CharSequence name, final CharSequence value) throws IOException {
         if (elementNames.isEmpty()) {
             if (elementsWritten) {
                 throw new OperationNotAllowedException("Root element has already been closed.");
@@ -523,7 +523,7 @@ public final class XmlWriter implements IXmlWriter {
         return this;
     }
 
-    private void writeAttributeContent(CharSequence content) throws IOException {
+    private void writeAttributeContent(final CharSequence content) throws IOException {
         writeEscaped(content, true);
     }
 
@@ -531,7 +531,7 @@ public final class XmlWriter implements IXmlWriter {
         if (elementNames.isEmpty()) {
             if (elementsWritten) {
                 throw new OperationNotAllowedException("Root element has already been closed.");
-            } 
+            }
             throw new OperationNotAllowedException("An element must be opened before content can be written.");
         }
         if (inElement) {
@@ -540,7 +540,7 @@ public final class XmlWriter implements IXmlWriter {
     }
 
     @Override
-    public IXmlWriter content(CharSequence content) throws IOException {
+    public IXmlWriter content(final CharSequence content) throws IOException {
         prepareForData();
         writeEscaped(content, false);
         inElement = false;
@@ -548,7 +548,7 @@ public final class XmlWriter implements IXmlWriter {
     }
 
     @Override
-    public IXmlWriter cdata(CharSequence content) throws IOException {
+    public IXmlWriter cdata(final CharSequence content) throws IOException {
         prepareForData();
         StringBuilder sb = new StringBuilder(content);
         int found;
@@ -556,11 +556,11 @@ public final class XmlWriter implements IXmlWriter {
             sb.replace(found, found + 3, "{rat:CDATA close}");
         }
 
-        writer.write("<![CDATA[ " );
-        for (int i=0;i<sb.length();i++) {
+        writer.write("<![CDATA[ ");
+        for (int i = 0; i < sb.length(); i++) {
             char c = sb.charAt(i);
             if (isOutOfRange(c)) {
-                writer.write(String.format("\\u%X", (int)c));
+                writer.write(String.format("\\u%X", (int) c));
             } else {
                 writer.write(c);
             }
@@ -571,7 +571,7 @@ public final class XmlWriter implements IXmlWriter {
         return this;
     }
 
-    private void writeEscaped(final CharSequence content, boolean isAttributeContent) throws IOException {
+    private void writeEscaped(final CharSequence content, final boolean isAttributeContent) throws IOException {
         final int length = content.length();
         for (int i = 0; i < length; i++) {
             char character = content.charAt(i);
@@ -609,7 +609,7 @@ public final class XmlWriter implements IXmlWriter {
         if (elementNames.isEmpty()) {
             if (elementsWritten) {
                 throw new OperationNotAllowedException("Root element has already been closed.");
-            } 
+            }
             throw new OperationNotAllowedException("Close called before an element has been opened.");
         }
         final CharSequence elementName = elementNames.pop();
@@ -635,7 +635,7 @@ public final class XmlWriter implements IXmlWriter {
      * {@link #openElement} or after the first element has been closed
      */
     @Override
-    public IXmlWriter closeElement(CharSequence name) throws IOException {
+    public IXmlWriter closeElement(final CharSequence name) throws IOException {
         Objects.requireNonNull(name);
         if (elementNames.isEmpty()) {
             if (elementsWritten) {

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/package-info.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/package-info.java
@@ -16,22 +16,7 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  */
-package org.apache.rat.report.xml.writer;
-
-import java.io.IOException;
-
 /**
- * Indicates that the requested document is not well formed.
+ * Classes to handle writing well formed XML documents.
  */
-public class InvalidXmlException extends IOException {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Instantiate exception with given message.
-     * @param message more context when this exception happens.
-     */
-    public InvalidXmlException(final String message) {
-        super(message);
-    }
-}
+package org.apache.rat.report.xml.writer;

--- a/src/conf/checkstyle-suppressions.xml
+++ b/src/conf/checkstyle-suppressions.xml
@@ -42,4 +42,8 @@
   <suppress checks="HideUtilityClassConstructor" files="OptionValidator.java" />
   <suppress checks="HideUtilityClassConstructor" files="Util.java" />
 
+  <!-- Suppress magic numbers in XMLWriter code -->
+  <suppress checks="MagicNumber|JavadocVariable" files="XmlWriter.java" />
+
+
 </suppressions>


### PR DESCRIPTION
fix for RAT-430
Ignored magic numbers nad javadoc in old XmlWriter code

Leaves an issue with `report/xml/writer/impl/base` not having a `package-info.java` file, but I think that we should probably move all the files into `report/xml/writer` after RAT-323 is completed