### PR TITLE
Added information about RAT-476 to RAT-335 test

### DIFF
--- a/apache-rat-core/src/it/resources/ReportTest/RAT_335/src/.gitignore
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_335/src/.gitignore
@@ -3,5 +3,6 @@
 # This makes it ignore dir3/dir3.log and dir3/file3.log
 *.log
 
-# This makes it "unignore" dir3/file3.log
+# This makes it "unignore" dir3/file3.log but dir1/file1.log should still be ignored
+# because of the specific unignore int dir1.
 !file*.log

--- a/apache-rat-core/src/it/resources/ReportTest/RAT_335/src/README.txt
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_335/src/README.txt
@@ -3,10 +3,9 @@ Note the output when running in the real commandline version of git
 # Files that must be ignored (dropping the gitignore matches outside of this test tree)
 $ git check-ignore --no-index --verbose $(find . -type f|sort) | fgrep 'apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/'
 
-apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore:2:!dir1.md  ./dir1/dir1.md
+
 apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore:1:*.txt     ./dir1/dir1.txt
 apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/dir1/.gitignore:3:file1.log ./dir1/file1.log
 apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:1:*.md   ./dir2/dir2.md
 apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:4:*.log  ./dir3/dir3.log
-apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:7:!file*.log     ./dir3/file3.log
 apache-rat-plugin/src/test/resources/unit/RAT-335-GitIgnore/.gitignore:1:*.md   ./root.md

--- a/apache-rat-core/src/it/resources/ReportTest/RAT_335/src/dir1/.gitignore
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_335/src/dir1/.gitignore
@@ -1,3 +1,4 @@
 *.txt
 !dir1.md
+# this should override the "dont ignore file*.log" in the root .gitignore
 file1.log

--- a/apache-rat-core/src/it/resources/ReportTest/RAT_335/verify.groovy
+++ b/apache-rat-core/src/it/resources/ReportTest/RAT_335/verify.groovy
@@ -40,12 +40,14 @@ Document document = XmlUtils.toDom(new FileInputStream(args[0]))
 XPath xPath = XPathFactory.newInstance().newXPath()
 
 List<String> ignoredFiles = new ArrayList<>(Arrays.asList(
-        "/dir1/dir1.txt",
-        "/dir1/.gitignore",
-        "/dir2/dir2.md",
-        "/dir3/dir3.log",
         "/.gitignore",
-        "/root.md"))
+        "/root.md",
+        "/dir3/dir3.log",
+        "/dir1/.gitignore",
+        "/dir1/dir1.txt",
+//        "/dir1/file1.log",  This file is excluded due to bug noted in RAT-476
+        "/dir2/dir2.md",
+))
 
 NodeList nodeList = XmlUtils.getNodeList(document, xPath, "/rat-report/resource[@type='IGNORED']")
 for (int i = 0 ; i < nodeList.getLength(); i++) {

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileProcessors/AbstractFileProcessorBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileProcessors/AbstractFileProcessorBuilder.java
@@ -106,10 +106,9 @@ public abstract class AbstractFileProcessorBuilder {
      * Creates the MatcherSet from each level and returns them in a list in reverse order.
      * @return a list of MatcherSet
      */
-
     private List<MatcherSet> createMatcherSetList() {
         List<Integer> keys = new ArrayList<>(levelBuilders.keySet());
-        keys.sort((a, b) -> -1 * Integer.compare(a, b));
+        keys.sort((a, b) -> Integer.compare(b, a));
         return keys.stream().map(key -> levelBuilders.get(key).asMatcherSet()).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
* Adjusted RAT-355 test a per git reporting of include/exclude

Discovered RAT 335 was not 100% correct, then discovered that RAT-476 already covers the issue that I uncovered in RAT-335 test.  So rat 335 test is adjusted to show current state and has note to indicate why.

Also added comment to RAT-476 indicating that RAT-335 test should be updated when it is fixed.

