### PR TITLE
RAT-2: Added --input-exclude-size option

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -297,6 +297,15 @@ public class ReportConfiguration {
     }
 
     /**
+     * Excludes files that match a FileFilter.
+     * @param name the name of the DocumentNameMatcher.
+     * @param matcher the DocumentNameMatcher to match.
+     */
+    public void addExcludedMatcher(final String name, final DocumentNameMatcher matcher) {
+        exclusionProcessor.addExcludedFilter(DocumentNameMatcherSupplier.from(name, matcher));
+    }
+
+    /**
      * Excludes files that match the pattern.
      *
      * @param patterns the collection of patterns to exclude.

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -624,7 +624,7 @@ public class ReportConfiguration {
 
     /**
      * Adds a license family category (id) to the list of approved licenses
-     * @param licenseId the license Id to add.
+     * @param licenseId the license id to add.
      */
     public void addApprovedLicenseId(final String licenseId) {
         licenseSetFactory.addLicenseId(licenseId);

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -264,12 +264,12 @@ public enum Arg {
     ),
 
     /**
-     * Excludes files based on standard groupings.
+     * Excludes files if they are smaller than the given threshold.
      */
     EXCLUDE_SIZE(new OptionGroup()
             .addOption(Option.builder().longOpt("input-exclude-size").argName("Integer")
                     .hasArg().type(Integer.class)
-                    .desc("Excludes files with sizes less than the argument.")
+                    .desc("Excludes files with sizes less than the given argument.")
                     .build())
     ),
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -46,6 +46,7 @@ import org.apache.rat.ReportConfiguration;
 import org.apache.rat.config.AddLicenseHeaders;
 import org.apache.rat.config.exclusion.ExclusionUtils;
 import org.apache.rat.config.exclusion.StandardCollection;
+import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.report.claim.ClaimStatistic.Counter;
 import org.apache.rat.utils.DefaultLog;
@@ -262,6 +263,15 @@ public enum Arg {
                     .build())
     ),
 
+    /**
+     * Excludes files based on standard groupings.
+     */
+    EXCLUDE_SIZE(new OptionGroup()
+            .addOption(Option.builder().longOpt("input-exclude-size").argName("Integer")
+                    .hasArg().type(Integer.class)
+                    .desc("Excludes files with sizes less than the argument.")
+                    .build())
+    ),
     /**
      * Excludes files by expression.
      */
@@ -688,6 +698,15 @@ public enum Arg {
                         configuration.addExcludedCollection(collection);
                     }
                 }
+            }
+            if (EXCLUDE_SIZE.isSelected()) {
+                final int maxSize = EXCLUDE_SIZE.getParsedOptionValue(context.getCommandLine());
+                DocumentNameMatcher matcher =
+                    documentName -> {
+                        File f = new File(documentName.getName());
+                        return f.isFile() && f.length() < maxSize;
+                };
+                context.getConfiguration().addExcludedMatcher(String.format("File size < %s bytes", maxSize), matcher);
             }
             if (INCLUDE.isSelected()) {
                 String[] includes = context.getCommandLine().getOptionValues(INCLUDE.getSelected());

--- a/apache-rat-core/src/main/java/org/apache/rat/document/DocumentNameMatcherSupplier.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/document/DocumentNameMatcherSupplier.java
@@ -27,9 +27,24 @@ import java.io.FileFilter;
 public interface DocumentNameMatcherSupplier {
     DocumentNameMatcher get(DocumentName dir);
 
+    /**
+     * Creates a DocumentNameMatcherSupplier from a file filter.
+     * @param fileFilter the file filter to process.
+     * @return a DocumentNameMatcherSupplier.
+     */
     static DocumentNameMatcherSupplier from(final FileFilter fileFilter) {
         DocumentNameMatcher nameMatcher = DocumentNameMatcher.from(fileFilter);
         return docName -> new TraceableDocumentNameMatcher(fileFilter::toString, nameMatcher);
+    }
 
+    /**
+     * Create a DocumentNameMatcherSupplier from a DocumentNameMatcher and a name.
+     * @param name the name for the matcher.
+     * @param nameMatcher the matcher.
+     * @return A DocumentNameMatcherDupplier.
+     */
+    static DocumentNameMatcherSupplier from(final String name, final DocumentNameMatcher nameMatcher) {
+        TraceableDocumentNameMatcher tmatcher = TraceableDocumentNameMatcher.make(() -> name, nameMatcher);
+        return docName -> tmatcher;
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,9 @@ The <action> type attribute can be one of:
     </release>
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-2" type="add" dev="claudenw">
+        Added --input-exclude-size as an option to skip the scanning of very small files.
+      </action>
       <action issue="RAT-41" type="fix" dev="claudenw">
         Added core integration tests and verified results without generating output via ClaimStatistics.
       </action>


### PR DESCRIPTION
Fix for RAT-2

Added --input-exclude-size <bytes> as an option to skip the scanning of very small files.