### PR TITLE
RAT-426: fixed checkstyle in licenses and moved ILicenseFamily builder

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
@@ -142,7 +142,7 @@ public class HeaderCheckWorker {
             licenses.stream().filter(lic -> lic.matches(headers)).forEach(document.getMetaData()::reportOnLicense);
             if (document.getMetaData().detectedLicense()) {
                 if (document.getMetaData().licenses().anyMatch(
-                        lic -> ILicenseFamily.GENTERATED_CATEGORY.equals(lic.getLicenseFamily().getFamilyCategory()))) {
+                        lic -> ILicenseFamily.GENERATED.getFamilyCategory().equals(lic.getLicenseFamily().getFamilyCategory()))) {
                     document.getMetaData().setDocumentType(Document.Type.GENERATED);
                 }
             } else {

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/HeaderCheckWorker.java
@@ -101,9 +101,9 @@ public class HeaderCheckWorker {
      * Convenience constructor wraps given <code>Reader</code> in a
      * <code>BufferedReader</code>.
      *
-     * @param reader The reader on the document. not null.
-     * @param licenses The licenses to check against. not null.
-     * @param name The document that is being checked. possibly null
+     * @param reader The reader on the document. Not null.
+     * @param licenses The licenses to check against. Not null.
+     * @param name The document that is being checked. Possibly null.
      */
     public HeaderCheckWorker(final Reader reader, final Collection<ILicense> licenses, final Document name) {
         this(reader, DEFAULT_NUMBER_OF_RETAINED_HEADER_LINES, licenses, name);
@@ -112,11 +112,11 @@ public class HeaderCheckWorker {
     /**
      * Constructs a check worker for the license against the specified document.
      *
-     * @param reader The reader on the document. not null.
+     * @param reader The reader on the document. Not null.
      * @param numberOfRetainedHeaderLine the maximum number of lines to read to find
      * the license information.
-     * @param licenses The licenses to check against. not null.
-     * @param document The document that is being checked. possibly null
+     * @param licenses The licenses to check against. Not null.
+     * @param document The document that is being checked. Possibly null.
      */
     public HeaderCheckWorker(final Reader reader, final int numberOfRetainedHeaderLine, final Collection<ILicense> licenses,
             final Document document) {

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/IHeaderMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/IHeaderMatcher.java
@@ -67,7 +67,7 @@ public interface IHeaderMatcher {
      * @return the component description.
      */
     default Description getDescription() {
-        return  DescriptionBuilder.build(this);
+        return DescriptionBuilder.build(this);
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
@@ -18,11 +18,8 @@
  */
 package org.apache.rat.analysis;
 
-import java.util.Objects;
-
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
-import org.apache.rat.license.ILicenseFamilyBuilder;
 
 /**
  * An ILicense implementation that represents an unknown license.

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/UnknownLicense.java
@@ -46,13 +46,12 @@ public final class UnknownLicense implements ILicense {
      * Do not allow other constructions.
      */
     private UnknownLicense() {
-        family = new ILicenseFamilyBuilder().setLicenseFamilyCategory(ILicenseFamily.UNKNOWN_CATEGORY)
-                .setLicenseFamilyName("Unknown license").build();
+        family = ILicenseFamily.UNKNOWN;
     }
 
     @Override
     public String getId() {
-        return ILicenseFamily.UNKNOWN_CATEGORY;
+        return family.getFamilyCategory();
     }
 
     @Override
@@ -72,7 +71,7 @@ public final class UnknownLicense implements ILicense {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(ILicenseFamily.UNKNOWN_CATEGORY);
+        return family.hashCode();
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/license/ILicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/ILicense.java
@@ -73,7 +73,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
     }
 
     /**
-     * A default implementatin of a License hash
+     * A default implementation of a License hash
      * @param license the license to hash
      * @return the license hash value
      */
@@ -167,7 +167,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
         Builder setName(String name);
 
         /**
-         * Sets the set of license families to use duirng build.
+         * Sets the set of license families to use during build.
          *
          * @param licenseFamilies the license families to use
          * @return this builder.

--- a/apache-rat-core/src/main/java/org/apache/rat/license/ILicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/ILicense.java
@@ -27,16 +27,17 @@ import org.apache.rat.analysis.IHeaderMatcher;
  * The definition of a License.
  */
 public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
+
     /**
      * Gets the license family.
-     * 
+     *
      * @return the ILicenseFamily implementation for this license.
      */
     ILicenseFamily getLicenseFamily();
 
     /**
      * Gets the note associated with the license.
-     * 
+     *
      * @return the note associated with this license. May be null or empty.
      */
     String getNote();
@@ -44,14 +45,14 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
     /**
      * Returns the name of this license. If no name was specified then the name of
      * the family is returned.
-     * 
+     *
      * @return the name of this license.
      */
     String getName();
 
     /**
      * Gets the name of the family that this license if part of.
-     * 
+     *
      * @return the name of the license family that this license is part of.
      */
     default String getFamilyName() {
@@ -60,7 +61,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
 
     /**
      * Get the header matcher for this license.
-     * 
+     *
      * @return the header matcher for this license.
      */
     IHeaderMatcher getMatcher();
@@ -87,15 +88,19 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
      * @return true if the object is equal to the license1.
      */
     static boolean equals(ILicense license1, Object o) {
-        if (license1 == o) return true;
-        if (!(o instanceof ILicense)) return false;
+        if (license1 == o) {
+            return true;
+        }
+        if (!(o instanceof ILicense)) {
+            return false;
+        }
         ILicense that = (ILicense) o;
         return license1.compareTo(that) == 0;
     }
 
     /**
      * Gets a builder for licenses.
-     * 
+     *
      * @return An ILicense.Builder instance.
      */
     static ILicense.Builder builder() {
@@ -109,7 +114,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
 
         /**
          * Sets the matcher from a builder.
-         * 
+         *
          * @param matcher the builder for the matcher for the license.
          * @return this builder for chaining.
          */
@@ -117,7 +122,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
 
         /**
          * Sets the matcher.
-         * 
+         *
          * @param matcher the matcher for the license.
          * @return this builder for chaining.
          */
@@ -126,7 +131,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
         /**
          * Sets the notes for the license. If called multiple times the notes are
          * concatenated to create a single note.
-         * 
+         *
          * @param notes the notes for the license.
          * @return this builder for chaining.
          */
@@ -135,7 +140,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
         /**
          * Sets the ID of the license. If the ID is not set then the ID of the license
          * family is used.
-         * 
+         *
          * @param id the ID for the license
          * @return this builder for chaining.
          */
@@ -146,7 +151,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
          * all licenses and must be 5 characters. If more than 5 characters are provided
          * then only the first 5 are taken. If fewer than 5 characters are provided the
          * category is padded with spaces.
-         * 
+         *
          * @param licenseFamilyCategory the family category for the license.
          * @return this builder for chaining.
          */
@@ -155,7 +160,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
         /**
          * Sets the name of the license. If the name is not set then the name of the
          * license family is used.
-         * 
+         *
          * @param name the name for the license
          * @return this builder for chaining.
          */
@@ -163,7 +168,7 @@ public interface ILicense extends IHeaderMatcher, Comparable<ILicense> {
 
         /**
          * Sets the set of license families to use duirng build.
-         * 
+         *
          * @param licenseFamilies the license families to use
          * @return this builder.
          */

--- a/apache-rat-core/src/main/java/org/apache/rat/license/ILicenseFamily.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/ILicenseFamily.java
@@ -28,7 +28,7 @@ public interface ILicenseFamily extends Comparable<ILicenseFamily> {
 
     /** The license family for unknown licenses */
     ILicenseFamily UNKNOWN = new Builder().setLicenseFamilyName("Unknown license").setLicenseFamilyCategory("?????").build();
-    /** The license family  for generated files */
+    /** The license family for generated files */
     ILicenseFamily GENERATED = new Builder().setLicenseFamilyName("Generated file").setLicenseFamilyCategory("GEN").build();
 
     /**
@@ -78,9 +78,8 @@ public interface ILicenseFamily extends Comparable<ILicenseFamily> {
         /** The name of the family */
         private String licenseFamilyName;
 
-
         /**
-         * Sets the license family category. Will trim or extends the string with spaces
+         * Sets the license family category. Will trim or extend the string with spaces
          * to ensure that it is exactly 5 characters.
          *
          * @param licenseFamilyCategory the category string

--- a/apache-rat-core/src/main/java/org/apache/rat/license/ILicenseFamilyBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/ILicenseFamilyBuilder.java
@@ -18,61 +18,10 @@
  */
 package org.apache.rat.license;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.rat.ConfigurationException;
-import org.apache.rat.license.ILicenseFamily.Builder;
-
 /**
  * An instance of the ILicenseFamily Builder.
+ * @deprecated use {@link ILicenseFamily.Builder}
  */
-public class ILicenseFamilyBuilder implements Builder {
-
-    private String licenseFamilyCategory;
-    private String licenseFamilyName;
-
-    @Override
-    public Builder setLicenseFamilyCategory(String licenseFamilyCategory) {
-        this.licenseFamilyCategory = licenseFamilyCategory;
-        return this;
-    }
-    
-
-    @Override
-    public String getCategory() {
-        return licenseFamilyCategory;
-    }
-
-    @Override
-    public Builder setLicenseFamilyName(String licenseFamilyName) {
-        this.licenseFamilyName = licenseFamilyName;
-        return this;
-    }
-
-    @Override
-    public ILicenseFamily build() {
-        if (StringUtils.isBlank(licenseFamilyCategory)) {
-            throw new ConfigurationException("LicenseFamily Category must be specified");
-        }
-        if (StringUtils.isBlank(licenseFamilyName)) {
-            throw new ConfigurationException("LicenseFamily Name must be specified");
-        }
-        return new ILicenseFamily() { 
-            private final String cat = ILicenseFamily.makeCategory(licenseFamilyCategory);
-            private final String name = licenseFamilyName;
-            @Override
-            public String toString() {
-                return String.format("%s %s", getFamilyCategory(), getFamilyName());
-            }
-
-            @Override
-            public final String getFamilyName() {
-                return name;
-            }
-
-            @Override
-            public String getFamilyCategory() {
-                return cat;
-            }
-        };
-    }
+@Deprecated
+public class ILicenseFamilyBuilder extends ILicenseFamily.Builder {
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/LicenseSetFactory.java
@@ -39,7 +39,7 @@ public class LicenseSetFactory {
     /**
      * Search a SortedSet of ILicenseFamily instances looking for a matching instance.
      * @param target The instance to search for.
-     * @param licenseFamilies the license families to search
+     * @param licenseFamilies the license families to search.
      * @return the matching instance of the target given.
      */
     public static ILicenseFamily familySearch(final String target, final SortedSet<ILicenseFamily> licenseFamilies) {
@@ -51,7 +51,7 @@ public class LicenseSetFactory {
     /**
      * Search a SortedSet of ILicenseFamily instances looking for a matching instance.
      * @param target The instance to search for.
-     * @param licenseFamilies the license families to search
+     * @param licenseFamilies the license families to search.
      * @return the matching instance of the target given.
      */
     public static ILicenseFamily familySearch(final ILicenseFamily target, final SortedSet<ILicenseFamily> licenseFamilies) {
@@ -63,11 +63,11 @@ public class LicenseSetFactory {
      * An enum that defines the types of Licenses to extract.
      */
     public enum LicenseFilter {
-        /** All defined licenses are returned */
+        /** All defined licenses are returned. */
         ALL,
-        /** Only approved licenses are returned */
+        /** Only approved licenses are returned. */
         APPROVED,
-        /** No licenses are returned */
+        /** No licenses are returned. */
         NONE
     }
 
@@ -439,7 +439,7 @@ public class LicenseSetFactory {
 
     /**
      * Search a SortedSet of licenses for the matching license.
-     * License must mach both family code, and license id.
+     * License must match both family code, and license id.
      *
      * @param target the license to search for. Must not be null.
      * @param licenses the SortedSet of licenses to search.

--- a/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicense.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicense.java
@@ -31,8 +31,6 @@ import org.apache.rat.analysis.IHeaderMatcher;
 import org.apache.rat.analysis.IHeaders;
 import org.apache.rat.config.parameters.ComponentType;
 import org.apache.rat.config.parameters.ConfigComponent;
-import org.apache.rat.config.parameters.Description;
-import org.apache.rat.config.parameters.DescriptionBuilder;
 
 /**
  * A simple implementation of ILicense.
@@ -118,11 +116,6 @@ public class SimpleLicense implements ILicense {
     @Override
     public String getName() {
         return name;
-    }
-
-    @Override
-    public Description getDescription() {
-        return DescriptionBuilder.build(this);
     }
 
     public static class Builder implements ILicense.Builder {

--- a/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicenseFamily.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicenseFamily.java
@@ -24,7 +24,7 @@ import org.apache.rat.DeprecationReporter;
  * An implementation of the ILicenseFamily.
  */
 @Deprecated // remove in v1.0
-@DeprecationReporter.Info(since = "0.17", forRemoval = true, use = "ILicenseFamilyBuilder")
+@DeprecationReporter.Info(since = "0.17", forRemoval = true, use = "ILicenseFamily.Builder")
 public class SimpleLicenseFamily  {
     private String familyName;
     private String familyCategory;

--- a/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicenseFamily.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/SimpleLicenseFamily.java
@@ -46,11 +46,9 @@ public class SimpleLicenseFamily  {
         return String.format("%s %s", getFamilyCategory(), getFamilyName());
     }
 
-
     public final String getFamilyName() {
         return familyName;
     }
-
 
     public String getFamilyCategory() {
         return familyCategory;

--- a/apache-rat-core/src/main/java/org/apache/rat/license/package-info.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/license/package-info.java
@@ -1,0 +1,21 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+* Classes describing licenses
+*/
+package org.apache.rat.license;

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/ClaimStatistic.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/ClaimStatistic.java
@@ -84,7 +84,7 @@ public class ClaimStatistic {
     /**
      * Increments the number of times the Document.Type was seen.
      * @param documentType the Document.Type to increment.
-     * @param value the vlaue to increment the counter by.
+     * @param value the value to increment the counter by.
      */
     public void incCounter(Document.Type documentType, int value) {
         documentCategoryMap.compute(documentType, (k,v)-> v == null? new IntCounter().increment(value) : v.increment(value));
@@ -101,7 +101,7 @@ public class ClaimStatistic {
 
     /**
      * Increments the number of times a license family category was seen.
-     * @param licenseFamilyCategory the License family category to incmrement.
+     * @param licenseFamilyCategory the License family category to increment.
      * @param value the value to increment the count by.
      */
     public void incLicenseCategoryCount(String licenseFamilyCategory, int value) {

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/impl/ClaimAggregator.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/impl/ClaimAggregator.java
@@ -55,9 +55,9 @@ public class ClaimAggregator extends AbstractClaimReporter {
     @Override
     protected void handleLicenseClaim(ILicense license) {
         String category = license.getLicenseFamily().getFamilyCategory();
-        if (category.equals(ILicenseFamily.GENTERATED_CATEGORY)) {
+        if (category.equals(ILicenseFamily.GENERATED.getFamilyCategory())) {
             statistic.incCounter(Counter.GENERATED, 1);
-        } else if (category.equals(ILicenseFamily.UNKNOWN_CATEGORY)) {
+        } else if (category.equals(ILicenseFamily.UNKNOWN.getFamilyCategory())) {
             statistic.incCounter(Counter.UNKNOWN, 1);
         }
         statistic.incLicenseCategoryCount(category, 1);

--- a/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/claim/util/LicenseAddingReport.java
@@ -37,7 +37,7 @@ public class LicenseAddingReport extends AbstractReport {
 
     /**
      * Creates a LicenseAddingReport that inserts the copyright message and may overwrite the files.
-     * @param copyrightMsg The message to insert into the files.  May be {@code null}.
+     * @param copyrightMsg The message to insert into the files. May be {@code null}.
      * @param overwrite if {@code true} will overwrite the files rather than create {@code .new} files.
      */
     public LicenseAddingReport(final String copyrightMsg, final boolean overwrite) {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,9 @@ The <action> type attribute can be one of:
     </release>
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-426" type="fix" dev="claudenw">
+        Fix checkstyle issues in license.
+      </action>
       <action issue="RAT-420" type="fix" dev="claudenw">
         Fix checkstyle issues in config.
       </action>


### PR DESCRIPTION
Fixed for RAT-426

Also moved ILicenseFamilyBuilder into ILicenseFamily.Builder to simplify the code.