### PR TITLE
RAT-439 checkstyle cleanup last pass

### DIFF
--- a/apache-rat-core/pom.xml
+++ b/apache-rat-core/pom.xml
@@ -79,6 +79,7 @@
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
           <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
           <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>../src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>../src/conf/checkstyle-suppressions.xml</suppressionsLocation>

--- a/apache-rat-core/pom.xml
+++ b/apache-rat-core/pom.xml
@@ -76,9 +76,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <failsOnError>false</failsOnError>
-          <failOnViolation>false</failOnViolation>
-          <excludes>**/org/apache/rat/analysis/license/**</excludes>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <failOnViolation>true</failOnViolation>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>../src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>../src/conf/checkstyle-suppressions.xml</suppressionsLocation>
         </configuration>

--- a/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
@@ -44,7 +44,7 @@ import org.apache.rat.report.RatReport;
 import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.report.xml.XmlReportFactory;
 import org.apache.rat.report.xml.writer.IXmlWriter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 import org.w3c.dom.Document;
 
 /**

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPattern.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPattern.java
@@ -26,7 +26,7 @@ import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log;
 
 import static java.lang.String.format;
-@SuppressWarnings("checkstyle:RegexpSingleLine")
+@SuppressWarnings({"checkstyle:RegexpSingleLine", "checkstyle:JavadocVariable"})
 /**
  * <p>Describes a match target for SelectorUtils.</p>
  *

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPattern.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPattern.java
@@ -26,7 +26,7 @@ import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log;
 
 import static java.lang.String.format;
-
+@SuppressWarnings("checkstyle:RegexpSingleLine")
 /**
  * <p>Describes a match target for SelectorUtils.</p>
  *

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPatterns.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPatterns.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
+@SuppressWarnings("checkstyle:RegexpSingleLine")
 /**
  * A list of patterns to be matched
  * <p>Based on code from plexus-utils.</p>

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPatterns.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/MatchPatterns.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
-@SuppressWarnings("checkstyle:RegexpSingleLine")
+@SuppressWarnings({"checkstyle:RegexpSingleLine", "checkstyle:JavadocVariable"})
 /**
  * A list of patterns to be matched
  * <p>Based on code from plexus-utils.</p>

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/SelectorUtils.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/SelectorUtils.java
@@ -60,7 +60,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-@SuppressWarnings("checkstyle:RegexpSingleLine")
+@SuppressWarnings({"checkstyle:RegexpSingleLine", "checkstyle:JavadocVariable"})
 /**
  * <p>This is a utility class used by selectors and DirectoryScanner. The functionality more properly belongs just to
  * selectors, but unfortunately DirectoryScanner exposed these as protected methods. Thus we have to support any

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/SelectorUtils.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/plexus/SelectorUtils.java
@@ -60,7 +60,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-
+@SuppressWarnings("checkstyle:RegexpSingleLine")
 /**
  * <p>This is a utility class used by selectors and DirectoryScanner. The functionality more properly belongs just to
  * selectors, but unfortunately DirectoryScanner exposed these as protected methods. Thus we have to support any

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/Format.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/Format.java
@@ -102,7 +102,7 @@ public enum Format {
     }
 
    /**
-    * Determine the {@code Format} from an URI.
+    * Determine the {@code Format} from a URI.
     * @param uri the URI to check.
     * @return the Format
     */

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/LicenseReader.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/LicenseReader.java
@@ -29,7 +29,7 @@ import org.apache.rat.license.ILicenseFamily;
  */
 public interface LicenseReader {
     /**
-     * Adds an URI to the set of files to be read.
+     * Adds a URI to the set of files to be read.
      * @param uri the URI to read.
      */
     void addLicenses(URI uri);

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/MatcherReader.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/MatcherReader.java
@@ -25,7 +25,7 @@ import java.net.URI;
  */
 public interface MatcherReader {
     /**
-     * Adds an URI to the set of files to be read.
+     * Adds a URI to the set of files to be read.
      * @param uri the URI to read.
      */
     void addMatchers(URI uri);

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfig.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfig.java
@@ -88,7 +88,7 @@ public final class XMLConfig {
 
     /**
      * Returns true if the child should be a child node of a license node, as
-     * opposed to a attribute of the license.
+     * opposed to an attribute of the license.
      *
      * @param child the name of the child node.
      * @return true if the child should be a child node.

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationReader.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationReader.java
@@ -540,8 +540,13 @@ public final class XMLConfigurationReader implements LicenseReader, MatcherReade
                 approvedFamilies.add(attributes.get(XMLConfig.ATT_LICENSE_REF));
             } else if (attributes.containsKey(XMLConfig.ATT_ID)) {
                 ILicenseFamily target = parseFamily(attributes);
-                licenseFamilies.add(target);
-                approvedFamilies.add(target.getFamilyCategory());
+                if (target != null) {
+                    licenseFamilies.add(target);
+                    String familyCategory = target.getFamilyCategory();
+                    if (StringUtils.isNotBlank(familyCategory)) {
+                        approvedFamilies.add(familyCategory);
+                    }
+                }
             } else {
                 throw new ConfigurationException(String.format("family tag requires %s or %s attribute",
                         XMLConfig.ATT_LICENSE_REF, XMLConfig.ATT_ID));

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/XMLConfigurationWriter.java
@@ -42,7 +42,7 @@ import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.report.xml.writer.IXmlWriter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 
 /**
  * Writes the XML configuration file format.

--- a/apache-rat-core/src/main/java/org/apache/rat/configuration/builders/ChildContainerBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/configuration/builders/ChildContainerBuilder.java
@@ -60,6 +60,10 @@ public abstract class ChildContainerBuilder extends AbstractBuilder {
     public AbstractBuilder setResource(final String resourceName) {
         // this method is called by reflection
         URL url = this.getClass().getResource(resourceName);
+        if (url == null) {
+            throw new ConfigurationException("Unable to read matching text file: " + resourceName);
+        }
+
         try (InputStream in = url.openStream();
              BufferedReader buffer = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
             String txt;

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/XmlReportFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/XmlReportFactory.java
@@ -28,17 +28,17 @@ import org.apache.rat.ReportConfiguration;
 import org.apache.rat.VersionInfo;
 import org.apache.rat.analysis.DefaultAnalyserFactory;
 import org.apache.rat.api.RatException;
-import org.apache.rat.document.IDocumentAnalyser;
 import org.apache.rat.document.DocumentAnalyserMultiplexer;
+import org.apache.rat.document.IDocumentAnalyser;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.policy.DefaultPolicy;
 import org.apache.rat.report.ConfigurationReport;
 import org.apache.rat.report.RatReport;
-import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.report.claim.ClaimAggregator;
-import org.apache.rat.report.claim.SimpleXmlClaimReporter;
 import org.apache.rat.report.claim.ClaimReporterMultiplexer;
+import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.report.claim.LicenseAddingReport;
+import org.apache.rat.report.claim.SimpleXmlClaimReporter;
 import org.apache.rat.report.xml.writer.IXmlWriter;
 
 /**

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/IXmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/IXmlWriter.java
@@ -43,7 +43,7 @@ public interface IXmlWriter extends AutoCloseable {
      *
      * @param elementName the name of the element, not null
      * @return this object
-     * @throws InvalidXmlException if the name is not valid for an xml element
+     * @throws InvalidXmlException if the name is not valid for a xml element
      * @throws OperationNotAllowedException
      * if called after the first element has been closed
      */
@@ -67,7 +67,7 @@ public interface IXmlWriter extends AutoCloseable {
      * @param name the attribute name, not null
      * @param value the attribute value, not null
      * @return this object
-     * @throws InvalidXmlException if the name is not valid for an xml attribute
+     * @throws InvalidXmlException if the name is not valid for a xml attribute
      * or if a value for the attribute has already been written
      * @throws OperationNotAllowedException if called after {@link #content(CharSequence)}
      * or {@link #closeElement()} or before any call to {@link #openElement(CharSequence)}
@@ -90,7 +90,7 @@ public interface IXmlWriter extends AutoCloseable {
     /**
      * Writes CDATA content.
      * This method DOES NOT automatically escape characters.
-     * It will remove enclosed CDATA closing strings (e.g. {@code ]]>}
+     * It will remove enclosed CDATA closing strings (e.g. {@code ]]>})
      *
      * @param content the content to write
      * @return this object

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/InvalidXmlException.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/InvalidXmlException.java
@@ -21,7 +21,7 @@ package org.apache.rat.report.xml.writer;
 import java.io.IOException;
 
 /**
- * Indicates that the requested document is not well formed.
+ * Indicates that the requested document is not well-formed.
  */
 public class InvalidXmlException extends IOException {
 

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations      *
  * under the License.                                           *
  */
-package org.apache.rat.report.xml.writer.impl.base;
+package org.apache.rat.report.xml.writer;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -25,10 +25,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
-import org.apache.rat.report.xml.writer.IXmlWriter;
-import org.apache.rat.report.xml.writer.InvalidXmlException;
-import org.apache.rat.report.xml.writer.OperationNotAllowedException;
 
 /**
  * <p>
@@ -41,6 +37,7 @@ import org.apache.rat.report.xml.writer.OperationNotAllowedException;
  * Not intended to be subclassed. Please copy and hack!
  * </p>
  */
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:JavadocVariable"})
 public final class XmlWriter implements IXmlWriter {
 
     private static final byte NAME_START_MASK = 1 << 1;

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
@@ -444,7 +444,7 @@ public final class XmlWriter implements IXmlWriter {
      *
      * @param elementName the name of the element, not null
      * @return this object
-     * @throws InvalidXmlException if the name is not valid for an xml element
+     * @throws InvalidXmlException if the name is not valid for a xml element
      * @throws OperationNotAllowedException if called after the first element has
      * been closed
      */
@@ -487,7 +487,7 @@ public final class XmlWriter implements IXmlWriter {
      * @param name the attribute name, not null
      * @param value the attribute value, not null
      * @return this object
-     * @throws InvalidXmlException if the name is not valid for an xml attribute or
+     * @throws InvalidXmlException if the name is not valid for a xml attribute or
      * if a value for the attribute has already been written
      * @throws OperationNotAllowedException if called after
      * {@link #content(CharSequence)} or {@link #closeElement()} or before any call

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/package-info.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/package-info.java
@@ -17,6 +17,6 @@
  * under the License.                                           *
  */
 /**
- * Classes to handle writing well formed XML documents.
+ * Classes to handle writing well-formed XML documents.
  */
 package org.apache.rat.report.xml.writer;

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/DefaultAnalyserFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/DefaultAnalyserFactoryTest.java
@@ -32,7 +32,7 @@ import org.apache.rat.document.IDocumentAnalyser;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.document.FileDocument;
 import org.apache.rat.report.claim.SimpleXmlClaimReporter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 import org.apache.rat.test.utils.Resources;
 import org.apache.rat.testhelpers.TextUtils;
 import org.assertj.core.util.Files;

--- a/apache-rat-core/src/test/java/org/apache/rat/configuration/XMLConfigurationWriterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/configuration/XMLConfigurationWriterTest.java
@@ -35,7 +35,7 @@ import org.apache.rat.api.RatException;
 import org.apache.rat.config.parameters.Description;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 import org.apache.rat.testhelpers.XmlUtils;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;

--- a/apache-rat-core/src/test/java/org/apache/rat/report/ConfigurationReportTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/ConfigurationReportTest.java
@@ -35,7 +35,7 @@ import org.apache.rat.configuration.MatcherBuilderTracker;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.report.xml.writer.IXmlWriter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 import org.apache.rat.testhelpers.XmlUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -39,7 +39,7 @@ import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.report.RatReport;
 import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.report.xml.writer.IXmlWriter;
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 import org.apache.rat.test.utils.Resources;
 import org.apache.rat.testhelpers.TestingLicense;
 import org.apache.rat.testhelpers.TestingMatcher;

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/writer/XmlWriterUtilsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/writer/XmlWriterUtilsTest.java
@@ -18,7 +18,6 @@
  */ 
 package org.apache.rat.report.xml.writer;
 
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
 import org.apache.rat.testhelpers.XmlUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/writer/impl/base/XmlWriterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/writer/impl/base/XmlWriterTest.java
@@ -20,6 +20,7 @@ package org.apache.rat.report.xml.writer.impl.base;
 
 import org.apache.rat.report.xml.writer.InvalidXmlException;
 import org.apache.rat.report.xml.writer.OperationNotAllowedException;
+import org.apache.rat.report.xml.writer.XmlWriter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -235,8 +235,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
+          <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
           <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
           <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>../src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>../src/conf/checkstyle-suppressions.xml</suppressionsLocation>

--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -235,11 +235,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <failsOnError>false</failsOnError>
-          <failOnViolation>false</failOnViolation>
+          <failsOnError>true</failsOnError>
+          <failOnViolation>true</failOnViolation>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>../src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>../src/conf/checkstyle-suppressions.xml</suppressionsLocation>
-          <excludeGeneratedSources>true</excludeGeneratedSources>
         </configuration>
         <executions>
           <execution>

--- a/apache-rat-tasks/pom.xml
+++ b/apache-rat-tasks/pom.xml
@@ -210,11 +210,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <failsOnError>false</failsOnError>
-          <failOnViolation>false</failOnViolation>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>../src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>../src/conf/checkstyle-suppressions.xml</suppressionsLocation>
-          <excludeGeneratedSources>true</excludeGeneratedSources>
         </configuration>
         <executions>
           <execution>

--- a/apache-rat-tools/pom.xml
+++ b/apache-rat-tools/pom.xml
@@ -66,8 +66,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
-          <failsOnError>false</failsOnError>
-          <failOnViolation>false</failOnViolation>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>../src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>../src/conf/checkstyle-suppressions.xml</suppressionsLocation>
         </configuration>

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/AntDocumentation.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/AntDocumentation.java
@@ -178,7 +178,7 @@ public final class AntDocumentation {
          */
         public static void writeLicense(final Writer writer) throws IOException {
             try (InputStream in = AntDocumentation.class.getResourceAsStream("/license.apt")) {
-                if(in == null) {
+                if (in == null) {
                     throw new FileNotFoundException("Could not find license.apt");
                 }
                 IOUtils.copy(in, writer, StandardCharsets.UTF_8);

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/AntGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/AntGenerator.java
@@ -149,7 +149,7 @@ public final class AntGenerator {
                         break;
                     case "${commonArgs}":
                         try (InputStream argsTpl = MavenGenerator.class.getResourceAsStream("/Args.tpl")) {
-                            if(argsTpl == null) {
+                            if (argsTpl == null) {
                                 throw new RuntimeException("Args.tpl not found");
                             }
                             IOUtils.copy(argsTpl, writer, StandardCharsets.UTF_8);

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/MavenGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/MavenGenerator.java
@@ -139,7 +139,7 @@ public final class MavenGenerator {
                         break;
                     case "${commonArgs}":
                         try (InputStream argsTpl = MavenGenerator.class.getResourceAsStream("/Args.tpl")) {
-                            if(argsTpl == null) {
+                            if (argsTpl == null) {
                                 throw new RuntimeException("Args.tpl not found");
                             }
                             IOUtils.copy(argsTpl, writer, StandardCharsets.UTF_8);

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdGenerator.java
@@ -137,7 +137,7 @@ public class XsdGenerator {
         List<Description> children = new ArrayList<>();
         List<Description> attributes = new ArrayList<>();
 
-        if(desc != null && desc.getChildren() != null) {
+        if (desc != null && desc.getChildren() != null) {
             for (Description child : desc.getChildren().values()) {
                 if (XMLConfig.isLicenseChild(child.getCommonName())) {
                     children.add(child);

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdWriter.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdWriter.java
@@ -21,7 +21,7 @@ package org.apache.rat.tools.xsd;
 import java.io.IOException;
 import java.io.Writer;
 
-import org.apache.rat.report.xml.writer.impl.base.XmlWriter;
+import org.apache.rat.report.xml.writer.XmlWriter;
 
 /**
  * A writer that writes XSD nodes.

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,9 @@ agnostic home for software distribution comprehension and audit tools.
         <configuration>
           <configLocation>src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>src/conf/checkstyle-suppressions.xml</suppressionsLocation>
+          <violationSeverity>warning</violationSeverity>
+          <failOnViolation>true</failOnViolation>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -362,8 +362,8 @@ agnostic home for software distribution comprehension and audit tools.
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.8.6.5</version>
           <configuration>
-            <!-- RAT-369: JDK21 finds 56 errors, while older releases find less -->
-            <maxAllowedViolations>56</maxAllowedViolations>
+            <!-- RAT-369: JDK21 finds 55 errors, while older releases find less -->
+            <maxAllowedViolations>55</maxAllowedViolations>
             <failOnError>true</failOnError>
             <!-- we only want to see our own problems and in all subpackages -->
             <onlyAnalyze>org.apache.rat.-</onlyAnalyze>

--- a/pom.xml
+++ b/pom.xml
@@ -242,11 +242,13 @@ agnostic home for software distribution comprehension and audit tools.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
+          <consoleOutput>true</consoleOutput>
+          <failsOnError>true</failsOnError>
+          <failOnViolation>true</failOnViolation>
+          <violationSeverity>warning</violationSeverity>
+          <excludeGeneratedSources>true</excludeGeneratedSources>
           <configLocation>src/conf/checkstyle.xml</configLocation>
           <suppressionsLocation>src/conf/checkstyle-suppressions.xml</suppressionsLocation>
-          <violationSeverity>warning</violationSeverity>
-          <failOnViolation>true</failOnViolation>
-          <excludeGeneratedSources>true</excludeGeneratedSources>
         </configuration>
       </plugin>
       <plugin>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,9 @@ The <action> type attribute can be one of:
     </release>
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-439" type="fix" dev="claudenw">
+        Fix checkstyle issues and make the build fail in case of new checkstyle warnings and errors.
+      </action>
       <action issue="RAT-438" type="fix" dev="claudenw">
         Fix checkstyle issues in plugin module.
         Deprecated several classes.

--- a/src/conf/checkstyle-suppressions.xml
+++ b/src/conf/checkstyle-suppressions.xml
@@ -51,12 +51,4 @@
   <suppress checks="MagicNumber" files="src[/\\]test[/\\]java[/\\]" />
   <suppress checks="ParameterNumber" files="src[/\\]test[/\\]java[/\\]" />
 
-
-  <!-- Suppress magic numbers in old code -->
-  <suppress checks="MagicNumber|JavadocVariable" files="XmlWriter.java" />
-
-  <!-- Suppress errors in imported plexus code -->
-  <suppress checks="JavadocVariable"
-            files="src[/\\]main[/\\]java[/\\]org[/\\]apache[/\\]rat[/\\]config[/\\]exclusion[/\\]plexus[/\\].*" />
-
 </suppressions>

--- a/src/conf/checkstyle-suppressions.xml
+++ b/src/conf/checkstyle-suppressions.xml
@@ -51,4 +51,6 @@
   <suppress checks="MagicNumber" files="src[/\\]test[/\\]java[/\\]" />
   <suppress checks="ParameterNumber" files="src[/\\]test[/\\]java[/\\]" />
 
+  <!-- Suppress checks for RELEASE NOTES -->
+  <suppress checks="LineLength" files="RELEASE_NOTES.txt" />
 </suppressions>

--- a/src/conf/checkstyle-suppressions.xml
+++ b/src/conf/checkstyle-suppressions.xml
@@ -51,18 +51,6 @@
   <suppress checks="MagicNumber" files="src[/\\]test[/\\]java[/\\]" />
   <suppress checks="ParameterNumber" files="src[/\\]test[/\\]java[/\\]" />
 
-  <!-- Suppress visibility check of some member fields as they have to be kept
-       for binary compatibility reasons                                         -->
-  <suppress checks="VisibilityModifier" files="HelpFormatter.java" />
-
-  <!-- Cannot hide public constructor due to binary compatibility reasons       -->
-  <suppress checks="HideUtilityClassConstructor" files="PatternOptionBuilder.java" />
-  <suppress checks="HideUtilityClassConstructor" files="TypeHandler.java" />
-
-  <!-- These are final package private classes, and we do not want to hide the
-       constructor as this will negatively affect the code coverage             -->
-  <suppress checks="HideUtilityClassConstructor" files="OptionValidator.java" />
-  <suppress checks="HideUtilityClassConstructor" files="Util.java" />
 
   <!-- Suppress magic numbers in old code -->
   <suppress checks="MagicNumber|JavadocVariable" files="XmlWriter.java" />
@@ -71,7 +59,4 @@
   <suppress checks="JavadocVariable"
             files="src[/\\]main[/\\]java[/\\]org[/\\]apache[/\\]rat[/\\]config[/\\]exclusion[/\\]plexus[/\\].*" />
 
-  <!-- Suppress errors in imported iterator code -->
-  <suppress checks="JavadocPackage|JavadocType|JavadocVariable|FinalParameters|VisibilityModifier|WhitespaceAfter|MethodName|NoWhitespaceBefore|NeedBraces|ParenPad|InnerAssignment|LeftCurly|ExplicitInitialization"
-            files="src[/\\]main[/\\]java[/\\]org[/\\]apache[/\\]rat[/\\]utils[/\\]iterator[/\\].*" />
 </suppressions>

--- a/src/conf/checkstyle.xml
+++ b/src/conf/checkstyle.xml
@@ -34,7 +34,13 @@
     <property name="max" value="160" />
   </module>
 
+  <!-- Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings annotation -->
+  <module name="SuppressWarningsFilter" />
+
   <module name="TreeWalker">
+    <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
+    <module name="SuppressWarningsHolder" />
+
     <module name="LeftCurly" />
 
     <!-- Checks for Javadoc comments. -->
@@ -132,7 +138,6 @@
       <property name="groups" value="java,javax,org"/>
       <property name="ordered" value="true"/>
       <property name="separated" value="true"/>
-
     </module>
 
   </module>


### PR DESCRIPTION
Fix for RAT-439

Last pass on cleanup.
Make checkstyle warning fail.
minimize checkstyle-supressions.xml
Utilize @SuppressWarning annotation where reasonable.

Fixed issue with XmlWriter package.