### PR TITLE
Override Guava version to 33.4.8-jre to fix CVE-2023-2976, CVE-2020-8908

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,12 @@ agnostic home for software distribution comprehension and audit tools.
         <version>1.3.1</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <!-- overwrite due to CVE-2023-2976 in Guice transitive dependencies -->
+        <version>33.4.8-jre</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <reporting>


### PR DESCRIPTION
**Summary**

This PR overrides the version of **Guava** to **33.4.8-jre** to address security vulnerabilities identified in older transitive dependencies.

**Details**

Guava is pulled in transitively via the following dependency chain:

<img width="1614" height="329" alt="image" src="https://github.com/user-attachments/assets/cfcb55d8-51af-41da-b306-b2ef06d4e389" />



The older 30.1-jre version is affected by the following CVEs:

- CVE-2023-2976 : Temporary file creation vulnerability

- CVE-2020-8908 : Local information disclosure via insecure file permissions

To mitigate these issues, this PR explicitly overrides Guava’s version to 33.4.8-jre, which resolves the conflict and ensures all modules consistently use the secure version.

**Verification**

Run **mvn dependency:tree -Dverbose** to confirm the override is effective.

