### PR TITLE
RAT-98: changed 'name matcher' to 'document excluder'

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -249,10 +249,10 @@ public final class OptionCollection {
             DefaultLog.getInstance().error("Directory '" + documentName + "' does not exist.");
             return null;
         }
-        DocumentNameMatcher documentNameMatcher = config.getNameMatcher(documentName);
+        DocumentNameMatcher documentExcluder = config.getDocumentExcluder(documentName);
 
-        Document doc = new FileDocument(documentName, absBase, documentNameMatcher);
-        if (!documentNameMatcher.matches(doc.getName())) {
+        Document doc = new FileDocument(documentName, absBase, documentExcluder);
+        if (!documentExcluder.matches(doc.getName())) {
             DefaultLog.getInstance().error("Directory '" + documentName + "' is in excluded list.");
             return null;
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -414,11 +414,11 @@ public class ReportConfiguration {
     }
 
     /**
-     * Get the DocumentNameMatcher based on the directory.
+     * Get the DocumentNameMatcher that excludes files found in the directory tree..
      * @param baseDir the DocumentName for the base directory.
      * @return the DocumentNameMatcher for the base directory.
      */
-    public DocumentNameMatcher getNameMatcher(final DocumentName baseDir) {
+    public DocumentNameMatcher getDocumentExcluder(final DocumentName baseDir) {
         return exclusionProcessor.getNameMatcher(baseDir);
     }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/api/Document.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/api/Document.java
@@ -52,7 +52,7 @@ public abstract class Document implements Comparable<Document> {
     }
 
     /** The path matcher used by this document */
-    protected final DocumentNameMatcher nameMatcher;
+    protected final DocumentNameMatcher nameExcluder;
     /** The metadata for this document */
     private final MetaData metaData;
     /** The fully qualified name of this document */
@@ -61,11 +61,11 @@ public abstract class Document implements Comparable<Document> {
     /**
      * Creates an instance.
      * @param name the native NameSet of the resource.
-     * @param nameMatcher the document name matcher to filter directories/files.
+     * @param nameExcluder the document name matcher to filter directories/files.
      */
-    protected Document(final DocumentName name, final DocumentNameMatcher nameMatcher) {
+    protected Document(final DocumentName name, final DocumentNameMatcher nameExcluder) {
         this.name = name;
-        this.nameMatcher = nameMatcher;
+        this.nameExcluder = nameExcluder;
         this.metaData = new MetaData();
     }
 
@@ -81,8 +81,8 @@ public abstract class Document implements Comparable<Document> {
      * Gets the file filter this document was created with.
      * @return the file filter this document was created with.
      */
-    public final DocumentNameMatcher getNameMatcher() {
-        return nameMatcher;
+    public final DocumentNameMatcher getNameExcluder() {
+        return nameExcluder;
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/document/FileDocument.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/document/FileDocument.java
@@ -42,20 +42,20 @@ public class FileDocument extends Document {
      * Creates a File document.
      * @param basedir the base directory for this document.
      * @param file the file to wrap.
-     * @param nameMatcher the path matcher to filter files/directories with.
+     * @param nameExcluder the path matcher to filter files/directories with.
      */
-    public FileDocument(final DocumentName basedir, final File file, final DocumentNameMatcher nameMatcher) {
-        super(DocumentName.builder(file).setBaseName(basedir.getBaseName()).build(), nameMatcher);
+    public FileDocument(final DocumentName basedir, final File file, final DocumentNameMatcher nameExcluder) {
+        super(DocumentName.builder(file).setBaseName(basedir.getBaseName()).build(), nameExcluder);
         this.file = file;
     }
 
     /**
      * Creates a File document where the baseDir is the root directory.
      * @param file the file to wrap.
-     * @param nameMatcher the path matcher to filter files/directories with.
+     * @param nameExcluder the path matcher to filter files/directories with.
      */
-    public FileDocument(final File file, final DocumentNameMatcher nameMatcher) {
-        super(DocumentName.builder(file).setBaseName(File.separator).build(), nameMatcher);
+    public FileDocument(final File file, final DocumentNameMatcher nameExcluder) {
+        super(DocumentName.builder(file).setBaseName(File.separator).build(), nameExcluder);
         this.file = file;
     }
 
@@ -70,12 +70,12 @@ public class FileDocument extends Document {
             SortedSet<Document> result = new TreeSet<>();
             File[] files = file.listFiles();
             if (files != null) {
-                FileFilter fileFilter = ExclusionUtils.asFileFilter(name, nameMatcher);
+                FileFilter fileFilter = ExclusionUtils.asFileFilter(name, nameExcluder);
                 for (File child : files) {
                     if (fileFilter.accept(child)) {
-                        result.add(new FileDocument(name, child, nameMatcher));
+                        result.add(new FileDocument(name, child, nameExcluder));
                     } else {
-                        result.add(new IgnoredDocument(name, child, nameMatcher));
+                        result.add(new IgnoredDocument(name, child, nameExcluder));
                     }
                 }
             }

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/ArchiveWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/ArchiveWalker.java
@@ -88,14 +88,14 @@ public class ArchiveWalker extends Walker {
                 if (!entry.isDirectory() && input.canReadEntryData(entry)) {
                     DocumentName innerName = DocumentName.builder().setDirSeparator("/").setName(entry.getName())
                             .setBaseName(".").setCaseSensitive(true).build();
-                    if (this.getDocument().getNameMatcher().matches(innerName)) {
+                    if (this.getDocument().getNameExcluder().matches(innerName)) {
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
                         IOUtils.copy(input, baos);
                         DocumentName archiveName = getDocument().getName();
                         String outerNameStr = format("%s#%s", archiveName.getName(), entry.getName());
                         DocumentName outerName = DocumentName.builder(archiveName).setName(outerNameStr)
                                 .setCaseSensitive(true).build();
-                        result.add(new ArchiveEntryDocument(outerName, baos.toByteArray(), getDocument().getNameMatcher()));
+                        result.add(new ArchiveEntryDocument(outerName, baos.toByteArray(), getDocument().getNameExcluder()));
                     }
                 }
             }

--- a/apache-rat-core/src/test/java/org/apache/rat/DefaultsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/DefaultsTest.java
@@ -40,7 +40,7 @@ public class DefaultsTest {
 
         Set<String> names = new TreeSet<>();
         licenses.forEach(x -> names.add(x.getLicenseFamily().getFamilyCategory()));
-        assertThat(names.size()).isEqualTo(FAMILIES.length);
+        assertThat(names).hasSize(FAMILIES.length);
         names.removeAll(Arrays.asList(FAMILIES));
         assertThat(names).isEmpty();
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
@@ -44,7 +44,6 @@ import java.util.SortedSet;
 import java.util.function.Function;
 
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.apache.commons.io.function.IOSupplier;
 import org.apache.rat.ReportConfiguration.NoCloseOutputStream;
 import org.apache.rat.analysis.IHeaderMatcher;
 import org.apache.rat.config.AddLicenseHeaders;
@@ -91,11 +90,11 @@ public class ReportConfigurationTest {
     @Test
     public void testAddIncludedFilter() {
         underTest.addExcludedFilter(DirectoryFileFilter.INSTANCE);
-        DocumentNameMatcher matcher = underTest.getNameMatcher(DocumentName.builder(new File(File.separator)).build());
-        assertEquals("not(DirectoryFileFilter)", matcher.toString());
-        assertFalse(matcher.matches(DocumentName.builder(tempDir).build()));
+        DocumentNameMatcher exlcuder = underTest.getDocumentExcluder(DocumentName.builder(new File(File.separator)).build());
+        assertEquals("not(DirectoryFileFilter)", exlcuder.toString());
+        assertFalse(exlcuder.matches(DocumentName.builder(tempDir).build()));
         File f = new File(tempDir, "foo.txt");
-        assertTrue(matcher.matches(DocumentName.builder(f).build()));
+        assertTrue(exlcuder.matches(DocumentName.builder(f).build()));
     }
 
     @Test
@@ -367,27 +366,27 @@ public class ReportConfigurationTest {
     @Test
     public void exclusionTest() {
         DocumentName baseDir = DocumentName.builder(tempDir).build();
-        assertTrue(underTest.getNameMatcher(baseDir).matches(mkDocumentName(new File(tempDir,"foo"))));
-        assertTrue(underTest.getNameMatcher(baseDir).matches(mkDocumentName(new File("foo"))));
+        assertTrue(underTest.getDocumentExcluder(baseDir).matches(mkDocumentName(new File(tempDir,"foo"))));
+        assertTrue(underTest.getDocumentExcluder(baseDir).matches(mkDocumentName(new File("foo"))));
 
         underTest.setFrom(Defaults.builder().build());
 
         File f = new File(tempDir, ".hiddenDir");
         assertTrue(f.mkdir(), () -> "Could not create directory " + f);
 
-        assertFalse(underTest.getNameMatcher(baseDir).matches(mkDocumentName(new File(tempDir, ".hiddenDir"))));
+        assertFalse(underTest.getDocumentExcluder(baseDir).matches(mkDocumentName(new File(tempDir, ".hiddenDir"))));
 
         underTest.addIncludedCollection(StandardCollection.HIDDEN_DIR);
-        assertTrue(underTest.getNameMatcher(baseDir).matches(mkDocumentName(new File(tempDir, ".hiddenDir"))));
+        assertTrue(underTest.getDocumentExcluder(baseDir).matches(mkDocumentName(new File(tempDir, ".hiddenDir"))));
 
         underTest.addExcludedCollection(StandardCollection.HIDDEN_DIR);
-        assertTrue(underTest.getNameMatcher(baseDir).matches(mkDocumentName(new File(tempDir, ".hiddenDir"))));
+        assertTrue(underTest.getDocumentExcluder(baseDir).matches(mkDocumentName(new File(tempDir, ".hiddenDir"))));
 
         underTest.addExcludedFilter(DirectoryFileFilter.DIRECTORY);
 
         File file = new File(tempDir, "newDir");
         assertTrue(file.mkdirs(), () -> "Could not create directory " + file);
-        assertFalse(underTest.getNameMatcher(baseDir).matches(mkDocumentName(file)));
+        assertFalse(underTest.getDocumentExcluder(baseDir).matches(mkDocumentName(file)));
     }
 
     @Test

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
@@ -332,7 +332,7 @@ public class ReporterTest {
         configuration.setFrom(defaults);
         DocumentName documentName = DocumentName.builder(elementsFile).build();
         configuration.addSource(new DirectoryWalker(new FileDocument(documentName, elementsFile,
-                configuration.getNameMatcher(documentName))));
+                configuration.getDocumentExcluder(documentName))));
         return configuration;
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/report/xml/XmlReportFactoryTest.java
@@ -75,7 +75,7 @@ public class XmlReportFactoryTest {
         configuration.setFrom(Defaults.builder().build());
         DocumentName documentName = DocumentName.builder(elementsDir).build();
         DirectoryWalker directory = new DirectoryWalker(new FileDocument(documentName, elementsDir,
-                configuration.getNameMatcher(documentName)));
+                configuration.getDocumentExcluder(documentName)));
         final ClaimStatistic statistic = new ClaimStatistic();
 
         configuration.addLicense(testingLicense);

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
@@ -211,12 +211,12 @@ public abstract class AbstractOptionsProvider {
         String[] excluded = { "some.foo", "B.bar", "justbaz"};
         try {
             ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
             for (String fname : notExcluded) {
-                assertTrue(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertTrue(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
             for (String fname : excluded) {
-                assertFalse(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertFalse(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
         } catch (IOException e) {
             fail(e.getMessage());
@@ -251,12 +251,12 @@ public abstract class AbstractOptionsProvider {
         String[] notExcluded = { "afile~more",   "what.#afile", "%afile%withMore", "well._afile" };
         try {
             ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
             for (String fname : excluded) {
-                assertFalse(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertFalse(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
             for (String fname : notExcluded) {
-                assertTrue(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertTrue(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
         } catch (IOException e) {
             fail(e.getMessage());
@@ -283,12 +283,12 @@ public abstract class AbstractOptionsProvider {
         expected.add(0, "!" + new File(baseDir, "thingone").getPath());
         try {
             ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
             for (String fname : excluded) {
-                assertFalse(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertFalse(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
             for (String fname : notExcluded) {
-                assertTrue(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertTrue(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
         } catch (IOException e) {
             fail(e.getMessage());
@@ -307,12 +307,12 @@ public abstract class AbstractOptionsProvider {
 
         try {
             ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
             for (String fname : excluded) {
-                assertFalse(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertFalse(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
             for (String fname : notExcluded) {
-                assertTrue(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertTrue(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
         } catch (IOException e) {
             fail(e.getMessage());
@@ -327,12 +327,12 @@ public abstract class AbstractOptionsProvider {
         try {
             ReportConfiguration config = generateConfig(ImmutablePair.of(option, args),
                     ImmutablePair.of(excludeOption, EXCLUDE_ARGS));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
             for (String fname : excluded) {
-                assertFalse(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertFalse(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
             for (String fname : notExcluded) {
-                assertTrue(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertTrue(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
         } catch (IOException e) {
             fail(e.getMessage());
@@ -369,12 +369,12 @@ public abstract class AbstractOptionsProvider {
         String[] notExcluded = { "afile~", ".#afile", "%afile%", "._afile", "what.#afile", "%afile%withMore", "well._afile" };
         try {
             ReportConfiguration config = generateConfig(excludes, ImmutablePair.of(option, args));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
             for (String fname : excluded) {
-                assertFalse(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertFalse(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
             for (String fname : notExcluded) {
-                assertTrue(matcher.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
+                assertTrue(excluder.matches(mkDocName(fname)), () -> option.getKey() + " " + fname);
             }
         } catch (IOException e) {
             fail(e.getMessage());
@@ -844,8 +844,8 @@ public abstract class AbstractOptionsProvider {
     protected void scanHiddenDirectoriesTest() {
         try {
             ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.INCLUDE_STD.find("scan-hidden-directories"), null));
-            DocumentNameMatcher matcher = config.getNameMatcher(baseName());
-            assertTrue(matcher.matches(mkDocName(".file")), ".file");
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            assertTrue(excluder.matches(mkDocName(".file")), ".file");
         } catch (IOException e) {
             fail(e.getMessage());
         }

--- a/apache-rat-core/src/test/java/org/apache/rat/walker/DirectoryWalkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/walker/DirectoryWalkerTest.java
@@ -60,7 +60,7 @@ public class DirectoryWalkerTest {
 
     public Document toWalk() {
         DocumentName documentName = DocumentName.builder(tempDir).build();
-        return new FileDocument(documentName, tempDir, reportConfiguration.getNameMatcher(documentName));
+        return new FileDocument(documentName, tempDir, reportConfiguration.getDocumentExcluder(documentName));
     }
 
     @BeforeAll

--- a/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
+++ b/apache-rat-plugin/src/main/java/org/apache/rat/mp/AbstractRatMojo.java
@@ -538,7 +538,7 @@ public abstract class AbstractRatMojo extends BaseRatMojo {
                     getLicenses().map(x -> x.build(families)).forEach(process);
                 }
                 DocumentName dirName = DocumentName.builder(basedir).build();
-                config.addSource(new DirectoryWalker(new FileDocument(dirName, basedir, config.getNameMatcher(dirName))));
+                config.addSource(new DirectoryWalker(new FileDocument(dirName, basedir, config.getDocumentExcluder(dirName))));
 
                 if (helpLicenses) {
                     new org.apache.rat.help.Licenses(config, new PrintWriter(log.asWriter())).printHelp();

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/ResourceCollectionContainer.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/ResourceCollectionContainer.java
@@ -52,7 +52,7 @@ class ResourceCollectionContainer implements IReportable {
             if (r.isFilesystemOnly()) {
                 FileResource fr = (FileResource) r;
                 DocumentName dirName = DocumentName.builder(fr.getFile()).setBaseName(fr.getProject().getBaseDir()).build();
-                FileDocument document = new FileDocument(dirName, fr.getFile(), configuration.getNameMatcher(dirName));
+                FileDocument document = new FileDocument(dirName, fr.getFile(), configuration.getDocumentExcluder(dirName));
                 report.report(document);
             }
         }


### PR DESCRIPTION
Changed name of variable(s) and method to be lexically correct.  It is not a document name matcher but rather an excluder.  

Part of #417 simplification.