### PR TITLE
RAT-98: fixed DocumentNameMatcher idiom misuse

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/document/DocumentNameMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/document/DocumentNameMatcher.java
@@ -305,7 +305,7 @@ public final class DocumentNameMatcher {
         return new DocumentNameMatcher(format("matcherSet(%s)", join(workingSet)),
                 new CollectionPredicateImpl(workingSet) {
                     @Override
-                    public boolean test(DocumentName documentName) {
+                    public boolean test(final DocumentName documentName) {
                         if (includes.matches(documentName)) {
                             return true;
                         }

--- a/apache-rat-core/src/main/java/org/apache/rat/document/DocumentNameMatcher.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/document/DocumentNameMatcher.java
@@ -23,7 +23,6 @@ import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -303,7 +302,16 @@ public final class DocumentNameMatcher {
             return MATCHES_ALL;
         }
         List<DocumentNameMatcher> workingSet = Arrays.asList(includes, excludes);
-        return new DocumentNameMatcher(format("matcherSet(%s)", join(workingSet)), new MatcherPredicate(workingSet));
+        return new DocumentNameMatcher(format("matcherSet(%s)", join(workingSet)),
+                new CollectionPredicateImpl(workingSet) {
+                    @Override
+                    public boolean test(DocumentName documentName) {
+                        if (includes.matches(documentName)) {
+                            return true;
+                        }
+                        return !excludes.matches(documentName);
+                    }
+                });
     }
 
     /**
@@ -463,27 +471,6 @@ public final class DocumentNameMatcher {
                 }
             }
             return false;
-        }
-    }
-
-    /**
-     * An implementation of "or" logic across a collection of DocumentNameMatchers.
-     */
-    // package private for testing access
-    static class MatcherPredicate extends CollectionPredicateImpl {
-        MatcherPredicate(final Iterable<DocumentNameMatcher> matchers) {
-            super(matchers);
-        }
-
-        @Override
-        public boolean test(final DocumentName documentName) {
-            Iterator<DocumentNameMatcher> iter = getMatchers().iterator();
-            // included
-            if (iter.next().matches(documentName)) {
-                return true;
-            }
-            // excluded
-            return !iter.next().matches(documentName);
         }
     }
 


### PR DESCRIPTION
Quick fix to redo a missing idiom misuse correction.