### PR TITLE
RAT-471 - Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,7 @@ on:
   pull_request:
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   build:

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -4,7 +4,7 @@
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
   <server>
-    <url>https://ge.apache.org</url>
+    <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>
   </server>
   <buildScan>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -3,6 +3,7 @@
 <develocity
   xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
+  <projectId>rat</projectId>
   <server>
     <url>https://develocity.apache.org</url>
     <allowUntrusted>false</allowUntrusted>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,7 +3,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>develocity-maven-extension</artifactId>
-    <version>1.23</version>
+    <version>1.22.2</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ASF Jenkins: [![ASF Jenkins Build Status](https://ci-builds.apache.org/buildStat
 
 GA: [![Github Action master branch status](https://github.com/apache/creadur-rat/actions/workflows/maven.yml/badge.svg?branch=master)](https://github.com/apache/creadur-rat/actions)
 
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.apache.org/scans?list.sortColumn=buildDuration&list.sortOrder=asc&search.buildToolType=maven&search.names=not:CI%20stage&search.rootProjectNames=Apache%20Creadur%20Rat&search.tasks=install&search.timeZoneId=Europe%2FBerlin&search.values=Build%20Parent-pom)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity.apache.org/scans?list.sortColumn=buildDuration&list.sortOrder=asc&search.buildToolType=maven&search.names=not:CI%20stage&search.rootProjectNames=Apache%20Creadur%20Rat&search.tasks=install&search.timeZoneId=Europe%2FBerlin&search.values=Build%20Parent-pom)
 
 ## What is RAT?
 


### PR DESCRIPTION
This PR migrates the RAT project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

Additionally, this PR migrates sets a projectId for use by Develocity.

https://issues.apache.org/jira/browse/RAT-471