### PR TITLE
RAT-473: take global gitignore into account 

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/StandardCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/StandardCollection.java
@@ -89,9 +89,11 @@ public enum StandardCollection {
                     "**/.project", "**/.settings/**", "**/.externalToolBuilders"),
             null, null),
     /**
-     * The files and directories created by GIT source code control to support GIT, also processes files listed in '.gitignore'.
+     * The files and directories created by GIT source code control to support GIT, also processes files listed in '.gitignore'
+     * and (unless RAT_NO_GIT_GLOBAL_IGNORE is specified) the global gitignore.
      */
-    GIT("The files and directories created by GIT source code control to support GIT, also processes files listed in '.gitignore'.",
+    GIT("The files and directories created by GIT source code control to support GIT, also processes files listed in '.gitignore' " +
+        "and (unless RAT_NO_GIT_GLOBAL_IGNORE is specified) the global gitignore.",
             Arrays.asList("**/.git/**", "**/.gitignore"),
             null,
             new GitIgnoreBuilder()

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileProcessors/AbstractFileProcessorBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileProcessors/AbstractFileProcessorBuilder.java
@@ -203,10 +203,14 @@ public abstract class AbstractFileProcessorBuilder {
         return result == null ? new File[0] : result;
     }
 
+    protected LevelBuilder getLevelBuilder(final int level) {
+        return levelBuilders.computeIfAbsent(level, k -> new LevelBuilder());
+    }
+
     /**
      * Manages the merging of {@link MatcherSet}s for the specified level.
      */
-    private static final class LevelBuilder {
+    protected static final class LevelBuilder {
         /**
          * The list of MatcherSets that this builder produced.
          */

--- a/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileProcessors/AbstractIgnoreBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileProcessors/AbstractIgnoreBuilderTest.java
@@ -95,13 +95,14 @@ public class AbstractIgnoreBuilderTest {
     }
 
     /**
-     * Asserts the correctness of the excluder. An excluder returns false if the document name is matched.
+     * Asserts the correctness of the matcher.
      * @param matcherSets the list of matchers to create the DocumentNameMatcher from.
      * @param baseDir the base directory for the excluder test.
-     * @param matching the matching strings.
-     * @param notMatching the non-matching strings.
+     * @param matching the matching strings (i.e. that should be ignored)
+     * @param notMatching the non-matching strings (i.e. that should be checked)
      */
     protected void assertCorrect(List<MatcherSet> matcherSets, DocumentName baseDir, Iterable<String> matching, Iterable<String> notMatching) {
+        // An excluder returns false if the document name is matched.
         DocumentNameMatcher excluder = MatcherSet.merge(matcherSets).createMatcher();
         for (String name : matching) {
             DocumentName docName = baseDir.resolve(SelectorUtils.extractPattern(name, baseDir.getDirectorySeparator()));

--- a/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/global-gitignore
+++ b/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/global-gitignore
@@ -1,0 +1,3 @@
+/*.txt
+!/local-should-precede-global.md
+/local-should-precede-global.xml

--- a/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/src/.gitignore
+++ b/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/src/.gitignore
@@ -5,3 +5,6 @@
 
 # This makes it "unignore" dir3/file3.log
 !file*.log
+
+# Don't ignore xml files
+!*.xml

--- a/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/src/local-should-precede-global.md
+++ b/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/src/local-should-precede-global.md
@@ -1,0 +1,5 @@
+The local .gitignore ignores '*.md'
+
+The global .gitignore un-ignores 'local-should-precede-global.md'
+
+The local .gitignore takes precedence over the global, so this file should be ignored.

--- a/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/src/local-should-precede-global.xml
+++ b/apache-rat-core/src/test/resources/GitIgnoreBuilderTest/src/local-should-precede-global.xml
@@ -1,0 +1,5 @@
+The local .gitignore un-ignores '*.xml'
+
+The global .gitignore ignores 'local-should-precede-global.xml'
+
+The local .gitignore takes precedence over the global, so this file should not be ignored.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,9 @@ The <action> type attribute can be one of:
     </release>
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-473" type="add" dev="engelen">
+        Take global gitignore into account when determining which files to audit and which to skip.
+      </action>
       <action issue="RAT-398" type="add" dev="claudenw">
         Deprecated certain Ant report functionality in favour of new CLI functionality. Deprecation information is printed to indicate how the new options can be configured.
       </action>


### PR DESCRIPTION
Take into account exclusions from the global gitignore file if it is present in the default location. It's kind of icky to read environment variables in code called from an enum constructor, but I didn't see a more elegant solution yet either. Relatedly, I have not yet created a unit test (or made sure that a global gitignore will not interfere with a global gitignore being present), hence the WIP status.

https://git-scm.com/docs/gitignore