### PR TITLE
Override Guava version to 33.5.0-jre to fix CVE-2023-2976, CVE-2020-8908

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,12 @@ agnostic home for software distribution comprehension and audit tools.
         <version>1.3.1</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <!-- overwrite due to CVE-2023-2976 and CVE-2020-8908 in Guice transitive dependencies -->
+        <version>33.5.0-jre</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <reporting>


### PR DESCRIPTION
**Summary**

This PR overrides the version of **Guava** to **33.5.0-jre** to address security vulnerabilities identified in older transitive dependencies.

**Details**

**Guava** is pulled in transitively via the following dependency chain:

<img width="1602" height="321" alt="image" src="https://github.com/user-attachments/assets/72694603-c492-4bb8-9752-ed2f71af9426" />

The older 30.1-jre version is affected by the following CVEs:

- CVE-2023-2976 : Temporary file creation vulnerability

- CVE-2020-8908 : Local information disclosure via insecure file permissions

To mitigate these issues, this PR explicitly overrides Guava’s version to 33.5.0-jre, which resolves the conflict and ensures all modules consistently use the secure version.

**Verification**

Run **mvn dependency:tree -Dverbose** to confirm the override is effective.