### PR TITLE
RAT-406: Tests to prove that issue is fixed

### DIFF
--- a/apache-rat-core/.gitignore
+++ b/apache-rat-core/.gitignore
@@ -1,11 +1,1 @@
-# somethings
-!thingone
-thing*
-
-
-# some fish
-**/fish
-*_fish
-# some colorful directories
-red/
-blue/*/
+/target/

--- a/apache-rat-core/.gitignore
+++ b/apache-rat-core/.gitignore
@@ -1,1 +1,11 @@
-/target/
+# somethings
+!thingone
+thing*
+
+
+# some fish
+**/fish
+*_fish
+# some colorful directories
+red/
+blue/*/

--- a/apache-rat-core/src/it/resources/ReportTest/RAT_406/commandLine.txt
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_406/commandLine.txt
@@ -1,0 +1,2 @@
+--licenses-denied
+DOJO

--- a/apache-rat-core/src/it/resources/ReportTest/RAT_406/expected-message.txt
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_406/expected-message.txt
@@ -1,0 +1,1 @@
+Issues with UNAPPROVED

--- a/apache-rat-core/src/it/resources/ReportTest/RAT_406/src/dojo/dojo.java
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_406/src/dojo/dojo.java
@@ -1,0 +1,4 @@
+/**
+ * DOJO flag
+ http://dojotoolkit.org/community/licensing.shtml
+ */

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -71,10 +71,6 @@ public final class OptionCollection {
     /** The Help option */
     public static final Option HELP = new Option("?", "help", false, "Print help for the RAT command line interface and exit.");
 
-    /** Provide license definition listing */
-    public static final Option HELP_LICENSES = Option.builder().longOpt("help-licenses")
-            .desc("Print help for the RAT command line interface and exit.").build();
-
     /** A mapping of {@code argName(value)} values to a description of those values. */
     @Deprecated
     private static final Map<String, Supplier<String>> ARGUMENT_TYPES;

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -145,13 +145,9 @@ public final class OptionCollection {
         Arg.processLogLevel(commandLine);
 
         ArgumentContext argumentContext = new ArgumentContext(workingDirectory, commandLine);
+
         if (commandLine.hasOption(HELP)) {
             helpCmd.accept(opts);
-            return null;
-        }
-
-        if (commandLine.hasOption(HELP_LICENSES)) {
-            new Licenses(createConfiguration(argumentContext), new PrintWriter(System.out)).printHelp();
             return null;
         }
 

--- a/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
@@ -120,11 +120,11 @@ public class Reporter {
 
     /**
      * Outputs the report using the stylesheet and output specified in the configuration.
-     *
+     * @return the Claim statistic from the run.
      * @throws RatException on error.
      */
-    public void output() throws RatException {
-        output(configuration.getStyleSheet(), configuration.getOutput());
+    public ClaimStatistic output() throws RatException {
+        return output(configuration.getStyleSheet(), configuration.getOutput());
     }
 
     /**
@@ -133,10 +133,11 @@ public class Reporter {
      *
      * @param stylesheet the style sheet to use for XSLT formatting.
      * @param output the output stream to write to.
+     * @return the Claim statistic for the run.
      * @throws RatException on error.
      */
-    public void output(final IOSupplier<InputStream> stylesheet, final IOSupplier<OutputStream> output) throws RatException {
-        execute();
+    public ClaimStatistic output(final IOSupplier<InputStream> stylesheet, final IOSupplier<OutputStream> output) throws RatException {
+        ClaimStatistic result = execute();
         TransformerFactory tf = TransformerFactory.newInstance();
         Transformer transformer;
         try (OutputStream out = output.get();
@@ -149,6 +150,7 @@ public class Reporter {
             transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
             transformer.transform(new DOMSource(document),
                     new StreamResult(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
+            return result;
         } catch (TransformerException | IOException e) {
             throw new RatException(e);
         }

--- a/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
@@ -28,7 +28,8 @@ import org.apache.rat.commandline.ArgumentContext;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.report.IReportable;
-import org.apache.rat.test.AbstractOptionsProvider;
+import org.apache.rat.test.AbstractConfigurationOptionsProvider;
+import org.apache.rat.test.utils.OptionFormatter;
 import org.apache.rat.testhelpers.TestingLog;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log;
@@ -61,7 +62,7 @@ public class OptionCollectionTest {
 
     @AfterAll
     static void preserveData() {
-        AbstractOptionsProvider.preserveData(testPath.toFile(), "optionTest");
+        AbstractConfigurationOptionsProvider.preserveData(testPath.toFile(), "optionTest");
     }
 
     /**
@@ -80,15 +81,6 @@ public class OptionCollectionTest {
     @EnabledOnOs(OS.WINDOWS)
     void cleanUp() {
         System.gc();
-    }
-
-    /**
-     * Returns the command line format (with '--' prefix) for the Option.
-     * @param opt the option to process.
-     * @return the command line option.
-     */
-    private static String longOpt(Option opt) {
-        return "--" + opt.getLongOpt();
     }
 
     @Test
@@ -166,14 +158,14 @@ public class OptionCollectionTest {
     /**
      * A class to provide the Options and tests to the testOptionsUpdateConfig.
      */
-    static class CliOptionsProvider extends AbstractOptionsProvider implements ArgumentsProvider {
+    static class CliOptionsProvider extends AbstractConfigurationOptionsProvider implements ArgumentsProvider {
 
         /** A flag to determine if help was called */
         final AtomicBoolean helpCalled = new AtomicBoolean(false);
 
         @Override
         public void helpTest() {
-            String[] args = { longOpt(OptionCollection.HELP) };
+            String[] args = { OptionFormatter.longOpt(OptionCollection.HELP) };
             try {
                 ReportConfiguration config = OptionCollection.parseCommands(testPath.toFile(), args, o -> helpCalled.set(true), true);
                 assertThat(config).as("Should not have config").isNull();

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
@@ -1,0 +1,1397 @@
+package org.apache.rat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.rat.api.RatException;
+import org.apache.rat.commandline.Arg;
+import org.apache.rat.commandline.StyleSheets;
+import org.apache.rat.config.exclusion.StandardCollection;
+import org.apache.rat.config.results.ClaimValidator;
+import org.apache.rat.configuration.builders.SpdxBuilder;
+import org.apache.rat.help.Help;
+import org.apache.rat.license.ILicense;
+import org.apache.rat.license.ILicenseFamily;
+import org.apache.rat.license.LicenseSetFactory;
+import org.apache.rat.report.claim.ClaimStatistic;
+import org.apache.rat.test.AbstractConfigurationOptionsProvider;
+import org.apache.rat.test.AbstractOptionsProvider;
+import org.apache.rat.test.utils.OptionFormatter;
+import org.apache.rat.test.utils.Resources;
+import org.apache.rat.testhelpers.TestingLog;
+import org.apache.rat.testhelpers.TextUtils;
+import org.apache.rat.testhelpers.XmlUtils;
+import org.apache.rat.utils.DefaultLog;
+import org.apache.rat.utils.Log;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import static org.apache.rat.commandline.Arg.HELP_LICENSES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+public class ReporterOptionsTest {
+
+    @TempDir
+    static Path testPath;
+
+    @AfterAll
+    static void preserveData() {
+        AbstractConfigurationOptionsProvider.preserveData(testPath.toFile(), "reporterOptionsTest");
+    }
+
+    private static void mkDir(File dir) {
+        boolean ignored = dir.mkdirs();
+    }
+
+    private static void delete(File file) {
+        if (file.exists()) {
+            boolean ignored = file.delete();
+        }
+    }
+
+    /**
+     * This method is a known workaround for
+     * {@link <a href="https://github.com/junit-team/junit5/issues/2811">junit 5 issue #2811</a> }.
+     */
+    @AfterEach
+    @EnabledOnOs(OS.WINDOWS)
+    void cleanUp() {
+        System.gc();
+    }
+
+    @BeforeEach
+    void setup() {
+        ReporterOptionsProvider.sourceDir = null;
+    }
+
+    /**
+     * A parameterized test for the options.
+     * @param name The name of the test.
+     */
+    @ParameterizedTest( name = "{index} {0}")
+    @ArgumentsSource(ReporterOptionsProvider.class)
+    public void testOptionsUpdateConfig(String name, OptionCollectionTest.OptionTest test) {
+        DefaultLog.getInstance().log(Log.Level.INFO, "Running test for: " + name);
+        test.test();
+    }
+
+    /**
+     * A class to provide the Options and tests to the testOptionsUpdateConfig.
+     */
+    static class ReporterOptionsProvider extends AbstractOptionsProvider implements ArgumentsProvider {
+        private static File sourceDir;
+
+        /**
+         * A flag to determine if help was called
+         */
+        final AtomicBoolean helpCalled = new AtomicBoolean(false);
+
+        public ReporterOptionsProvider() {
+            super(testPath.toFile());
+            testMap.put("addLicense", this::addLicenseTest);
+            testMap.put("config", this::configTest);
+            testMap.put("configuration-no-defaults", this::configurationNoDefaultsTest);
+            testMap.put("copyright", this::copyrightTest);
+            testMap.put("counter-min", this::counterMinTest);
+            testMap.put("counter-max", this::counterMaxTest);
+            testMap.put("dir", () -> DefaultLog.getInstance().info("--dir has no valid test"));
+            testMap.put("dry-run", this::dryRunTest);
+            testMap.put("edit-copyright", this::editCopyrightTest);
+            testMap.put("edit-license", this::editLicensesTest);
+            testMap.put("edit-overwrite", this::editOverwriteTest);
+            testMap.put("exclude", this::excludeTest);
+            testMap.put("exclude-file", this::excludeFileTest);
+            testMap.put("force", this::forceTest);
+            testMap.put("help", this::helpTest);
+            testMap.put("help-licenses", this::helpLicenses);
+            testMap.put("include", this::includeTest);
+            testMap.put("includes-file", this::includesFileTest);
+            testMap.put("input-exclude", this::inputExcludeTest);
+            testMap.put("input-exclude-file", this::inputExcludeFileTest);
+            testMap.put("input-exclude-parsed-scm", this::inputExcludeParsedScmTest);
+            testMap.put("input-exclude-std", this::inputExcludeStdTest);
+            testMap.put("input-exclude-size", this::inputExcludeSizeTest);
+            testMap.put("input-include", this::inputIncludeTest);
+            testMap.put("input-include-file", this::inputIncludeFileTest);
+            testMap.put("input-include-std", this::inputIncludeStdTest);
+            testMap.put("input-source", this::inputSourceTest);
+            testMap.put("license-families-approved", this::licenseFamiliesApprovedTest);
+            testMap.put("license-families-approved-file", this::licenseFamiliesApprovedFileTest);
+            testMap.put("license-families-denied", this::licenseFamiliesDeniedTest);
+            testMap.put("license-families-denied-file", this::licenseFamiliesDeniedFileTest);
+            testMap.put("licenses", this::licensesTest);
+            testMap.put("licenses-approved", this::licensesApprovedTest);
+            testMap.put("licenses-approved-file", this::licensesApprovedFileTest);
+            testMap.put("licenses-denied", this::licensesDeniedTest);
+            testMap.put("licenses-denied-file", this::licensesDeniedFileTest);
+            testMap.put("list-families", this::listFamiliesTest);
+            testMap.put("list-licenses", this::listLicensesTest);
+            testMap.put("log-level", this::logLevelTest);
+            testMap.put("no-default-licenses", this::noDefaultsTest);
+            testMap.put("out", this::outTest);
+            testMap.put("output-archive", this::outputArchiveTest);
+            testMap.put("output-families", this::outputFamiliesTest);
+            testMap.put("output-file", this::outputFileTest);
+            testMap.put("output-licenses", this::outputLicensesTest);
+            testMap.put("output-standard", this::outputStandardTest);
+            testMap.put("output-style", this::outputStyleTest);
+            testMap.put("scan-hidden-directories", this::scanHiddenDirectoriesTest);
+            testMap.put("stylesheet", this::styleSheetTest);
+            testMap.put("xml", this::xmlTest);
+            super.validate(Collections.emptyList());
+        }
+
+        /**
+         * Generate a ReportConfiguration from a set of arguments.
+         * Forces the {@code helpCalled} flag to be reset.
+         *
+         * @param args the arguments.
+         * @return A ReportConfiguration
+         * @throws IOException on critical error.
+         */
+        @Override
+        protected final ReportConfiguration generateConfig(List<Pair<Option, String[]>> args) throws IOException {
+            return generateConfig(args, false);
+        }
+
+        protected final ReportConfiguration generateConfig(List<Pair<Option, String[]>> args, boolean helpExpected) throws IOException {
+            if (sourceDir == null) {
+                throw new IOException("sourceDir not set");
+            }
+            helpCalled.set(false);
+            List<String> sArgs = new ArrayList<>();
+            for (Pair<Option, String[]> pair : args) {
+                if (pair.getKey() != null) {
+                    sArgs.add("--" + pair.getKey().getLongOpt());
+                    String[] oArgs = pair.getValue();
+                    if (oArgs != null) {
+                        Collections.addAll(sArgs, oArgs);
+                    }
+                }
+            }
+            ReportConfiguration config = OptionCollection.parseCommands(sourceDir, sArgs.toArray(new String[0]), o -> helpCalled.set(true), true);
+            assertThat(helpCalled.get()).as("Help was called").isEqualTo(helpExpected);
+            if (config != null && !config.hasSource()) {
+                config.addSource(OptionCollection.getReportable(sourceDir, config));
+            }
+            return config;
+        }
+
+        private void configureSourceDir(Option option) {
+            sourceDir = new File(baseDir, OptionFormatter.getName(option));
+            mkDir(sourceDir);
+        }
+
+        private void validateNoArgSetup() throws IOException, RatException {
+            // verify that without args the report is ok.
+            TestingLog log = new TestingLog();
+            DefaultLog.setInstance(log);
+            try {
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                ClaimValidator validator = config.getClaimValidator();
+                assertThat(validator.listIssues(claimStatistic)).isEmpty();
+            } finally {
+                DefaultLog.setInstance(null);
+            }
+
+        }
+
+        protected void addLicenseTest() {
+            editLicenseTest(Arg.EDIT_ADD.find("addLicense"));
+        }
+
+        protected void editLicensesTest() {
+            editLicenseTest(Arg.EDIT_ADD.find("edit-license"));
+        }
+
+        private void editLicenseTest(final Option option) {
+            try {
+                configureSourceDir(option);
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, null));
+                File testFile = writeFile("NoLicense.java", "class NoLicense {}");
+                File resultFile = new File(sourceDir, "NoLicense.java.new");
+                delete(resultFile);
+
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                String contents = String.join("\n", IOUtils.readLines(new FileReader(testFile)));
+                assertThat(contents).isEqualTo("class NoLicense {}");
+                assertThat(resultFile).exists();
+                contents = String.join("\n", IOUtils.readLines(new FileReader(resultFile)));
+                assertThat(contents).isEqualTo("/*\n" +
+                        " * Licensed to the Apache Software Foundation (ASF) under one\n" +
+                        " * or more contributor license agreements.  See the NOTICE file\n" +
+                        " * distributed with this work for additional information\n" +
+                        " * regarding copyright ownership.  The ASF licenses this file\n" +
+                        " * to you under the Apache License, Version 2.0 (the\n" +
+                        " * \"License\"); you may not use this file except in compliance\n" +
+                        " * with the License.  You may obtain a copy of the License at\n" +
+                        " * \n" +
+                        " *   http://www.apache.org/licenses/LICENSE-2.0\n" +
+                        " * \n" +
+                        " * Unless required by applicable law or agreed to in writing,\n" +
+                        " * software distributed under the License is distributed on an\n" +
+                        " * \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n" +
+                        " * KIND, either express or implied.  See the License for the\n" +
+                        " * specific language governing permissions and limitations\n" +
+                        " * under the License.\n" +
+                        " */\n\n" +
+                        "class NoLicense {}");
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected File writeFile(File dir, String name) {
+            return writeFile(dir, name, Collections.singletonList(name));
+        }
+
+        protected File writeFile(String name) {
+            return writeFile(sourceDir, name, Collections.singletonList(name));
+        }
+
+        protected File writeFile(String name, String content) {
+            return writeFile(sourceDir, name, Collections.singletonList(content));
+        }
+
+        protected File writeFile(String name, Iterable<String> content) {
+            return writeFile(sourceDir, name, content);
+        }
+
+        private void execLicensesDeniedTest(final Option option, final String[] args) {
+            try {
+                configureSourceDir(option);
+                File illumosFile = writeFile("illumousFile.java", "The contents of this file are " +
+                        "subject to the terms of the Common Development and Distribution License (the \"License\") You " +
+                        "may not use this file except in compliance with the License.");
+
+                validateNoArgSetup();
+
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                ClaimValidator validator = config.getClaimValidator();
+                assertThat(validator.listIssues(claimStatistic)).containsExactly("UNAPPROVED");
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void licensesDeniedTest() {
+            execLicensesDeniedTest(Arg.LICENSES_DENIED.find("licenses-denied"), new String[]{"ILLUMOS"});
+        }
+
+        protected void licensesDeniedFileTest() {
+            File outputFile = writeFile("licensesDenied.txt", Collections.singletonList("ILLUMOS"));
+            execLicensesDeniedTest(Arg.LICENSES_DENIED_FILE.find("licenses-denied-file"),
+                    new String[]{outputFile.getAbsolutePath()});
+        }
+
+        private void noDefaultsTest(final Option option) {
+            try {
+                configureSourceDir(option);
+                File testFile = writeFile("Test.java", Arrays.asList("/*\n", "SPDX-License-Identifier: Apache-2.0\n",
+                        "*/\n\n", "class Test {}\n"));
+
+                validateNoArgSetup();
+
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, null));
+                Reporter reporter = new Reporter(config);
+                try {
+                    reporter.execute();
+                    fail("Should have thrown exception");
+                } catch (RatException e) {
+                    ClaimStatistic claimStatistic = reporter.getClaimsStatistic();
+                    ClaimValidator validator = config.getClaimValidator();
+                    assertThat(validator.listIssues(claimStatistic)).containsExactlyInAnyOrder("DOCUMENT_TYPES", "LICENSE_CATEGORIES", "LICENSE_NAMES", "STANDARDS");
+                }
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void noDefaultsTest() {
+            noDefaultsTest(Arg.CONFIGURATION_NO_DEFAULTS.find("no-default-licenses"));
+        }
+
+        protected void configurationNoDefaultsTest() {
+            noDefaultsTest(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"));
+        }
+
+        protected void counterMaxTest() {
+            Option option = Arg.COUNTER_MAX.option();
+            String[] arg = {null};
+            try {
+                configureSourceDir(option);
+                File testFile = writeFile("Test.java", Arrays.asList("/*\n", "SPDX-License-Identifier: Unapproved\n",
+                        "*/\n\n", "class Test {}\n"));
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                ClaimValidator validator = config.getClaimValidator();
+                assertThat(validator.listIssues(claimStatistic)).containsExactly("UNAPPROVED");
+
+                arg[0] = "Unapproved:1";
+                config = generateConfig(ImmutablePair.of(option, arg));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                validator = config.getClaimValidator();
+                assertThat(validator.listIssues(claimStatistic)).isEmpty();
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void counterMinTest() {
+            Option option = Arg.COUNTER_MIN.option();
+            String[] arg = {null};
+
+            try {
+                configureSourceDir(option);
+                File testFile = writeFile("Test.java", Arrays.asList("/*\n", "SPDX-License-Identifier: Unapproved\n",
+                        "*/\n\n", "class Test {}\n"));
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                ClaimValidator validator = config.getClaimValidator();
+                assertThat(validator.listIssues(claimStatistic)).containsExactly("UNAPPROVED");
+
+                arg[0] = "Unapproved:1";
+                config = generateConfig(ImmutablePair.of(option, arg));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                validator = config.getClaimValidator();
+                assertThat(validator.listIssues(claimStatistic)).isEmpty();
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        // exclude tests
+        private void execExcludeTest(final Option option, final String[] args) {
+            String[] notExcluded = {"notbaz", "well._afile"};
+            String[] excluded = {"some.foo", "B.bar", "justbaz"};
+            try {
+                configureSourceDir(option);
+                writeFile("notbaz");
+                writeFile("well._afile");
+                writeFile("some.foo");
+                writeFile("B.bar");
+                writeFile("justbaz");
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(5);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+
+                // filter out source
+                config = generateConfig(ImmutablePair.of(option, args));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(3);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        private void excludeFileTest(final Option option) {
+            File outputFile = writeFile("exclude.txt", Arrays.asList(EXCLUDE_ARGS));
+            execExcludeTest(option, new String[]{outputFile.getAbsolutePath()});
+        }
+
+        protected void excludeFileTest() {
+            excludeFileTest(Arg.EXCLUDE_FILE.find("exclude-file"));
+        }
+
+        protected void inputExcludeFileTest() {
+            excludeFileTest(Arg.EXCLUDE_FILE.find("input-exclude-file"));
+        }
+
+        protected void excludeTest() {
+            execExcludeTest(Arg.EXCLUDE.find("exclude"), EXCLUDE_ARGS);
+        }
+
+        protected void inputExcludeTest() {
+            execExcludeTest(Arg.EXCLUDE.find("input-exclude"), EXCLUDE_ARGS);
+        }
+
+        private void inputExcludeSizeTest() {
+            Option option = Arg.EXCLUDE_SIZE.option();
+            String[] args = {"5"};
+
+            try {
+                configureSourceDir(option);
+                writeFile("Hi.txt", "Hi");
+                writeFile("Hello.txt", "Hello");
+                writeFile("HelloWorld.txt", "HelloWorld");
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(3);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+
+                // filter out source
+                config = generateConfig(ImmutablePair.of(option, args));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void inputExcludeStdTest() {
+            Option option = Arg.EXCLUDE_STD.find("input-exclude-std");
+            String[] args = {StandardCollection.MAVEN.name()};
+            // these files are excluded by default "afile~", ".#afile", "%afile%", "._afile"
+            // these files are not excluded by default "afile~more", "what.#afile", "%afile%withMore", "well._afile", "build.log"
+            // build.log is excluded by MAVEN.
+            try {
+                configureSourceDir(option);
+                writeFile("afile~");
+                writeFile(".#afile");
+                writeFile("%afile%");
+                writeFile("._afile");
+                writeFile("afile~more");
+                writeFile("what.#afile");
+                writeFile("%afile%withMore");
+                writeFile("well._afile");
+                writeFile("build.log");
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(5);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(4);
+
+                config = generateConfig(ImmutablePair.of(option, args));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(4);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(5);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void inputExcludeParsedScmTest() {
+            Option option = Arg.EXCLUDE_PARSE_SCM.find("input-exclude-parsed-scm");
+            String[] args = {"GIT"};
+            String[] lines = {
+                    "# somethings",
+                    "!thingone", "thing*", System.lineSeparator(),
+                    "# some fish",
+                    "**/fish", "*_fish",
+                    "# some colorful directories",
+                    "red/", "blue/*/"};
+
+            try {
+                configureSourceDir(option);
+
+                writeFile(".gitignore", Arrays.asList(lines));
+                writeFile("thingone");
+                writeFile("thingtwo");
+
+                File dir = new File(sourceDir, "dir");
+                mkDir(dir);
+                writeFile(dir, "fish_two");
+                writeFile(dir, "fish");
+
+                dir = new File(sourceDir, "red");
+                mkDir(dir);
+                writeFile(dir, "fish");
+
+                dir = new File(sourceDir, "blue/fish");
+                mkDir(dir);
+                writeFile(dir, "dory");
+
+                dir = new File(sourceDir, "some");
+                mkDir(dir);
+                writeFile(dir, "fish");
+                writeFile(dir, "things");
+                writeFile(dir, "thingone");
+
+                dir = new File(sourceDir, "another");
+                mkDir(dir);
+                writeFile(dir, "red_fish");
+
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(11);
+                // .gitignore is ignored by default as it is hidden but not counted
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+
+                config = generateConfig(ImmutablePair.of(option, args));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(3);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(8);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        // include tests
+        private void execIncludeTest(final Option option, final String[] args) {
+            Option excludeOption = Arg.EXCLUDE.option();
+            String[] notExcluded = {"B.bar", "justbaz", "notbaz"};
+            String[] excluded = {"some.foo"};
+            try {
+                configureSourceDir(option);
+                writeFile("notbaz");
+                writeFile("some.foo");
+                writeFile("B.bar");
+                writeFile("justbaz");
+
+                ReportConfiguration config = generateConfig(Collections.emptyList());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(4);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+
+                // verify exclude removes most files.
+                config = generateConfig(ImmutablePair.of(excludeOption, EXCLUDE_ARGS));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                // .gitignore is ignored by default as it is hidden but not counted
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(3);
+
+                // verify include pust them back
+                config = generateConfig(ImmutablePair.of(option, args), ImmutablePair.of(excludeOption, EXCLUDE_ARGS));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(3);
+                // .gitignore is ignored by default as it is hidden but not counted
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        private void includeFileTest(final Option option) {
+            File outputFile = writeFile("include.txt", Arrays.asList(INCLUDE_ARGS));
+            execIncludeTest(option, new String[]{outputFile.getAbsolutePath()});
+        }
+
+        protected void inputIncludeFileTest() {
+            includeFileTest(Arg.INCLUDE_FILE.find("input-include-file"));
+        }
+
+        protected void includesFileTest() {
+            includeFileTest(Arg.INCLUDE_FILE.find("includes-file"));
+        }
+
+        protected void includeTest() {
+            execIncludeTest(Arg.INCLUDE.find("include"), INCLUDE_ARGS);
+        }
+
+        protected void inputIncludeTest() {
+            execIncludeTest(Arg.INCLUDE.find("input-include"), INCLUDE_ARGS);
+        }
+
+        protected void inputIncludeStdTest() {
+            Option option = Arg.INCLUDE_STD.find("input-include-std");
+            String[] args = {StandardCollection.MISC.name()};
+            try {
+                configureSourceDir(option);
+
+                writeFile("afile~more");
+                writeFile("afile~");
+                writeFile(".#afile");
+                writeFile("%afile%");
+                writeFile("._afile");
+                writeFile("what.#afile");
+                writeFile("%afile%withMore");
+                writeFile("well._afile");
+
+                ImmutablePair<Option, String[]> excludes = ImmutablePair.of(Arg.EXCLUDE.find("input-exclude"),
+                        new String[]{"*~more", "*~"});
+
+                ReportConfiguration config = generateConfig(Collections.singletonList(excludes));
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(3);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(5);
+
+                config = generateConfig(excludes, ImmutablePair.of(option, args));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(7);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void inputSourceTest() {
+            Option option = Arg.SOURCE.find("input-source");
+            try {
+                configureSourceDir(option);
+
+                writeFile("codefile");
+                File inputFile = writeFile("intput.txt", "codefile");
+                writeFile("notcodFile");
+
+                ReportConfiguration config = generateConfig();
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(3);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+
+                config = generateConfig(ImmutablePair.of(option, new String[]{inputFile.getAbsolutePath()}));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        private ReportConfiguration addCatzLicense(ReportConfiguration config) {
+            String catz = ILicenseFamily.makeCategory("catz");
+            config.addFamily(ILicenseFamily.builder().setLicenseFamilyCategory(catz).setLicenseFamilyName("catz").build());
+            config.addLicense(ILicense.builder().setFamily(catz)
+                    .setMatcher(new SpdxBuilder().setName("catz")));
+            return config;
+        }
+
+        private void execLicenseFamiliesApprovedTest(final Option option, final String[] args) {
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+            try {
+                configureSourceDir(option);
+                // write the catz licensed text file
+                writeFile("catz.txt", "SPDX-License-Identifier: catz");
+
+                ReportConfiguration config = addCatzLicense(generateConfig());
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(0);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+                config = addCatzLicense(generateConfig(arg1));
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void licenseFamiliesApprovedFileTest() {
+            File outputFile = writeFile("familiesApproved.txt", Collections.singletonList("catz"));
+            execLicenseFamiliesApprovedTest(Arg.FAMILIES_APPROVED_FILE.find("license-families-approved-file"),
+                    new String[]{outputFile.getAbsolutePath()});
+        }
+
+        protected void licenseFamiliesApprovedTest() {
+            execLicenseFamiliesApprovedTest(Arg.FAMILIES_APPROVED.find("license-families-approved"),
+                    new String[]{"catz"});
+        }
+
+        private void execLicenseFamiliesDeniedTest(final Option option, final String[] args) {
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+            String bsd = ILicenseFamily.makeCategory("BSD-3");
+            try {
+                configureSourceDir(option);
+
+                // write the catz licensed text file
+                writeFile("bsd.txt", "SPDX-License-Identifier: BSD-3-Clause");
+
+                ReportConfiguration config = generateConfig();
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+
+                config = generateConfig(arg1);
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(0);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void licenseFamiliesDeniedFileTest() {
+            File outputFile = writeFile("familiesDenied.txt", Collections.singletonList("BSD-3"));
+            execLicenseFamiliesDeniedTest(Arg.FAMILIES_DENIED_FILE.find("license-families-denied-file"),
+                    new String[]{outputFile.getAbsolutePath()});
+        }
+
+        protected void licenseFamiliesDeniedTest() {
+            execLicenseFamiliesDeniedTest(Arg.FAMILIES_DENIED.find("license-families-denied"),
+                    new String[]{"BSD-3"});
+        }
+
+
+        private void configTest(final Option option) {
+            try {
+                configureSourceDir(option);
+                String[] args = {
+                        Resources.getResourceFile("OptionTools/One.xml").getAbsolutePath(),
+                        Resources.getResourceFile("OptionTools/Two.xml").getAbsolutePath()};
+
+                Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+
+                writeFile("bsd.txt", "SPDX-License-Identifier: BSD-3-Clause");
+                writeFile("one.txt", "one is the lonelest number");
+
+                ReportConfiguration config = generateConfig();
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+                config = generateConfig(arg1);
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+
+                Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"), null);
+
+                config = generateConfig(arg1, arg2);
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void licensesTest() {
+            configTest(Arg.CONFIGURATION.find("licenses"));
+        }
+
+        protected void configTest() {
+            configTest(Arg.CONFIGURATION.find("config"));
+        }
+
+        protected void execLicensesApprovedTest(final Option option, String[] args) {
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+
+            try {
+                configureSourceDir(option);
+
+                writeFile("gpl.txt", "SPDX-License-Identifier: GPL-1.0-only");
+                writeFile("apl.txt", "SPDX-License-Identifier: Apache-2.0");
+
+                ReportConfiguration config = generateConfig();
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+                config = generateConfig(arg1);
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+
+
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void licensesApprovedFileTest() {
+            File outputFile = writeFile("licensesApproved.txt", Collections.singletonList("GPL1"));
+            execLicensesApprovedTest(Arg.LICENSES_APPROVED_FILE.find("licenses-approved-file"),
+                    new String[]{outputFile.getAbsolutePath()});
+        }
+
+        protected void licensesApprovedTest() {
+            execLicensesApprovedTest(Arg.LICENSES_APPROVED.find("licenses-approved"),
+                    new String[]{"GPL1"});
+        }
+
+        protected void scanHiddenDirectoriesTest() {
+            Option option = Arg.INCLUDE_STD.find("scan-hidden-directories");
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, null);
+
+            try {
+                configureSourceDir(option);
+
+                writeFile("apl.txt", "SPDX-License-Identifier: Apache-2.0");
+
+                File hiddenDir = new File(sourceDir, ".hiddendir");
+                mkDir(hiddenDir);
+                writeFile(hiddenDir, "gpl.txt", Collections.singletonList("SPDX-License-Identifier: GPL-1.0-only"));
+
+                ReportConfiguration config = generateConfig();
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+
+                config = generateConfig(arg1);
+                reporter = new Reporter(config);
+                claimStatistic = reporter.execute();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(2);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        private void outTest(final Option option) {
+            try {
+                configureSourceDir(option);
+                writeFile("apl.txt", "SPDX-License-Identifier: Apache-2.0");
+                File outFile = new File(sourceDir, "outexample");
+                delete(outFile);
+                String[] args = new String[]{outFile.getAbsolutePath()};
+
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.output();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+
+                String actualText = TextUtils.readFile(outFile);
+                TextUtils.assertContainsExactly(1, "Apache License Version 2.0: 1 ", actualText);
+                TextUtils.assertContainsExactly(1, "STANDARD: 1 ", actualText);
+
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void outTest() {
+            outTest(Arg.OUTPUT_FILE.find("out"));
+        }
+
+        protected void outputFileTest() {
+            outTest(Arg.OUTPUT_FILE.find("output-file"));
+        }
+
+        private void styleSheetTest(final Option option) {
+            PrintStream origin = System.out;
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (PrintStream out = new PrintStream(baos)) {
+                System.setOut(out);
+                configureSourceDir(option);
+                // create a dummy stylesheet so that we have a local file for users of the testing jar.
+                File file = writeFile("stylesheet", "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
+                        "    <xsl:template match=\"@*|node()\">\n" +
+                        "        Hello world\n" +
+                        "    </xsl:template>\n" +
+                        "</xsl:stylesheet>");
+
+                String[] args = {null};
+                for (StyleSheets sheet : StyleSheets.values()) {
+                    args[0] = sheet.arg();
+                    ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                    Reporter reporter = new Reporter(config);
+                    ClaimStatistic claimStatistic = reporter.output();
+                    assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                    assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(0);
+                    assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+                    String actualText = baos.toString(StandardCharsets.UTF_8.name());
+                    switch (sheet) {
+                        case MISSING_HEADERS:
+                            TextUtils.assertContainsExactly(1, "Files with missing headers:\n" +
+                                    "  /stylesheet", actualText);
+                            break;
+                        case PLAIN:
+                            TextUtils.assertContainsExactly(1, "Unknown license: 1 ", actualText);
+                            TextUtils.assertContainsExactly(1, "?????: 1 ", actualText);
+                            break;
+                        case XML:
+                            TextUtils.assertContainsExactly(1, "<resource encoding=\"ISO-8859-1\" mediaType=\"text/plain\" name=\"/stylesheet\" type=\"STANDARD\">", actualText);
+                            break;
+                        case UNAPPROVED_LICENSES:
+                            TextUtils.assertContainsExactly(1, "Files with unapproved licenses:\n  /stylesheet", actualText);
+                            break;
+                        default:
+                            fail("No test for stylesheet " + sheet);
+                            break;
+                    }
+                    baos.reset();
+                }
+                args[0] = file.getAbsolutePath();
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.output();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(0);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+                String actualText = baos.toString(StandardCharsets.UTF_8.name());
+                TextUtils.assertContainsExactly(1, "Hello world", actualText);
+
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            } finally {
+                System.setOut(origin);
+            }
+        }
+
+        protected void styleSheetTest() {
+            styleSheetTest(Arg.OUTPUT_STYLE.find("stylesheet"));
+        }
+
+        protected void outputStyleTest() {
+            styleSheetTest(Arg.OUTPUT_STYLE.find("output-style"));
+        }
+
+        protected void xmlTest() {
+            PrintStream origin = System.out;
+            Option option = Arg.OUTPUT_STYLE.find("xml");
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (PrintStream out = new PrintStream(baos)) {
+                System.setOut(out);
+                configureSourceDir(option);
+                // create a dummy stylesheet so that we match the stylesheet tests.
+                File file = writeFile("stylesheet", "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n" +
+                        "    <xsl:template match=\"@*|node()\">\n" +
+                        "        Hello world\n" +
+                        "    </xsl:template>\n" +
+                        "</xsl:stylesheet>");
+
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, null));
+                Reporter reporter = new Reporter(config);
+                ClaimStatistic claimStatistic = reporter.output();
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.STANDARDS)).isEqualTo(1);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.APPROVED)).isEqualTo(0);
+                assertThat(claimStatistic.getCounter(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+
+                String actualText = baos.toString(StandardCharsets.UTF_8.name());
+                TextUtils.assertContainsExactly(1, "<resource encoding=\"ISO-8859-1\" mediaType=\"text/plain\" name=\"/stylesheet\" type=\"STANDARD\">", actualText);
+
+                try (InputStream expected = StyleSheets.getStyleSheet("xml").get();
+                     InputStream actual = config.getStyleSheet().get()) {
+                    assertThat(IOUtils.contentEquals(expected, actual)).as("'xml' does not match").isTrue();
+                }
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            } finally {
+                System.setOut(origin);
+            }
+        }
+
+        protected void logLevelTest() {
+            PrintStream origin = System.out;
+            Option option = Arg.LOG_LEVEL.find("log-level");
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Log.Level oldLevel = DefaultLog.getInstance().getLevel();
+            try (PrintStream out = new PrintStream(baos)) {
+                System.setOut(out);
+                configureSourceDir(option);
+
+                ReportConfiguration config = generateConfig();
+                Reporter reporter = new Reporter(config);
+                reporter.output();
+                TextUtils.assertNotContains("DEBUG", baos.toString(StandardCharsets.UTF_8.name()));
+
+                config = generateConfig(ImmutablePair.of(option, new String[]{"debug"}));
+                reporter = new Reporter(config);
+                reporter.output();
+                TextUtils.assertContains("DEBUG", baos.toString(StandardCharsets.UTF_8.name()));
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            } finally {
+                System.setOut(origin);
+                DefaultLog.getInstance().setLevel(oldLevel);
+            }
+        }
+
+        private void listLicenses(final Option option) {
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String[] args = {null};
+            File outFile = new File(sourceDir, "out.xml");
+            ImmutablePair<Option, String[]> outputFile = ImmutablePair.of(Arg.OUTPUT_FILE.option(), new String[]{outFile.getAbsolutePath()});
+            ImmutablePair<Option, String[]> stylesheet = ImmutablePair.of(Arg.OUTPUT_STYLE.option(), new String[]{StyleSheets.XML.arg()});
+
+            try {
+                configureSourceDir(option);
+                for (LicenseSetFactory.LicenseFilter filter : LicenseSetFactory.LicenseFilter.values()) {
+                    args[0] = filter.name();
+                    ReportConfiguration config = generateConfig(outputFile, stylesheet, ImmutablePair.of(option, args));
+                    Reporter reporter = new Reporter(config);
+                    reporter.output();
+                    Document document = XmlUtils.toDom(new FileInputStream(outFile));
+                    switch (filter) {
+                        case ALL:
+                            XmlUtils.assertIsPresent(filter.name(), document, xPath, "/rat-report/rat-config/licenses/license[@id='AL']");
+                            XmlUtils.assertIsPresent(filter.name(), document, xPath, "/rat-report/rat-config/licenses/license[@id='GPL1']");
+                            break;
+                        case APPROVED:
+                            XmlUtils.assertIsPresent(filter.name(), document, xPath, "/rat-report/rat-config/licenses/license[@id='AL']");
+                            XmlUtils.assertIsNotPresent(filter.name(), document, xPath, "/rat-report/rat-config/licenses/license[@id='GPL1']");
+                            break;
+                        case NONE:
+                            XmlUtils.assertIsNotPresent(filter.name(), document, xPath, "/rat-report/rat-config/licenses/license[@id='AL']");
+                            XmlUtils.assertIsNotPresent(filter.name(), document, xPath, "/rat-report/rat-config/licenses/license[@id='GPL1']");
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unexpected filter: " + filter);
+                    }
+                }
+            } catch (IOException | RatException | SAXException | ParserConfigurationException |
+                     XPathExpressionException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void listLicensesTest() {
+            listLicenses(Arg.OUTPUT_LICENSES.find("list-licenses"));
+        }
+
+        protected void outputLicensesTest() {
+            listLicenses(Arg.OUTPUT_LICENSES.find("output-licenses"));
+        }
+
+        private void listFamilies(final Option option) {
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String[] args = {null};
+            File outFile = new File(sourceDir, "out.xml");
+            ImmutablePair<Option, String[]> outputFile = ImmutablePair.of(Arg.OUTPUT_FILE.option(), new String[]{outFile.getAbsolutePath()});
+            ImmutablePair<Option, String[]> stylesheet = ImmutablePair.of(Arg.OUTPUT_STYLE.option(), new String[]{StyleSheets.XML.arg()});
+
+            try {
+                configureSourceDir(option);
+                for (LicenseSetFactory.LicenseFilter filter : LicenseSetFactory.LicenseFilter.values()) {
+                    args[0] = filter.name();
+                    ReportConfiguration config = generateConfig(outputFile, stylesheet, ImmutablePair.of(option, args));
+                    Reporter reporter = new Reporter(config);
+                    reporter.output();
+                    Document document = XmlUtils.toDom(Files.newInputStream(outFile.toPath()));
+                    switch (filter) {
+                        case ALL:
+                            XmlUtils.assertIsPresent(filter.name(), document, xPath, "/rat-report/rat-config/families/family[@id='AL']");
+                            XmlUtils.assertIsPresent(filter.name(), document, xPath, "/rat-report/rat-config/families/family[@id='GPL']");
+                            break;
+                        case APPROVED:
+                            XmlUtils.assertIsPresent(filter.name(), document, xPath, "/rat-report/rat-config/families/family[@id='AL']");
+                            XmlUtils.assertIsNotPresent(filter.name(), document, xPath, "/rat-report/rat-config/families/family[@id='GPL']");
+                            break;
+                        case NONE:
+                            XmlUtils.assertIsNotPresent(filter.name(), document, xPath, "/rat-report/rat-config/families/family[@id='AL']");
+                            XmlUtils.assertIsNotPresent(filter.name(), document, xPath, "/rat-report/rat-config/families/family[@id='GPL']");
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unexpected filter: " + filter);
+                    }
+                }
+            } catch (IOException | RatException | SAXException | ParserConfigurationException |
+                     XPathExpressionException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void listFamiliesTest() {
+            listFamilies(Arg.OUTPUT_FAMILIES.find("list-families"));
+        }
+
+        protected void outputFamiliesTest() {
+            listFamilies(Arg.OUTPUT_FAMILIES.find("output-families"));
+        }
+
+        private void archiveTest(final Option option) {
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String[] args = {null};
+            File outFile = new File(sourceDir, "out.xml");
+            ImmutablePair<Option, String[]> outputFile = ImmutablePair.of(Arg.OUTPUT_FILE.option(), new String[]{outFile.getAbsolutePath()});
+            ImmutablePair<Option, String[]> stylesheet = ImmutablePair.of(Arg.OUTPUT_STYLE.option(), new String[]{StyleSheets.XML.arg()});
+
+            try {
+                configureSourceDir(option);
+                File archive = Resources.getResourceFile("tikaFiles/archive/dummy.jar");
+                File localArchive = new File(sourceDir, "dummy.jar");
+                try (InputStream in = Files.newInputStream(archive.toPath());
+                     OutputStream out = Files.newOutputStream(localArchive.toPath())) {
+                    IOUtils.copy(in, out);
+                }
+
+                for (ReportConfiguration.Processing proc : ReportConfiguration.Processing.values()) {
+                    args[0] = proc.name();
+                    ReportConfiguration config = generateConfig(outputFile, stylesheet, ImmutablePair.of(option, args));
+                    Reporter reporter = new Reporter(config);
+                    reporter.output();
+
+                    Document document = XmlUtils.toDom(Files.newInputStream(outFile.toPath()));
+                    XmlUtils.assertIsPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']");
+                    switch (proc) {
+                        case ABSENCE:
+                            XmlUtils.assertIsPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']/license[@family='AL   ']");
+                            XmlUtils.assertIsPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']/license[@family='?????']");
+                            break;
+                        case PRESENCE:
+                            XmlUtils.assertIsPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']/license[@family='AL   ']");
+                            XmlUtils.assertIsNotPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']/license[@family='?????']");
+                            break;
+                        case NOTIFICATION:
+                            XmlUtils.assertIsNotPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']/license[@family='AL   ']");
+                            XmlUtils.assertIsNotPresent(proc.name(), document, xPath, "/rat-report/resource[@name='/dummy.jar']/license[@family='?????']");
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unexpected processing " + proc);
+                    }
+                }
+            } catch (IOException | RatException | SAXException | ParserConfigurationException |
+                     XPathExpressionException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void outputArchiveTest() {
+            archiveTest(Arg.OUTPUT_ARCHIVE.find("output-archive"));
+        }
+
+        private void standardTest(final Option option) {
+            XPath xPath = XPathFactory.newInstance().newXPath();
+            String[] args = {null};
+            File outFile = new File(sourceDir, "out.xml");
+            ImmutablePair<Option, String[]> outputFile = ImmutablePair.of(Arg.OUTPUT_FILE.option(), new String[]{outFile.getAbsolutePath()});
+            ImmutablePair<Option, String[]> stylesheet = ImmutablePair.of(Arg.OUTPUT_STYLE.option(), new String[]{StyleSheets.XML.arg()});
+
+            try {
+                configureSourceDir(option);
+                writeFile("Test.java", Arrays.asList("/*\n", "SPDX-License-Identifier: Apache-2.0\n",
+                        "*/\n\n", "class Test {}\n"));
+                writeFile("Missing.java", Arrays.asList("/* no license */\n\n", "class Test {}\n"));
+
+                String testDoc = "/rat-report/resource[@name='/Test.java']";
+                String missingDoc = "/rat-report/resource[@name='/Missing.java']";
+
+                for (ReportConfiguration.Processing proc : ReportConfiguration.Processing.values()) {
+                    args[0] = proc.name();
+                    ReportConfiguration config = generateConfig(outputFile, stylesheet, ImmutablePair.of(option, args));
+                    Reporter reporter = new Reporter(config);
+                    reporter.output();
+
+                    Document document = XmlUtils.toDom(Files.newInputStream(outFile.toPath()));
+                    XmlUtils.assertIsPresent(proc.name(), document, xPath, testDoc);
+                    XmlUtils.assertIsPresent(proc.name(), document, xPath, missingDoc);
+
+                    switch (proc) {
+                        case ABSENCE:
+                            XmlUtils.assertIsPresent(proc.name(), document, xPath, testDoc + "/license[@family='AL   ']");
+                            XmlUtils.assertIsPresent(proc.name(), document, xPath, missingDoc + "/license[@family='?????']");
+                            break;
+                        case PRESENCE:
+                            XmlUtils.assertIsPresent(proc.name(), document, xPath, testDoc + "/license[@family='AL   ']");
+                            XmlUtils.assertIsNotPresent(proc.name(), document, xPath, missingDoc + "/license[@family='?????']");
+                            break;
+                        case NOTIFICATION:
+                            XmlUtils.assertIsNotPresent(proc.name(), document, xPath, testDoc + "/license[@family='AL   ']");
+                            XmlUtils.assertIsNotPresent(proc.name(), document, xPath, missingDoc + "/license[@family='?????']");
+                            break;
+                        default:
+                            throw new IllegalArgumentException("Unexpected processing " + proc);
+                    }
+                }
+            } catch (IOException | RatException | SAXException | ParserConfigurationException |
+                     XPathExpressionException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void outputStandardTest() {
+            standardTest(Arg.OUTPUT_STANDARD.find("output-standard"));
+        }
+
+        private void editCopyrightTest(final Option option, final Option extraOption) {
+            final String myCopyright = "MyCopyright";
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, new String[]{myCopyright});
+            final boolean forced = Arg.EDIT_OVERWRITE.option().equals(extraOption);
+            final boolean dryRun = Arg.DRY_RUN.option().equals(extraOption);
+            Pair<Option, String[]> extraArg = null;
+            if (forced || dryRun) {
+                extraArg = ImmutablePair.of(extraOption, null);
+            }
+
+            try {
+                configureSourceDir(option);
+                File javaFile = writeFile("Missing.java", Arrays.asList("/* no license */\n\n", "class Test {}\n"));
+                File newJavaFile = new File(sourceDir, "Missing.java.new");
+                delete(newJavaFile);
+
+                ReportConfiguration config = extraArg != null ? generateConfig(arg1, extraArg) : generateConfig(arg1);
+                Reporter reporter = new Reporter(config);
+                reporter.execute();
+
+                String actualText = TextUtils.readFile(javaFile);
+                TextUtils.assertNotContains(myCopyright, actualText);
+
+                Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.EDIT_ADD.find("edit-license"), null);
+                config = extraArg != null ? generateConfig(arg1, arg2, extraArg) : generateConfig(arg1, arg2);
+                reporter = new Reporter(config);
+                reporter.execute();
+
+                actualText = TextUtils.readFile(javaFile);
+                if (forced) {
+                    TextUtils.assertContains(myCopyright, actualText);
+                    assertThat(newJavaFile).doesNotExist();
+                } else if (dryRun) {
+                    TextUtils.assertNotContains(myCopyright, actualText);
+                    assertThat(newJavaFile).doesNotExist();
+                } else {
+                    TextUtils.assertNotContains(myCopyright, actualText);
+                    assertThat(newJavaFile).exists();
+                }
+            } catch (IOException | RatException e) {
+                fail(e.getMessage(), e);
+            }
+        }
+
+        protected void copyrightTest() {
+            editCopyrightTest(Arg.EDIT_COPYRIGHT.find("copyright"), null);
+        }
+
+        protected void editCopyrightTest() {
+            editCopyrightTest(Arg.EDIT_COPYRIGHT.find("edit-copyright"), null);
+        }
+
+        protected void forceTest() {
+            editCopyrightTest(Arg.EDIT_COPYRIGHT.find("edit-copyright"), Arg.EDIT_OVERWRITE.find("force"));
+        }
+
+        protected void editOverwriteTest() {
+            editCopyrightTest(Arg.EDIT_COPYRIGHT.find("edit-copyright"), Arg.EDIT_OVERWRITE.find("edit-overwrite"));
+        }
+
+        @Override
+        public void helpTest() {
+            PrintStream origin = System.out;
+            Options options = OptionCollection.buildOptions();
+            Pair<Option, String[]> arg1 = ImmutablePair.of(OptionCollection.HELP, null);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            String actualText = null;
+            try (PrintStream out = new PrintStream(baos)) {
+                System.setOut(out);
+                configureSourceDir(OptionCollection.HELP);
+
+                ReportConfiguration config = generateConfig(Arrays.asList(arg1), true);
+                assertThat(helpCalled.get()).as("Help was not called").isTrue();
+                new Help(System.out).printUsage(options);
+                actualText = baos.toString(StandardCharsets.UTF_8.name());
+            } catch (IOException e) {
+                fail(e.getMessage(), e);
+            } finally {
+                System.setOut(origin);
+            }
+
+            // verify all the options
+            assertThat(actualText).contains("====== Available Options ======");
+            for (Option option : options.getOptions()) {
+                StringBuilder regex = new StringBuilder();
+                if (option.getOpt() != null) {
+                    regex.append("-").append(option.getOpt());
+                    if (option.hasLongOpt()) {
+                        regex.append(",");
+                    }
+                }
+                if (option.hasLongOpt()) {
+                    regex.append("--").append(option.getLongOpt());
+                }
+                if (option.hasArg()) {
+                    String name = option.getArgName() == null ? "arg" : option.getArgName();
+                    regex.append(".+\\<").append(name).append("\\>");
+                }
+                if (option.isDeprecated()) {
+                    regex.append(".+\\[Deprecated ");
+                }
+                assertThat(Pattern.compile(regex.toString()).matcher(actualText).find()).as("missing '" + regex + "'").isTrue();
+            }
+
+            assertThat(actualText).contains("====== Argument Types ======");
+            assertThat(actualText).contains("====== Standard Collections ======");
+            for (StandardCollection collection : StandardCollection.values()) {
+                assertThat(actualText).contains("<" + collection.name() + ">");
+            }
+        }
+
+
+        protected void helpLicenses() {
+            PrintStream origin = System.out;
+            Option option = HELP_LICENSES.option();
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, null);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            String actualText = null;
+            try (PrintStream out = new PrintStream(baos)) {
+                System.setOut(out);
+                configureSourceDir(option);
+                ReportConfiguration config = generateConfig(arg1);
+                actualText = baos.toString(StandardCharsets.UTF_8.name());
+            } catch (IOException e) {
+                fail(e.getMessage(), e);
+            } finally {
+                System.setOut(origin);
+            }
+
+            TextUtils.assertContains("====== Licenses ======", actualText);
+            TextUtils.assertContains("====== Defined Matchers ======", actualText);
+            TextUtils.assertContains("====== Defined Families ======", actualText);
+        }
+
+        protected void dryRunTest() {
+            editCopyrightTest(Arg.EDIT_COPYRIGHT.find("edit-copyright"), Arg.DRY_RUN.find("dry-run"));
+        }
+    }
+}

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
@@ -270,6 +270,7 @@ public class ReporterOptionsTest {
 
                 Reporter reporter = new Reporter(config);
                 ClaimStatistic claimStatistic = reporter.execute();
+                assertThat(claimStatistic).isNotNull();
                 String contents = String.join("\n", IOUtils.readLines(new FileReader(testFile)));
                 assertThat(contents).isEqualTo("class NoLicense {}");
                 assertThat(resultFile).exists();
@@ -577,7 +578,6 @@ public class ReporterOptionsTest {
                 dir = new File(sourceDir, "another");
                 mkDir(dir);
                 writeFile(dir, "red_fish");
-
 
                 ReportConfiguration config = generateConfig(Collections.emptyList());
                 Reporter reporter = new Reporter(config);
@@ -1392,7 +1392,6 @@ public class ReporterOptionsTest {
             }
         }
 
-
         protected void helpLicenses() {
             PrintStream origin = System.out;
             Option option = HELP_LICENSES.option();
@@ -1410,6 +1409,7 @@ public class ReporterOptionsTest {
                 System.setOut(origin);
             }
 
+            assertThat(actualText).isNotNull();
             TextUtils.assertContains("====== Licenses ======", actualText);
             TextUtils.assertContains("====== Defined Matchers ======", actualText);
             TextUtils.assertContains("====== Defined Families ======", actualText);

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
@@ -975,7 +975,7 @@ public class ReporterOptionsTest {
                     String actualText = baos.toString(StandardCharsets.UTF_8.name());
                     switch (sheet) {
                         case MISSING_HEADERS:
-                            TextUtils.assertContainsExactly(1, "Files with missing headers:\n" +
+                            TextUtils.assertContainsExactly(1, "Files with missing headers:" + System.lineSeparator() +
                                     "  /stylesheet", actualText);
                             break;
                         case PLAIN:

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
@@ -986,7 +986,7 @@ public class ReporterOptionsTest {
                             TextUtils.assertContainsExactly(1, "<resource encoding=\"ISO-8859-1\" mediaType=\"text/plain\" name=\"/stylesheet\" type=\"STANDARD\">", actualText);
                             break;
                         case UNAPPROVED_LICENSES:
-                            TextUtils.assertContainsExactly(1, "Files with unapproved licenses:\n  /stylesheet", actualText);
+                            TextUtils.assertContainsExactly(1, "Files with unapproved licenses:" + System.lineSeparator() + "  /stylesheet", actualText);
                             break;
                         default:
                             fail("No test for stylesheet " + sheet);

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterOptionsTest.java
@@ -3,7 +3,6 @@ package org.apache.rat;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -115,7 +114,12 @@ public class ReporterOptionsTest {
     @ArgumentsSource(ReporterOptionsProvider.class)
     public void testOptionsUpdateConfig(String name, OptionCollectionTest.OptionTest test) {
         DefaultLog.getInstance().log(Log.Level.INFO, "Running test for: " + name);
-        test.test();
+        try {
+            test.test();
+        } catch (Exception e) {
+            fail("failed running "+name, e);
+            throw e;
+        }
     }
 
     /**

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractConfigurationOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractConfigurationOptionsProvider.java
@@ -1,0 +1,857 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
+package org.apache.rat.test;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import org.apache.commons.cli.Option;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.rat.OptionCollectionTest;
+import org.apache.rat.ReportConfiguration;
+import org.apache.rat.ReporterTest;
+import org.apache.rat.commandline.Arg;
+import org.apache.rat.commandline.StyleSheets;
+import org.apache.rat.config.exclusion.StandardCollection;
+import org.apache.rat.document.DocumentNameMatcher;
+import org.apache.rat.document.DocumentName;
+import org.apache.rat.document.DocumentNameMatcherTest;
+import org.apache.rat.license.ILicense;
+import org.apache.rat.license.ILicenseFamily;
+import org.apache.rat.license.LicenseSetFactory;
+import org.apache.rat.report.claim.ClaimStatistic;
+import org.apache.rat.test.utils.Resources;
+import org.apache.rat.testhelpers.TextUtils;
+import org.apache.rat.utils.DefaultLog;
+import org.apache.rat.utils.Log.Level;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import static org.apache.rat.commandline.Arg.HELP_LICENSES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+/**
+ * A list of methods that an OptionsProvider in a test case must support.
+ * Use of this interface ensures consistent testing across the UIs. Each method
+ * tests an Option from OptionCollection that must be implemented in the UI.
+ * Each method in this interface tests an Option in {@link org.apache.rat.OptionCollection}.
+ */
+public abstract class AbstractConfigurationOptionsProvider extends AbstractOptionsProvider {
+
+    /**
+     * Copy the runtime data to the "target" directory.
+     * @param baseDir the base directory to copy to.
+     * @param targetDir the directory relative to the base directory to copy to.
+     */
+    public static void preserveData(File baseDir, String targetDir) {
+        final Path recordPath = FileSystems.getDefault().getPath("target", targetDir);
+        recordPath.toFile().mkdirs();
+        try {
+            FileUtils.copyDirectory(baseDir, recordPath.toFile());
+        } catch (IOException e) {
+            System.err.format("Unable to copy data from %s to %s%n", baseDir, recordPath);
+        }
+    }
+
+    /**
+     * Gets the document name based on the baseDir.
+     * @return The document name based on the baseDir.
+     */
+    protected DocumentName baseName() {
+        return DocumentName.builder(baseDir).build();
+    }
+
+    /**
+     * Copies the test data to the specified directory.
+     * @param baseDir the directory to copy the {@code /src/test/resources} to.
+     * @return the {@code baseDir} argument.
+     */
+    public static File setup(final File baseDir) {
+        try {
+            final File sourceDir = Resources.getResourceDirectory("OptionTools");
+            FileUtils.copyDirectory(sourceDir, new File(baseDir,"/src/test/resources/OptionTools"));
+        } catch (IOException e) {
+            DefaultLog.getInstance().error("Can not copy 'OptionTools' to " + baseDir, e);
+        }
+        return baseDir;
+    }
+
+    protected AbstractConfigurationOptionsProvider(final Collection<String> unsupportedArgs, final File baseDir) {
+        super(setup(baseDir));
+        testMap.put("addLicense", this::addLicenseTest);
+        testMap.put("config", this::configTest);
+        testMap.put("configuration-no-defaults", this::configurationNoDefaultsTest);
+        testMap.put("copyright", this::copyrightTest);
+        testMap.put("counter-min", this::counterMinTest);
+        testMap.put("counter-max", this::counterMaxTest);
+        testMap.put("dir", () -> DefaultLog.getInstance().info("--dir has no valid test"));
+        testMap.put("dry-run", this::dryRunTest);
+        testMap.put("edit-copyright", this::editCopyrightTest);
+        testMap.put("edit-license", this::editLicensesTest);
+        testMap.put("edit-overwrite", this::editOverwriteTest);
+        testMap.put("exclude", this::excludeTest);
+        testMap.put("exclude-file", this::excludeFileTest);
+        testMap.put("force", this::forceTest);
+        testMap.put("help", this::helpTest);
+        testMap.put("help-licenses", this::helpLicenses);
+        testMap.put("include", this::includeTest);
+        testMap.put("includes-file", this::includesFileTest);
+        testMap.put("input-exclude", this::inputExcludeTest);
+        testMap.put("input-exclude-file", this::inputExcludeFileTest);
+        testMap.put("input-exclude-parsed-scm", this::inputExcludeParsedScmTest);
+        testMap.put("input-exclude-std", this::inputExcludeStdTest);
+        testMap.put("input-exclude-size", this::inputExcludeSizeTest);
+        testMap.put("input-include", this::inputIncludeTest);
+        testMap.put("input-include-file", this::inputIncludeFileTest);
+        testMap.put("input-include-std", this::inputIncludeStdTest);
+        testMap.put("input-source", this::inputSourceTest);
+        testMap.put("license-families-approved", this::licenseFamiliesApprovedTest);
+        testMap.put("license-families-approved-file", this::licenseFamiliesApprovedFileTest);
+        testMap.put("license-families-denied", this::licenseFamiliesDeniedTest);
+        testMap.put("license-families-denied-file", this::licenseFamiliesDeniedFileTest);
+        testMap.put("licenses", this::licensesTest);
+        testMap.put("licenses-approved", this::licensesApprovedTest);
+        testMap.put("licenses-approved-file", this::licensesApprovedFileTest);
+        testMap.put("licenses-denied", this::licensesDeniedTest);
+        testMap.put("licenses-denied-file", this::licensesDeniedFileTest);
+        testMap.put("list-families", this::listFamiliesTest);
+        testMap.put("list-licenses", this::listLicensesTest);
+        testMap.put("log-level", this::logLevelTest);
+        testMap.put("no-default-licenses", this::noDefaultsTest);
+        testMap.put("out", this::outTest);
+        testMap.put("output-archive", this::outputArchiveTest);
+        testMap.put("output-families", this::outputFamiliesTest);
+        testMap.put("output-file", this::outputFileTest);
+        testMap.put("output-licenses", this::outputLicensesTest);
+        testMap.put("output-standard", this::outputStandardTest);
+        testMap.put("output-style", this::outputStyleTest);
+        testMap.put("scan-hidden-directories", this::scanHiddenDirectoriesTest);
+        testMap.put("stylesheet", this::styleSheetTest);
+        testMap.put("xml", this::xmlTest);
+        super.validate(unsupportedArgs);
+    }
+
+    /** Help test */
+    protected abstract void helpTest();
+
+    // exclude tests
+    private void execExcludeTest(final Option option, final String[] args) {
+        String[] notExcluded = {"notbaz", "well._afile"};
+        String[] excluded = {"some.foo", "B.bar", "justbaz"};
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            for (String fname : notExcluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
+            }
+            for (String fname : excluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void excludeFileTest(final Option option) {
+        File outputFile = writeFile("exclude.txt", Arrays.asList(EXCLUDE_ARGS));
+        execExcludeTest(option, new String[]{outputFile.getAbsolutePath()});
+    }
+
+    protected void excludeFileTest() {
+        excludeFileTest(Arg.EXCLUDE_FILE.find("exclude-file"));
+    }
+
+    protected void inputExcludeFileTest() {
+        excludeFileTest(Arg.EXCLUDE_FILE.find("input-exclude-file"));
+    }
+
+    protected void excludeTest() {
+        execExcludeTest(Arg.EXCLUDE.find("exclude"), EXCLUDE_ARGS);
+    }
+
+    protected void inputExcludeTest() {
+        execExcludeTest(Arg.EXCLUDE.find("input-exclude"), EXCLUDE_ARGS);
+    }
+
+    protected void inputExcludeStdTest() {
+        Option option = Arg.EXCLUDE_STD.find("input-exclude-std");
+        String[] args = {StandardCollection.MISC.name()};
+        String[] excluded = {"afile~", ".#afile", "%afile%", "._afile"};
+        String[] notExcluded = {"afile~more", "what.#afile", "%afile%withMore", "well._afile"};
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            for (String fname : excluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
+            }
+            for (String fname : notExcluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void inputExcludeParsedScmTest() {
+        Option option = Arg.EXCLUDE_PARSE_SCM.find("input-exclude-parsed-scm");
+        String[] args = {"GIT"};
+        String[] lines = {
+                "# somethings",
+                "!thingone", "thing*", System.lineSeparator(),
+                "# some fish",
+                "**/fish", "*_fish",
+                "# some colorful directories",
+                "red/", "blue/*/"};
+        String[] notExcluded = {"thingone", "dir/fish_two", "some/thingone", "blue/fish/dory" };
+        String[] excluded = {"thingtwo", "some/things", "dir/fish", "red/fish", "blue/fish", "some/fish", "another/red_fish"};
+
+        writeFile(".gitignore", Arrays.asList(lines));
+        File dir = new File(baseDir, "red");
+        dir.mkdirs();
+        dir = new File(baseDir, "blue");
+        dir = new File(dir, "fish");
+        dir.mkdirs();
+
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            for (String fname : excluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
+            }
+            for (String fname : notExcluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void inputExcludeSizeTest() {
+        Option option = Arg.EXCLUDE_SIZE.option();
+        String[] args = {"5"};
+        writeFile("Hi.txt", Collections.singletonList("Hi"));
+        writeFile("Hello.txt", Collections.singletonList("Hello"));
+        writeFile("HelloWorld.txt", Collections.singletonList("HelloWorld"));
+
+        String[] notExcluded = {"Hello.txt", "HelloWorld.txt"};
+        String[] excluded = {"Hi.txt"};
+
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            for (String fname : excluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
+            }
+            for (String fname : notExcluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    // include tests
+    private void execIncludeTest(final Option option, final String[] args) {
+        Option excludeOption = Arg.EXCLUDE.option();
+        String[] notExcluded = {"B.bar", "justbaz", "notbaz"};
+        String[] excluded = {"some.foo"};
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args),
+                    ImmutablePair.of(excludeOption, EXCLUDE_ARGS));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            for (String fname : excluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
+            }
+            for (String fname : notExcluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void includeFileTest(final Option option) {
+        File outputFile = writeFile("include.txt", Arrays.asList(INCLUDE_ARGS));
+        execIncludeTest(option, new String[]{outputFile.getAbsolutePath()});
+    }
+
+    protected void inputIncludeFileTest() {
+        includeFileTest(Arg.INCLUDE_FILE.find("input-include-file"));
+    }
+
+    protected void includesFileTest() {
+        includeFileTest(Arg.INCLUDE_FILE.find("includes-file"));
+    }
+
+    protected void includeTest() {
+        execIncludeTest(Arg.INCLUDE.find("include"), INCLUDE_ARGS);
+    }
+
+    protected void inputIncludeTest() {
+        execIncludeTest(Arg.INCLUDE.find("input-include"), INCLUDE_ARGS);
+    }
+
+    protected void inputIncludeStdTest() {
+        ImmutablePair<Option, String[]> excludes = ImmutablePair.of(Arg.EXCLUDE.find("input-exclude"),
+                new String[]{"*~more", "*~"});
+        Option option = Arg.INCLUDE_STD.find("input-include-std");
+        String[] args = {StandardCollection.MISC.name()};
+        String[] excluded = {"afile~more"};
+        String[] notExcluded = {"afile~", ".#afile", "%afile%", "._afile", "what.#afile", "%afile%withMore", "well._afile"};
+        try {
+            ReportConfiguration config = generateConfig(excludes, ImmutablePair.of(option, args));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            for (String fname : excluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
+            }
+            for (String fname : notExcluded) {
+                DocumentName docName = mkDocName(fname);
+                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void inputSourceTest() {
+        Option option = Arg.SOURCE.find("input-source");
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, new String[]{baseDir.getAbsolutePath()}));
+            assertThat(config.hasSource()).isTrue();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    // LICENSE tests
+    protected void execLicensesApprovedTest(final Option option, String[] args) {
+        Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+        try {
+            ReportConfiguration config = generateConfig(arg1);
+            SortedSet<String> result = config.getLicenseIds(LicenseSetFactory.LicenseFilter.APPROVED);
+            assertThat(result).contains("one", "two");
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        Pair<Option, String[]> arg2 = ImmutablePair.of(
+                Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"),
+                null
+        );
+
+        try {
+            ReportConfiguration config = generateConfig(arg1, arg2);
+            SortedSet<String> result = config.getLicenseIds(LicenseSetFactory.LicenseFilter.APPROVED);
+            assertThat(result).containsExactly("one", "two");
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void helpLicenses() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream origin = System.out;
+        try (PrintStream out = new PrintStream(output)) {
+            System.setOut(out);
+            generateConfig(ImmutablePair.of(HELP_LICENSES.option(), null));
+        } catch (IOException e) {
+            fail(e.getMessage());
+        } finally {
+            System.setOut(origin);
+        }
+        String txt = output.toString();
+        TextUtils.assertContains("====== Licenses ======", txt);
+        TextUtils.assertContains("====== Defined Matchers ======", txt);
+        TextUtils.assertContains("====== Defined Families ======", txt);
+    }
+
+    protected void licensesApprovedFileTest() {
+        File outputFile = writeFile("licensesApproved.txt", Arrays.asList("one", "two"));
+        execLicensesApprovedTest(Arg.LICENSES_APPROVED_FILE.find("licenses-approved-file"),
+                new String[]{outputFile.getAbsolutePath()});
+    }
+
+    protected void licensesApprovedTest() {
+        execLicensesApprovedTest(Arg.LICENSES_APPROVED.find("licenses-approved"),
+                new String[]{"one, two"});
+    }
+
+    private void execLicensesDeniedTest(final Option option, final String[] args) {
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            assertThat(config.getLicenseIds(LicenseSetFactory.LicenseFilter.ALL)).contains("ILLUMOS");
+            SortedSet<String> result = config.getLicenseIds(LicenseSetFactory.LicenseFilter.APPROVED);
+            assertThat(result).doesNotContain("ILLUMOS");
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void licensesDeniedTest() {
+        execLicensesDeniedTest(Arg.LICENSES_DENIED.find("licenses-denied"), new String[]{"ILLUMOS"});
+    }
+
+    protected void licensesDeniedFileTest() {
+        File outputFile = writeFile("licensesDenied.txt", Collections.singletonList("ILLUMOS"));
+        execLicensesDeniedTest(Arg.LICENSES_DENIED_FILE.find("licenses-denied-file"),
+                new String[]{outputFile.getAbsolutePath()});
+    }
+
+    private void execLicenseFamiliesApprovedTest(final Option option, final String[] args) {
+        String catz = ILicenseFamily.makeCategory("catz");
+        Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+        try {
+            ReportConfiguration config = generateConfig(arg1);
+            SortedSet<String> result = config.getLicenseCategories(LicenseSetFactory.LicenseFilter.APPROVED);
+            assertThat(result).contains(catz);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"), null);
+        try {
+            ReportConfiguration config = generateConfig(arg1, arg2);
+            SortedSet<String> result = config.getLicenseCategories(LicenseSetFactory.LicenseFilter.APPROVED);
+            assertThat(result).containsExactly(catz);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void licenseFamiliesApprovedFileTest() {
+        File outputFile = writeFile("familiesApproved.txt", Collections.singletonList("catz"));
+        execLicenseFamiliesApprovedTest(Arg.FAMILIES_APPROVED_FILE.find("license-families-approved-file"),
+                new String[]{outputFile.getAbsolutePath()});
+    }
+
+    protected void licenseFamiliesApprovedTest() {
+        execLicenseFamiliesApprovedTest(Arg.FAMILIES_APPROVED.find("license-families-approved"),
+                new String[]{"catz"});
+    }
+
+    private void execLicenseFamiliesDeniedTest(final Option option, final String[] args) {
+        String gpl = ILicenseFamily.makeCategory("GPL");
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            assertThat(config.getLicenseCategories(LicenseSetFactory.LicenseFilter.ALL)).contains(gpl);
+            SortedSet<String> result = config.getLicenseCategories(LicenseSetFactory.LicenseFilter.APPROVED);
+            assertThat(result).doesNotContain(gpl);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void licenseFamiliesDeniedFileTest() {
+        File outputFile = writeFile("familiesDenied.txt", Collections.singletonList("GPL"));
+        execLicenseFamiliesDeniedTest(Arg.FAMILIES_DENIED_FILE.find("license-families-denied-file"),
+                new String[]{outputFile.getAbsolutePath()});
+    }
+
+    protected void licenseFamiliesDeniedTest() {
+        execLicenseFamiliesDeniedTest(Arg.FAMILIES_DENIED.find("license-families-denied"),
+                new String[]{"GPL"});
+    }
+
+    protected void counterMaxTest() {
+        Option option = Arg.COUNTER_MAX.option();
+        String[] args = {null, null};
+
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.nullPair());
+            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+            args[0] = "Unapproved:-1";
+            args[1] = "ignored:1";
+            config = generateConfig(ImmutablePair.of(option, args));
+            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(Integer.MAX_VALUE);
+            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
+            args[1] = "unapproved:5";
+            args[0] = "ignored:0";
+            config = generateConfig(ImmutablePair.of(option, args));
+            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(5);
+            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void counterMinTest() {
+        Option option = Arg.COUNTER_MIN.option();
+        String[] args = {null, null};
+
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.nullPair());
+            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
+            args[0] = "Unapproved:1";
+            args[1] = "ignored:1";
+            config = generateConfig(ImmutablePair.of(option, args));
+            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
+            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
+            args[1] = "unapproved:5";
+            args[0] = "ignored:0";
+            config = generateConfig(ImmutablePair.of(option, args));
+            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(5);
+            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void configTest(final Option option) {
+        String[] args = {"src/test/resources/OptionTools/One.xml", "src/test/resources/OptionTools/Two.xml"};
+        Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
+        try {
+            ReportConfiguration config = generateConfig(arg1);
+            SortedSet<ILicense> set = config.getLicenses(LicenseSetFactory.LicenseFilter.ALL);
+            assertThat(set).hasSizeGreaterThan(2);
+            assertThat(LicenseSetFactory.search("ONE", "ONE", set)).isPresent();
+            assertThat(LicenseSetFactory.search("TWO", "TWO", set)).isPresent();
+
+            Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"), null);
+
+            config = generateConfig(arg1, arg2);
+            set = config.getLicenses(LicenseSetFactory.LicenseFilter.ALL);
+            assertThat(set).hasSize(2);
+            assertThat(LicenseSetFactory.search("ONE", "ONE", set)).isPresent();
+            assertThat(LicenseSetFactory.search("TWO", "TWO", set)).isPresent();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void licensesTest() {
+        configTest(Arg.CONFIGURATION.find("licenses"));
+    }
+
+    protected void configTest() {
+        configTest(Arg.CONFIGURATION.find("config"));
+    }
+
+    private void noDefaultsTest(final Option arg) {
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(arg, null));
+            assertThat(config.getLicenses(LicenseSetFactory.LicenseFilter.ALL)).isEmpty();
+            config = generateConfig(ImmutablePair.nullPair());
+            assertThat(config.getLicenses(LicenseSetFactory.LicenseFilter.ALL)).isNotEmpty();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void noDefaultsTest() {
+        noDefaultsTest(Arg.CONFIGURATION_NO_DEFAULTS.find("no-default-licenses"));
+    }
+
+    protected void configurationNoDefaultsTest() {
+        noDefaultsTest(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"));
+    }
+
+    protected void dryRunTest() {
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.DRY_RUN.find("dry-run"), null));
+            assertThat(config.isDryRun()).isTrue();
+            config = generateConfig(ImmutablePair.nullPair());
+            assertThat(config.isDryRun()).isFalse();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    private void editCopyrightTest(final Option option) {
+        try {
+            Pair<Option, String[]> arg1 = ImmutablePair.of(option, new String[]{"MyCopyright"});
+            ReportConfiguration config = generateConfig(arg1);
+            assertThat(config.getCopyrightMessage()).as("Copyright without --edit-license should not work").isNull();
+            Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.EDIT_ADD.find("edit-license"), null);
+            config = generateConfig(arg1, arg2);
+            assertThat(config.getCopyrightMessage()).isEqualTo("MyCopyright");
+        } catch (IOException e) {
+            e.printStackTrace();
+            if (e.getCause() != null) {
+                fail(e.getMessage() + ": " + e.getCause().getMessage());
+            }
+            fail(e.getMessage());
+        }
+    }
+
+    protected void copyrightTest() {
+        editCopyrightTest(Arg.EDIT_COPYRIGHT.find("copyright"));
+    }
+
+    protected void editCopyrightTest() {
+        editCopyrightTest(Arg.EDIT_COPYRIGHT.find("edit-copyright"));
+    }
+
+    private void editLicenseTest(final Option option) {
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, null));
+            assertThat(config.isAddingLicenses()).isTrue();
+            config = generateConfig(ImmutablePair.nullPair());
+            assertThat(config.isAddingLicenses()).isFalse();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void addLicenseTest() {
+        editLicenseTest(Arg.EDIT_ADD.find("addLicense"));
+    }
+
+    protected void editLicensesTest() {
+        editLicenseTest(Arg.EDIT_ADD.find("edit-license"));
+    }
+
+    private void overwriteTest(final Option option) {
+        Pair<Option, String[]> arg1 = ImmutablePair.of(option, null);
+        try {
+            ReportConfiguration config = generateConfig(arg1);
+            assertThat(config.isAddingLicensesForced()).isFalse();
+            Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.EDIT_ADD.find("edit-license"), null);
+
+            config = generateConfig(arg1, arg2);
+            assertThat(config.isAddingLicensesForced()).isTrue();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void forceTest() {
+        overwriteTest(Arg.EDIT_OVERWRITE.find("force"));
+    }
+
+    protected void editOverwriteTest() {
+        overwriteTest(Arg.EDIT_OVERWRITE.find("edit-overwrite"));
+    }
+
+    protected void logLevelTest() {
+        Option option = Arg.LOG_LEVEL.find("log-level");
+        String[] args = {null};
+        Level logLevel = DefaultLog.getInstance().getLevel();
+        try {
+            for (Level level : Level.values()) {
+                try {
+                    args[0] = level.name();
+                    generateConfig(ImmutablePair.of(option, args));
+                    assertThat(DefaultLog.getInstance().getLevel()).isEqualTo(level);
+                } catch (IOException e) {
+                    fail(e.getMessage());
+                }
+            }
+        } finally {
+            DefaultLog.getInstance().setLevel(logLevel);
+        }
+    }
+
+    private void archiveTest(final Option option) {
+        String[] args = {null};
+        try {
+            for (ReportConfiguration.Processing proc : ReportConfiguration.Processing.values()) {
+                args[0] = proc.name();
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                assertThat(config.getArchiveProcessing()).isEqualTo(proc);
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void outputArchiveTest() {
+        archiveTest(Arg.OUTPUT_ARCHIVE.find("output-archive"));
+    }
+
+    private void listFamilies(final Option option) {
+        String[] args = {null};
+        for (LicenseSetFactory.LicenseFilter filter : LicenseSetFactory.LicenseFilter.values()) {
+            try {
+                args[0] = filter.name();
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                assertThat(config.listFamilies()).isEqualTo(filter);
+            } catch (IOException e) {
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    protected void listFamiliesTest() {
+        listFamilies(Arg.OUTPUT_FAMILIES.find("list-families"));
+    }
+
+    protected void outputFamiliesTest() {
+        listFamilies(Arg.OUTPUT_FAMILIES.find("output-families"));
+    }
+
+    private void outTest(final Option option) {
+        File outFile = new File(baseDir, "outexample-" + option.getLongOpt());
+        String[] args = new String[]{outFile.getAbsolutePath()};
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+            try (OutputStream os = config.getOutput().get()) {
+                os.write("Hello world".getBytes());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(outFile.toPath())))) {
+                assertThat(reader.readLine()).isEqualTo("Hello world");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void outTest() {
+        outTest(Arg.OUTPUT_FILE.find("out"));
+    }
+
+    protected void outputFileTest() {
+        outTest(Arg.OUTPUT_FILE.find("output-file"));
+    }
+
+    private void listLicenses(final Option option) {
+        String[] args = {null};
+        for (LicenseSetFactory.LicenseFilter filter : LicenseSetFactory.LicenseFilter.values()) {
+            try {
+                args[0] = filter.name();
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                assertThat(config.listLicenses()).isEqualTo(filter);
+            } catch (IOException e) {
+                fail(e.getMessage());
+            }
+        }
+    }
+
+    protected void listLicensesTest() {
+        listLicenses(Arg.OUTPUT_LICENSES.find("list-licenses"));
+    }
+
+    protected void outputLicensesTest() {
+        listLicenses(Arg.OUTPUT_LICENSES.find("output-licenses"));
+    }
+
+    private void standardTest(final Option option) {
+        String[] args = {null};
+        try {
+            for (ReportConfiguration.Processing proc : ReportConfiguration.Processing.values()) {
+                args[0] = proc.name();
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                assertThat(config.getStandardProcessing()).isEqualTo(proc);
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void outputStandardTest() {
+        standardTest(Arg.OUTPUT_STANDARD.find("output-standard"));
+    }
+
+    private void styleSheetTest(final Option option) {
+        // copy the dummy stylesheet so that we have a local file for users of the testing jar.
+        File file = new File(baseDir, "stylesheet-" + option.getLongOpt());
+        try (
+                InputStream in = ReporterTest.class.getResourceAsStream("MatcherContainerResource.txt");
+                OutputStream out = Files.newOutputStream(file.toPath())) {
+            IOUtils.copy(in, out);
+        } catch (IOException e) {
+            fail("Could not copy MatcherContainerResource.txt: " + e.getMessage());
+        }
+        // run the test
+        String[] args = {null};
+        try {
+            for (String sheet : new String[]{"plain-rat", "missing-headers", "unapproved-licenses", file.getAbsolutePath()}) {
+                args[0] = sheet;
+                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
+                try (InputStream expected = StyleSheets.getStyleSheet(sheet).get();
+                     InputStream actual = config.getStyleSheet().get()) {
+                    assertThat(IOUtils.contentEquals(expected, actual)).as(() -> String.format("'%s' does not match", sheet)).isTrue();
+                }
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void styleSheetTest() {
+        styleSheetTest(Arg.OUTPUT_STYLE.find("stylesheet"));
+    }
+
+    protected void outputStyleTest() {
+        styleSheetTest(Arg.OUTPUT_STYLE.find("output-style"));
+    }
+
+    protected void scanHiddenDirectoriesTest() {
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.INCLUDE_STD.find("scan-hidden-directories"), null));
+            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
+            assertThat(excluder.matches(mkDocName(".file"))).as(".file").isTrue();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    protected void xmlTest() {
+        try {
+            ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.OUTPUT_STYLE.find("xml"), null));
+            try (InputStream expected = StyleSheets.getStyleSheet("xml").get();
+                 InputStream actual = config.getStyleSheet().get()) {
+                assertThat(IOUtils.contentEquals(expected, actual)).as("'xml' does not match").isTrue();
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+
+}

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractConfigurationOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractConfigurationOptionsProvider.java
@@ -25,7 +25,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.rat.OptionCollectionTest;
 import org.apache.rat.ReportConfiguration;
 import org.apache.rat.ReporterTest;
 import org.apache.rat.commandline.Arg;
@@ -33,7 +32,6 @@ import org.apache.rat.commandline.StyleSheets;
 import org.apache.rat.config.exclusion.StandardCollection;
 import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.document.DocumentName;
-import org.apache.rat.document.DocumentNameMatcherTest;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory;
@@ -42,30 +40,20 @@ import org.apache.rat.test.utils.Resources;
 import org.apache.rat.testhelpers.TextUtils;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.provider.Arguments;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.PrintWriter;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 import static org.apache.rat.commandline.Arg.HELP_LICENSES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,14 +80,6 @@ public abstract class AbstractConfigurationOptionsProvider extends AbstractOptio
         } catch (IOException e) {
             System.err.format("Unable to copy data from %s to %s%n", baseDir, recordPath);
         }
-    }
-
-    /**
-     * Gets the document name based on the baseDir.
-     * @return The document name based on the baseDir.
-     */
-    protected DocumentName baseName() {
-        return DocumentName.builder(baseDir).build();
     }
 
     /**
@@ -852,6 +832,4 @@ public abstract class AbstractConfigurationOptionsProvider extends AbstractOptio
             fail(e.getMessage());
         }
     }
-
-
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
@@ -18,56 +18,32 @@
  */
 package org.apache.rat.test;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.nio.file.FileSystems;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 import org.apache.commons.cli.Option;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.rat.OptionCollectionTest;
 import org.apache.rat.ReportConfiguration;
-import org.apache.rat.ReporterTest;
 import org.apache.rat.commandline.Arg;
-import org.apache.rat.commandline.StyleSheets;
-import org.apache.rat.config.exclusion.StandardCollection;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.document.DocumentNameMatcherTest;
-import org.apache.rat.license.ILicense;
-import org.apache.rat.license.ILicenseFamily;
-import org.apache.rat.license.LicenseSetFactory;
-import org.apache.rat.report.claim.ClaimStatistic;
-import org.apache.rat.test.utils.Resources;
-import org.apache.rat.testhelpers.TextUtils;
-import org.apache.rat.utils.DefaultLog;
-import org.apache.rat.utils.Log.Level;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 
-import static org.apache.rat.commandline.Arg.HELP_LICENSES;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
 /**
@@ -183,7 +159,6 @@ public abstract class AbstractOptionsProvider implements ArgumentsProvider {
         }
         return file;
     }
-
 
     final protected DocumentName mkDocName(final String name) {
         return DocumentName.builder(new File(baseDir, name)).build();

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
@@ -18,8 +18,28 @@
  */
 package org.apache.rat.test;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.stream.Stream;
 import org.apache.commons.cli.Option;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -31,8 +51,8 @@ import org.apache.rat.ReporterTest;
 import org.apache.rat.commandline.Arg;
 import org.apache.rat.commandline.StyleSheets;
 import org.apache.rat.config.exclusion.StandardCollection;
-import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.document.DocumentName;
+import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.document.DocumentNameMatcherTest;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
@@ -44,27 +64,6 @@ import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
-
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeMap;
-import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 import static org.apache.rat.commandline.Arg.HELP_LICENSES;
@@ -114,73 +113,11 @@ public abstract class AbstractOptionsProvider implements ArgumentsProvider {
         return DocumentName.builder(baseDir).build();
     }
 
-    /**
-     * Copies the test data to the specified directory.
-     * @param baseDir the directory to copy the {@code /src/test/resources} to.
-     * @return the {@code baseDir} argument.
-     */
-    public static File setup(final File baseDir) {
-        try {
-            final File sourceDir = Resources.getResourceDirectory("OptionTools");
-            FileUtils.copyDirectory(sourceDir, new File(baseDir,"/src/test/resources/OptionTools"));
-        } catch (IOException e) {
-            DefaultLog.getInstance().error("Can not copy 'OptionTools' to " + baseDir, e);
-        }
-        return baseDir;
+    protected AbstractOptionsProvider(final File baseDir) {
+        this.baseDir = baseDir;
     }
 
-    protected AbstractOptionsProvider(final Collection<String> unsupportedArgs, final File baseDir) {
-        this.baseDir = setup(baseDir);
-        testMap.put("addLicense", this::addLicenseTest);
-        testMap.put("config", this::configTest);
-        testMap.put("configuration-no-defaults", this::configurationNoDefaultsTest);
-        testMap.put("copyright", this::copyrightTest);
-        testMap.put("counter-min", this::counterMinTest);
-        testMap.put("counter-max", this::counterMaxTest);
-        testMap.put("dir", () -> DefaultLog.getInstance().info("--dir has no valid test"));
-        testMap.put("dry-run", this::dryRunTest);
-        testMap.put("edit-copyright", this::editCopyrightTest);
-        testMap.put("edit-license", this::editLicensesTest);
-        testMap.put("edit-overwrite", this::editOverwriteTest);
-        testMap.put("exclude", this::excludeTest);
-        testMap.put("exclude-file", this::excludeFileTest);
-        testMap.put("force", this::forceTest);
-        testMap.put("help", this::helpTest);
-        testMap.put("help-licenses", this::helpLicenses);
-        testMap.put("include", this::includeTest);
-        testMap.put("includes-file", this::includesFileTest);
-        testMap.put("input-exclude", this::inputExcludeTest);
-        testMap.put("input-exclude-file", this::inputExcludeFileTest);
-        testMap.put("input-exclude-parsed-scm", this::inputExcludeParsedScmTest);
-        testMap.put("input-exclude-std", this::inputExcludeStdTest);
-        testMap.put("input-exclude-size", this::inputExcludeSizeTest);
-        testMap.put("input-include", this::inputIncludeTest);
-        testMap.put("input-include-file", this::inputIncludeFileTest);
-        testMap.put("input-include-std", this::inputIncludeStdTest);
-        testMap.put("input-source", this::inputSourceTest);
-        testMap.put("license-families-approved", this::licenseFamiliesApprovedTest);
-        testMap.put("license-families-approved-file", this::licenseFamiliesApprovedFileTest);
-        testMap.put("license-families-denied", this::licenseFamiliesDeniedTest);
-        testMap.put("license-families-denied-file", this::licenseFamiliesDeniedFileTest);
-        testMap.put("licenses", this::licensesTest);
-        testMap.put("licenses-approved", this::licensesApprovedTest);
-        testMap.put("licenses-approved-file", this::licensesApprovedFileTest);
-        testMap.put("licenses-denied", this::licensesDeniedTest);
-        testMap.put("licenses-denied-file", this::licensesDeniedFileTest);
-        testMap.put("list-families", this::listFamiliesTest);
-        testMap.put("list-licenses", this::listLicensesTest);
-        testMap.put("log-level", this::logLevelTest);
-        testMap.put("no-default-licenses", this::noDefaultsTest);
-        testMap.put("out", this::outTest);
-        testMap.put("output-archive", this::outputArchiveTest);
-        testMap.put("output-families", this::outputFamiliesTest);
-        testMap.put("output-file", this::outputFileTest);
-        testMap.put("output-licenses", this::outputLicensesTest);
-        testMap.put("output-standard", this::outputStandardTest);
-        testMap.put("output-style", this::outputStyleTest);
-        testMap.put("scan-hidden-directories", this::scanHiddenDirectoriesTest);
-        testMap.put("stylesheet", this::styleSheetTest);
-        testMap.put("xml", this::xmlTest);
+    protected void validate(final Collection<String> unsupportedArgs) {
         unsupportedArgs.forEach(testMap::remove);
         verifyAllMethodsDefinedAndNeeded(unsupportedArgs);
     }
@@ -231,6 +168,10 @@ public abstract class AbstractOptionsProvider implements ArgumentsProvider {
     protected abstract ReportConfiguration generateConfig(final List<Pair<Option, String[]>> args) throws IOException;
 
     protected File writeFile(final String name, final Iterable<String> lines) {
+        return writeFile(baseDir, name, lines);
+    }
+
+    final protected File writeFile(File baseDir, final String name, final Iterable<String> lines) {
         File file = new File(baseDir, name);
         try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
             lines.forEach(writer::println);
@@ -240,7 +181,8 @@ public abstract class AbstractOptionsProvider implements ArgumentsProvider {
         return file;
     }
 
-    protected DocumentName mkDocName(final String name) {
+
+    final protected DocumentName mkDocName(final String name) {
         return DocumentName.builder(new File(baseDir, name)).build();
     }
 
@@ -248,697 +190,19 @@ public abstract class AbstractOptionsProvider implements ArgumentsProvider {
     protected abstract void helpTest();
 
     /** Display the option and value under test */
-    private String displayArgAndName(final Option option, final String fname) {
+    final protected String displayArgAndName(final Option option, final String fname) {
         return String.format("%s %s", option.getLongOpt(), fname);
     }
 
-    private String dump(final DocumentNameMatcher nameMatcher, final DocumentName name) {
+    final protected String dump(final DocumentNameMatcher nameMatcher, final DocumentName name) {
         StringBuilder sb = new StringBuilder();
         nameMatcher.decompose(name).forEach(s -> sb.append(s).append("\n"));
         return sb.toString();
     }
 
-    private String dump(final Option option, final String fname, final DocumentNameMatcher matcher, final DocumentName name) {
+    final protected String dump(final Option option, final String fname, final DocumentNameMatcher matcher, final DocumentName name) {
         return String.format("Argument and Name: %s%nMatcher decomposition:%n%s", displayArgAndName(option, fname),
                 DocumentNameMatcherTest.processDecompose(matcher, name));
-    }
-
-    // exclude tests
-    private void execExcludeTest(final Option option, final String[] args) {
-        String[] notExcluded = {"notbaz", "well._afile"};
-        String[] excluded = {"some.foo", "B.bar", "justbaz"};
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            for (String fname : notExcluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
-            }
-            for (String fname : excluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private void excludeFileTest(final Option option) {
-        File outputFile = writeFile("exclude.txt", Arrays.asList(EXCLUDE_ARGS));
-        execExcludeTest(option, new String[]{outputFile.getAbsolutePath()});
-    }
-
-    protected void excludeFileTest() {
-        excludeFileTest(Arg.EXCLUDE_FILE.find("exclude-file"));
-    }
-
-    protected void inputExcludeFileTest() {
-        excludeFileTest(Arg.EXCLUDE_FILE.find("input-exclude-file"));
-    }
-
-    protected void excludeTest() {
-        execExcludeTest(Arg.EXCLUDE.find("exclude"), EXCLUDE_ARGS);
-    }
-
-    protected void inputExcludeTest() {
-        execExcludeTest(Arg.EXCLUDE.find("input-exclude"), EXCLUDE_ARGS);
-    }
-
-    protected void inputExcludeStdTest() {
-        Option option = Arg.EXCLUDE_STD.find("input-exclude-std");
-        String[] args = {StandardCollection.MISC.name()};
-        String[] excluded = {"afile~", ".#afile", "%afile%", "._afile"};
-        String[] notExcluded = {"afile~more", "what.#afile", "%afile%withMore", "well._afile"};
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            for (String fname : excluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
-            }
-            for (String fname : notExcluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void inputExcludeParsedScmTest() {
-        Option option = Arg.EXCLUDE_PARSE_SCM.find("input-exclude-parsed-scm");
-        String[] args = {"GIT"};
-        String[] lines = {
-                "# somethings",
-                "!thingone", "thing*", System.lineSeparator(),
-                "# some fish",
-                "**/fish", "*_fish",
-                "# some colorful directories",
-                "red/", "blue/*/"};
-        String[] notExcluded = {"thingone", "dir/fish_two", "some/thingone", "blue/fish/dory" };
-        String[] excluded = {"thingtwo", "some/things", "dir/fish", "red/fish", "blue/fish", "some/fish", "another/red_fish"};
-
-        writeFile(".gitignore", Arrays.asList(lines));
-        File dir = new File(baseDir, "red");
-        dir.mkdirs();
-        dir = new File(baseDir, "blue");
-        dir = new File(dir, "fish");
-        dir.mkdirs();
-
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            for (String fname : excluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
-            }
-            for (String fname : notExcluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private void inputExcludeSizeTest() {
-        Option option = Arg.EXCLUDE_SIZE.option();
-        String[] args = {"5"};
-        writeFile("Hi.txt", Collections.singletonList("Hi"));
-        writeFile("Hello.txt", Collections.singletonList("Hello"));
-        writeFile("HelloWorld.txt", Collections.singletonList("HelloWorld"));
-
-        String[] notExcluded = {"Hello.txt", "HelloWorld.txt"};
-        String[] excluded = {"Hi.txt"};
-
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            for (String fname : excluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
-            }
-            for (String fname : notExcluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    // include tests
-    private void execIncludeTest(final Option option, final String[] args) {
-        Option excludeOption = Arg.EXCLUDE.option();
-        String[] notExcluded = {"B.bar", "justbaz", "notbaz"};
-        String[] excluded = {"some.foo"};
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args),
-                    ImmutablePair.of(excludeOption, EXCLUDE_ARGS));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            for (String fname : excluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
-            }
-            for (String fname : notExcluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private void includeFileTest(final Option option) {
-        File outputFile = writeFile("include.txt", Arrays.asList(INCLUDE_ARGS));
-        execIncludeTest(option, new String[]{outputFile.getAbsolutePath()});
-    }
-
-    protected void inputIncludeFileTest() {
-        includeFileTest(Arg.INCLUDE_FILE.find("input-include-file"));
-    }
-
-    protected void includesFileTest() {
-        includeFileTest(Arg.INCLUDE_FILE.find("includes-file"));
-    }
-
-    protected void includeTest() {
-        execIncludeTest(Arg.INCLUDE.find("include"), INCLUDE_ARGS);
-    }
-
-    protected void inputIncludeTest() {
-        execIncludeTest(Arg.INCLUDE.find("input-include"), INCLUDE_ARGS);
-    }
-
-    protected void inputIncludeStdTest() {
-        ImmutablePair<Option, String[]> excludes = ImmutablePair.of(Arg.EXCLUDE.find("input-exclude"),
-                new String[]{"*~more", "*~"});
-        Option option = Arg.INCLUDE_STD.find("input-include-std");
-        String[] args = {StandardCollection.MISC.name()};
-        String[] excluded = {"afile~more"};
-        String[] notExcluded = {"afile~", ".#afile", "%afile%", "._afile", "what.#afile", "%afile%withMore", "well._afile"};
-        try {
-            ReportConfiguration config = generateConfig(excludes, ImmutablePair.of(option, args));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            for (String fname : excluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isFalse();
-            }
-            for (String fname : notExcluded) {
-                DocumentName docName = mkDocName(fname);
-                assertThat(excluder.matches(docName)).as(() -> dump(option, fname, excluder, docName)).isTrue();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void inputSourceTest() {
-        Option option = Arg.SOURCE.find("input-source");
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, new String[]{baseDir.getAbsolutePath()}));
-            assertThat(config.hasSource()).isTrue();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    // LICENSE tests
-    protected void execLicensesApprovedTest(final Option option, String[] args) {
-        Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
-        try {
-            ReportConfiguration config = generateConfig(arg1);
-            SortedSet<String> result = config.getLicenseIds(LicenseSetFactory.LicenseFilter.APPROVED);
-            assertThat(result).contains("one", "two");
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-
-        Pair<Option, String[]> arg2 = ImmutablePair.of(
-                Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"),
-                null
-        );
-
-        try {
-            ReportConfiguration config = generateConfig(arg1, arg2);
-            SortedSet<String> result = config.getLicenseIds(LicenseSetFactory.LicenseFilter.APPROVED);
-            assertThat(result).containsExactly("one", "two");
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void helpLicenses() {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        PrintStream origin = System.out;
-        try (PrintStream out = new PrintStream(output)) {
-            System.setOut(out);
-            generateConfig(ImmutablePair.of(HELP_LICENSES.option(), null));
-        } catch (IOException e) {
-            fail(e.getMessage());
-        } finally {
-            System.setOut(origin);
-        }
-        String txt = output.toString();
-        TextUtils.assertContains("====== Licenses ======", txt);
-        TextUtils.assertContains("====== Defined Matchers ======", txt);
-        TextUtils.assertContains("====== Defined Families ======", txt);
-    }
-
-    protected void licensesApprovedFileTest() {
-        File outputFile = writeFile("licensesApproved.txt", Arrays.asList("one", "two"));
-        execLicensesApprovedTest(Arg.LICENSES_APPROVED_FILE.find("licenses-approved-file"),
-                new String[]{outputFile.getAbsolutePath()});
-    }
-
-    protected void licensesApprovedTest() {
-        execLicensesApprovedTest(Arg.LICENSES_APPROVED.find("licenses-approved"),
-                new String[]{"one, two"});
-    }
-
-    private void execLicensesDeniedTest(final Option option, final String[] args) {
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            assertThat(config.getLicenseIds(LicenseSetFactory.LicenseFilter.ALL)).contains("ILLUMOS");
-            SortedSet<String> result = config.getLicenseIds(LicenseSetFactory.LicenseFilter.APPROVED);
-            assertThat(result).doesNotContain("ILLUMOS");
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void licensesDeniedTest() {
-        execLicensesDeniedTest(Arg.LICENSES_DENIED.find("licenses-denied"), new String[]{"ILLUMOS"});
-    }
-
-    protected void licensesDeniedFileTest() {
-        File outputFile = writeFile("licensesDenied.txt", Collections.singletonList("ILLUMOS"));
-        execLicensesDeniedTest(Arg.LICENSES_DENIED_FILE.find("licenses-denied-file"),
-                new String[]{outputFile.getAbsolutePath()});
-    }
-
-    private void execLicenseFamiliesApprovedTest(final Option option, final String[] args) {
-        String catz = ILicenseFamily.makeCategory("catz");
-        Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
-        try {
-            ReportConfiguration config = generateConfig(arg1);
-            SortedSet<String> result = config.getLicenseCategories(LicenseSetFactory.LicenseFilter.APPROVED);
-            assertThat(result).contains(catz);
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-
-        Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"), null);
-        try {
-            ReportConfiguration config = generateConfig(arg1, arg2);
-            SortedSet<String> result = config.getLicenseCategories(LicenseSetFactory.LicenseFilter.APPROVED);
-            assertThat(result).containsExactly(catz);
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void licenseFamiliesApprovedFileTest() {
-        File outputFile = writeFile("familiesApproved.txt", Collections.singletonList("catz"));
-        execLicenseFamiliesApprovedTest(Arg.FAMILIES_APPROVED_FILE.find("license-families-approved-file"),
-                new String[]{outputFile.getAbsolutePath()});
-    }
-
-    protected void licenseFamiliesApprovedTest() {
-        execLicenseFamiliesApprovedTest(Arg.FAMILIES_APPROVED.find("license-families-approved"),
-                new String[]{"catz"});
-    }
-
-    private void execLicenseFamiliesDeniedTest(final Option option, final String[] args) {
-        String gpl = ILicenseFamily.makeCategory("GPL");
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            assertThat(config.getLicenseCategories(LicenseSetFactory.LicenseFilter.ALL)).contains(gpl);
-            SortedSet<String> result = config.getLicenseCategories(LicenseSetFactory.LicenseFilter.APPROVED);
-            assertThat(result).doesNotContain(gpl);
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void licenseFamiliesDeniedFileTest() {
-        File outputFile = writeFile("familiesDenied.txt", Collections.singletonList("GPL"));
-        execLicenseFamiliesDeniedTest(Arg.FAMILIES_DENIED_FILE.find("license-families-denied-file"),
-                new String[]{outputFile.getAbsolutePath()});
-    }
-
-    protected void licenseFamiliesDeniedTest() {
-        execLicenseFamiliesDeniedTest(Arg.FAMILIES_DENIED.find("license-families-denied"),
-                new String[]{"GPL"});
-    }
-
-    protected void counterMaxTest() {
-        Option option = Arg.COUNTER_MAX.option();
-        String[] args = {null, null};
-
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.nullPair());
-            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
-            args[0] = "Unapproved:-1";
-            args[1] = "ignored:1";
-            config = generateConfig(ImmutablePair.of(option, args));
-            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(Integer.MAX_VALUE);
-            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
-            args[1] = "unapproved:5";
-            args[0] = "ignored:0";
-            config = generateConfig(ImmutablePair.of(option, args));
-            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(5);
-            assertThat(config.getClaimValidator().getMax(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void counterMinTest() {
-        Option option = Arg.COUNTER_MIN.option();
-        String[] args = {null, null};
-
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.nullPair());
-            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(0);
-            args[0] = "Unapproved:1";
-            args[1] = "ignored:1";
-            config = generateConfig(ImmutablePair.of(option, args));
-            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(1);
-            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.IGNORED)).isEqualTo(1);
-            args[1] = "unapproved:5";
-            args[0] = "ignored:0";
-            config = generateConfig(ImmutablePair.of(option, args));
-            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.UNAPPROVED)).isEqualTo(5);
-            assertThat(config.getClaimValidator().getMin(ClaimStatistic.Counter.IGNORED)).isEqualTo(0);
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private void configTest(final Option option) {
-        String[] args = {"src/test/resources/OptionTools/One.xml", "src/test/resources/OptionTools/Two.xml"};
-        Pair<Option, String[]> arg1 = ImmutablePair.of(option, args);
-        try {
-            ReportConfiguration config = generateConfig(arg1);
-            SortedSet<ILicense> set = config.getLicenses(LicenseSetFactory.LicenseFilter.ALL);
-            assertThat(set).hasSizeGreaterThan(2);
-            assertThat(LicenseSetFactory.search("ONE", "ONE", set)).isPresent();
-            assertThat(LicenseSetFactory.search("TWO", "TWO", set)).isPresent();
-
-            Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"), null);
-
-            config = generateConfig(arg1, arg2);
-            set = config.getLicenses(LicenseSetFactory.LicenseFilter.ALL);
-            assertThat(set).hasSize(2);
-            assertThat(LicenseSetFactory.search("ONE", "ONE", set)).isPresent();
-            assertThat(LicenseSetFactory.search("TWO", "TWO", set)).isPresent();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void licensesTest() {
-        configTest(Arg.CONFIGURATION.find("licenses"));
-    }
-
-    protected void configTest() {
-        configTest(Arg.CONFIGURATION.find("config"));
-    }
-
-    private void noDefaultsTest(final Option arg) {
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(arg, null));
-            assertThat(config.getLicenses(LicenseSetFactory.LicenseFilter.ALL)).isEmpty();
-            config = generateConfig(ImmutablePair.nullPair());
-            assertThat(config.getLicenses(LicenseSetFactory.LicenseFilter.ALL)).isNotEmpty();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void noDefaultsTest() {
-        noDefaultsTest(Arg.CONFIGURATION_NO_DEFAULTS.find("no-default-licenses"));
-    }
-
-    protected void configurationNoDefaultsTest() {
-        noDefaultsTest(Arg.CONFIGURATION_NO_DEFAULTS.find("configuration-no-defaults"));
-    }
-
-    protected void dryRunTest() {
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.DRY_RUN.find("dry-run"), null));
-            assertThat(config.isDryRun()).isTrue();
-            config = generateConfig(ImmutablePair.nullPair());
-            assertThat(config.isDryRun()).isFalse();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    private void editCopyrightTest(final Option option) {
-        try {
-            Pair<Option, String[]> arg1 = ImmutablePair.of(option, new String[]{"MyCopyright"});
-            ReportConfiguration config = generateConfig(arg1);
-            assertThat(config.getCopyrightMessage()).as("Copyright without --edit-license should not work").isNull();
-            Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.EDIT_ADD.find("edit-license"), null);
-            config = generateConfig(arg1, arg2);
-            assertThat(config.getCopyrightMessage()).isEqualTo("MyCopyright");
-        } catch (IOException e) {
-            e.printStackTrace();
-            if (e.getCause() != null) {
-                fail(e.getMessage() + ": " + e.getCause().getMessage());
-            }
-            fail(e.getMessage());
-        }
-    }
-
-    protected void copyrightTest() {
-        editCopyrightTest(Arg.EDIT_COPYRIGHT.find("copyright"));
-    }
-
-    protected void editCopyrightTest() {
-        editCopyrightTest(Arg.EDIT_COPYRIGHT.find("edit-copyright"));
-    }
-
-    private void editLicenseTest(final Option option) {
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, null));
-            assertThat(config.isAddingLicenses()).isTrue();
-            config = generateConfig(ImmutablePair.nullPair());
-            assertThat(config.isAddingLicenses()).isFalse();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void addLicenseTest() {
-        editLicenseTest(Arg.EDIT_ADD.find("addLicense"));
-    }
-
-    protected void editLicensesTest() {
-        editLicenseTest(Arg.EDIT_ADD.find("edit-license"));
-    }
-
-    private void overwriteTest(final Option option) {
-        Pair<Option, String[]> arg1 = ImmutablePair.of(option, null);
-        try {
-            ReportConfiguration config = generateConfig(arg1);
-            assertThat(config.isAddingLicensesForced()).isFalse();
-            Pair<Option, String[]> arg2 = ImmutablePair.of(Arg.EDIT_ADD.find("edit-license"), null);
-
-            config = generateConfig(arg1, arg2);
-            assertThat(config.isAddingLicensesForced()).isTrue();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void forceTest() {
-        overwriteTest(Arg.EDIT_OVERWRITE.find("force"));
-    }
-
-    protected void editOverwriteTest() {
-        overwriteTest(Arg.EDIT_OVERWRITE.find("edit-overwrite"));
-    }
-
-    protected void logLevelTest() {
-        Option option = Arg.LOG_LEVEL.find("log-level");
-        String[] args = {null};
-        Level logLevel = DefaultLog.getInstance().getLevel();
-        try {
-            for (Level level : Level.values()) {
-                try {
-                    args[0] = level.name();
-                    generateConfig(ImmutablePair.of(option, args));
-                    assertThat(DefaultLog.getInstance().getLevel()).isEqualTo(level);
-                } catch (IOException e) {
-                    fail(e.getMessage());
-                }
-            }
-        } finally {
-            DefaultLog.getInstance().setLevel(logLevel);
-        }
-    }
-
-    private void archiveTest(final Option option) {
-        String[] args = {null};
-        try {
-            for (ReportConfiguration.Processing proc : ReportConfiguration.Processing.values()) {
-                args[0] = proc.name();
-                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-                assertThat(config.getArchiveProcessing()).isEqualTo(proc);
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void outputArchiveTest() {
-        archiveTest(Arg.OUTPUT_ARCHIVE.find("output-archive"));
-    }
-
-    private void listFamilies(final Option option) {
-        String[] args = {null};
-        for (LicenseSetFactory.LicenseFilter filter : LicenseSetFactory.LicenseFilter.values()) {
-            try {
-                args[0] = filter.name();
-                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-                assertThat(config.listFamilies()).isEqualTo(filter);
-            } catch (IOException e) {
-                fail(e.getMessage());
-            }
-        }
-    }
-
-    protected void listFamiliesTest() {
-        listFamilies(Arg.OUTPUT_FAMILIES.find("list-families"));
-    }
-
-    protected void outputFamiliesTest() {
-        listFamilies(Arg.OUTPUT_FAMILIES.find("output-families"));
-    }
-
-    private void outTest(final Option option) {
-        File outFile = new File(baseDir, "outexample-" + option.getLongOpt());
-        String[] args = new String[]{outFile.getAbsolutePath()};
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-            try (OutputStream os = config.getOutput().get()) {
-                os.write("Hello world".getBytes());
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(Files.newInputStream(outFile.toPath())))) {
-                assertThat(reader.readLine()).isEqualTo("Hello world");
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void outTest() {
-        outTest(Arg.OUTPUT_FILE.find("out"));
-    }
-
-    protected void outputFileTest() {
-        outTest(Arg.OUTPUT_FILE.find("output-file"));
-    }
-
-    private void listLicenses(final Option option) {
-        String[] args = {null};
-        for (LicenseSetFactory.LicenseFilter filter : LicenseSetFactory.LicenseFilter.values()) {
-            try {
-                args[0] = filter.name();
-                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-                assertThat(config.listLicenses()).isEqualTo(filter);
-            } catch (IOException e) {
-                fail(e.getMessage());
-            }
-        }
-    }
-
-    protected void listLicensesTest() {
-        listLicenses(Arg.OUTPUT_LICENSES.find("list-licenses"));
-    }
-
-    protected void outputLicensesTest() {
-        listLicenses(Arg.OUTPUT_LICENSES.find("output-licenses"));
-    }
-
-    private void standardTest(final Option option) {
-        String[] args = {null};
-        try {
-            for (ReportConfiguration.Processing proc : ReportConfiguration.Processing.values()) {
-                args[0] = proc.name();
-                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-                assertThat(config.getStandardProcessing()).isEqualTo(proc);
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void outputStandardTest() {
-        standardTest(Arg.OUTPUT_STANDARD.find("output-standard"));
-    }
-
-    private void styleSheetTest(final Option option) {
-        // copy the dummy stylesheet so that we have a local file for users of the testing jar.
-        File file = new File(baseDir, "stylesheet-" + option.getLongOpt());
-        try (
-                InputStream in = ReporterTest.class.getResourceAsStream("MatcherContainerResource.txt");
-                OutputStream out = Files.newOutputStream(file.toPath())) {
-            IOUtils.copy(in, out);
-        } catch (IOException e) {
-            fail("Could not copy MatcherContainerResource.txt: " + e.getMessage());
-        }
-        // run the test
-        String[] args = {null};
-        try {
-            for (String sheet : new String[]{"plain-rat", "missing-headers", "unapproved-licenses", file.getAbsolutePath()}) {
-                args[0] = sheet;
-                ReportConfiguration config = generateConfig(ImmutablePair.of(option, args));
-                try (InputStream expected = StyleSheets.getStyleSheet(sheet).get();
-                     InputStream actual = config.getStyleSheet().get()) {
-                    assertThat(IOUtils.contentEquals(expected, actual)).as(() -> String.format("'%s' does not match", sheet)).isTrue();
-                }
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void styleSheetTest() {
-        styleSheetTest(Arg.OUTPUT_STYLE.find("stylesheet"));
-    }
-
-    protected void outputStyleTest() {
-        styleSheetTest(Arg.OUTPUT_STYLE.find("output-style"));
-    }
-
-    protected void scanHiddenDirectoriesTest() {
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.INCLUDE_STD.find("scan-hidden-directories"), null));
-            DocumentNameMatcher excluder = config.getDocumentExcluder(baseName());
-            assertThat(excluder.matches(mkDocName(".file"))).as(".file").isTrue();
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
-    }
-
-    protected void xmlTest() {
-        try {
-            ReportConfiguration config = generateConfig(ImmutablePair.of(Arg.OUTPUT_STYLE.find("xml"), null));
-            try (InputStream expected = StyleSheets.getStyleSheet("xml").get();
-                 InputStream actual = config.getStyleSheet().get()) {
-                assertThat(IOUtils.contentEquals(expected, actual)).as("'xml' does not match").isTrue();
-            }
-        } catch (IOException e) {
-            fail(e.getMessage());
-        }
     }
 
     @Override

--- a/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/AbstractOptionsProvider.java
@@ -172,6 +172,9 @@ public abstract class AbstractOptionsProvider implements ArgumentsProvider {
     }
 
     final protected File writeFile(File baseDir, final String name, final Iterable<String> lines) {
+        if (baseDir == null) {
+            fail("base directory not specified");
+        }
         File file = new File(baseDir, name);
         try (PrintWriter writer = new PrintWriter(new FileWriter(file))) {
             lines.forEach(writer::println);

--- a/apache-rat-core/src/test/java/org/apache/rat/test/utils/OptionFormatter.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/test/utils/OptionFormatter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   http://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
+package org.apache.rat.test.utils;
+
+import org.apache.commons.cli.Option;
+import org.apache.commons.lang3.StringUtils;
+
+public class OptionFormatter {
+    private OptionFormatter() {}
+    /**
+     * Returns the command line format (with '--' prefix) for the Option.
+     * @param opt the option to process.
+     * @return the command line option.
+     */
+    public static String longOpt(Option opt) {
+        return "--" + opt.getLongOpt();
+    }
+
+    public static String getName(Option opt) {
+        return StringUtils.defaultIfEmpty(opt.getLongOpt(), opt.getOpt());
+    }
+}

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TextUtils.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TextUtils.java
@@ -21,7 +21,12 @@ package org.apache.rat.testhelpers;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.regex.Pattern;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Utilities to assert text appears or does not appear in text.
@@ -82,11 +87,11 @@ public class TextUtils {
     public static void assertContainsExactly(int times, String find, String target) {
         String t = target;
         for (int i = 0; i < times; i++) {
-            assertThat(t.contains(find)).as(() -> format("Target does not contain %s copies fo %s%n%s", times, find, target))
+            assertThat(t.contains(find)).as(() -> format("Target does not contain %s copies of %s%n%s", times, find, target))
                     .isTrue();
             t = t.substring(t.indexOf(find) + find.length());
         }
-        assertThat(t.contains(find)).as(() -> format("Target contains more than %s copies fo %s%n%s", times, find, target))
+        assertThat(t.contains(find)).as(() -> format("Target contains more than %s copies of %s%n%s", times, find, target))
                 .isFalse();
     }
 
@@ -98,5 +103,9 @@ public class TextUtils {
     public static void assertNotContains(final String find, final String target) {
         assertThat(target.contains(find)).as(() -> format("Target contains the text: %s%n%s", find , target))
                 .isFalse();
+    }
+
+    public static String readFile(File f) throws IOException {
+        return String.join("\n", IOUtils.readLines(Files.newInputStream(f.toPath()), StandardCharsets.UTF_8));
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TextUtils.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/TextUtils.java
@@ -105,6 +105,12 @@ public class TextUtils {
                 .isFalse();
     }
 
+    /**
+     * Read given file as UTF-8.
+     * @param f File to read from.
+     * @return contents of the file as UTF-8.
+     * @throws IOException in case of I/O-errors.
+     */
     public static String readFile(File f) throws IOException {
         return String.join("\n", IOUtils.readLines(Files.newInputStream(f.toPath()), StandardCharsets.UTF_8));
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/XmlUtils.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/XmlUtils.java
@@ -216,5 +216,4 @@ public final class XmlUtils {
     public static void assertIsNotPresent(String identifier, Object source, XPath xPath, String xpath) throws XPathExpressionException {
         assertThat(isPresent(source, xPath, xpath)).as(identifier + ": Non-presence of " + xpath).isFalse();
     }
-
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/XmlUtils.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/XmlUtils.java
@@ -208,4 +208,13 @@ public final class XmlUtils {
     public static void assertIsNotPresent(Object source, XPath xPath, String xpath) throws XPathExpressionException {
         assertThat(isPresent(source, xPath, xpath)).as("Non-presence of " + xpath).isFalse();
     }
+
+    public static void assertIsPresent(String identifier, Object source, XPath xPath, String xpath) throws XPathExpressionException {
+        assertThat(isPresent(source, xPath, xpath)).as(identifier + ": Presence of " + xpath).isTrue();
+    }
+
+    public static void assertIsNotPresent(String identifier, Object source, XPath xPath, String xpath) throws XPathExpressionException {
+        assertThat(isPresent(source, xPath, xpath)).as(identifier + ": Non-presence of " + xpath).isFalse();
+    }
+
 }

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/OptionMojoTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/OptionMojoTest.java
@@ -25,7 +25,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.rat.test.AbstractOptionsProvider;
+import org.apache.rat.test.AbstractConfigurationOptionsProvider;
 import org.apache.rat.OptionCollectionTest;
 import org.apache.rat.ReportConfiguration;
 import org.apache.rat.plugin.BaseRatMojo;
@@ -69,7 +69,7 @@ public class OptionMojoTest {
 
     @AfterAll
     static void preserveData() {
-         AbstractOptionsProvider.preserveData(testPath.toFile(), "optionTest");
+         AbstractConfigurationOptionsProvider.preserveData(testPath.toFile(), "optionTest");
     }
 
     /**
@@ -89,7 +89,7 @@ public class OptionMojoTest {
         test.test();
     }
 
-    static class MojoOptionsProvider extends AbstractOptionsProvider implements ArgumentsProvider  {
+    static class MojoOptionsProvider extends AbstractConfigurationOptionsProvider implements ArgumentsProvider  {
 
         private RatCheckMojo mojo = null;
 
@@ -139,7 +139,7 @@ public class OptionMojoTest {
         protected final ReportConfiguration generateConfig(List<Pair<Option, String[]>> args) throws IOException {
             try {
                 this.mojo = generateMojo(args);
-                AbstractOptionsProvider.setup(this.mojo.getProject().getBasedir());
+                AbstractConfigurationOptionsProvider.setup(this.mojo.getProject().getBasedir());
                 return mojo.getConfiguration();
             } catch (MojoExecutionException e) {
                 throw new IOException(e.getMessage(), e);

--- a/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
+++ b/apache-rat-plugin/src/test/java/org/apache/rat/mp/RatCheckMojoTest.java
@@ -44,7 +44,7 @@ import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
 import org.apache.rat.report.claim.ClaimStatistic;
-import org.apache.rat.test.AbstractOptionsProvider;
+import org.apache.rat.test.AbstractConfigurationOptionsProvider;
 import org.apache.rat.test.utils.Resources;
 import org.apache.rat.testhelpers.TextUtils;
 import org.apache.rat.testhelpers.XmlUtils;
@@ -69,7 +69,7 @@ public class RatCheckMojoTest {
 
     @AfterAll
     static void preserveData() {
-        AbstractOptionsProvider.preserveData(tempDir.toFile(), "unit");
+        AbstractConfigurationOptionsProvider.preserveData(tempDir.toFile(), "unit");
     }
 
     @AfterAll

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.rat.test.AbstractOptionsProvider;
+import org.apache.rat.test.AbstractConfigurationOptionsProvider;
 import org.apache.rat.OptionCollectionTest;
 import org.apache.rat.ReportConfiguration;
 import org.apache.rat.testhelpers.TestingLog;
@@ -64,7 +64,7 @@ public class ReportOptionTest  {
 
     @AfterAll
     static void preserveData() {
-        AbstractOptionsProvider.preserveData(testPath.toFile(), "optionTest");
+        AbstractConfigurationOptionsProvider.preserveData(testPath.toFile(), "optionTest");
     }
 
     @ParameterizedTest
@@ -89,7 +89,7 @@ public class ReportOptionTest  {
         }
     }
 
-    final static class AntOptionsProvider extends AbstractOptionsProvider implements ArgumentsProvider {
+    final static class AntOptionsProvider extends AbstractConfigurationOptionsProvider implements ArgumentsProvider {
 
         public AntOptionsProvider() {
             super(BaseAntTask.unsupportedArgs(), testPath.toFile());

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -72,6 +72,9 @@ The <action> type attribute can be one of:
     </release>
     -->
     <release version="0.17-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-406" type="add" dev="claudenw">
+        Added integration tests for command line combinations to ensure marking a license as denied works.
+      </action>
       <action issue="RAT-483" type="fix" dev="claudenw">
         Reworked handling of resources fixed the site build.
       </action>


### PR DESCRIPTION
closes #406 

Additional tests to prove #406 is closed and to provide easy extension points for future tests of command line combinations.

- Added integration test for 406
- Extracted `AbstractConfigOptionsProvider` from `AbstractOptionsProvider`.
- Added `ReporterOptionsTest`  to test the result of passing arguments to the `Reporter`.  Tests all the options.
- `Reporter.output()` now returns a `ClaimStatistic` instance.
