### PR TITLE
RAT-551: Replace NoCloseOutputStream with Apache Commons CloseShieldOutputStream

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -39,6 +39,7 @@ import java.util.SortedSet;
 import java.util.function.Consumer;
 
 import org.apache.commons.io.function.IOSupplier;
+import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.rat.analysis.IHeaderMatcher;
 import org.apache.rat.commandline.StyleSheets;
 import org.apache.rat.config.AddLicenseHeaders;
@@ -504,10 +505,10 @@ public class ReportConfiguration {
      * Sets the supplier for the output stream. The supplier may be called multiple
      * times to provide the stream. Suppliers should prepare streams that are
      * appended to and that can be closed. If an {@code OutputStream} should not be
-     * closed consider wrapping it in a {@code NoCloseOutputStream}
+     * closed consider wrapping it in a {@code CloseShieldOutputStream}
      * @param out The OutputStream supplier that provides the output stream to write
      * the report to. A null value will use System.out.
-     * @see NoCloseOutputStream
+     * @see CloseShieldOutputStream
      */
     public void setOut(final IOSupplier<OutputStream> out) {
         this.out = out;
@@ -542,7 +543,7 @@ public class ReportConfiguration {
      * @return The supplier of the output stream to write the report to.
      */
     public IOSupplier<OutputStream> getOutput() {
-        return out == null ? () -> new NoCloseOutputStream(System.out) : out;
+        return out == null ? () -> CloseShieldOutputStream.wrap(System.out) : out;
     }
 
     /**
@@ -839,66 +840,6 @@ public class ReportConfiguration {
             String msg = "You must specify at least one license";
             logger.accept(msg);
             throw new ConfigurationException(msg);
-        }
-    }
-
-    /**
-     * A wrapper around an output stream that does not close the output stream.
-     */
-    public static class NoCloseOutputStream extends OutputStream {
-        /** the output stream this stream wraps */
-        private final OutputStream delegate;
-
-        /**
-         * Constructor.
-         * @param delegate the output stream to wrap.
-         */
-        public NoCloseOutputStream(final OutputStream delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void write(final int arg0) throws IOException {
-            delegate.write(arg0);
-        }
-
-        /**
-         * Does not actually close the delegate. But does perform a flush.
-         * @throws IOException on Error.
-         */
-        @Override
-        public void close() throws IOException {
-            this.delegate.flush();
-        }
-
-        @Override
-        public boolean equals(final Object obj) {
-            return delegate.equals(obj);
-        }
-
-        @Override
-        public void flush() throws IOException {
-            delegate.flush();
-        }
-
-        @Override
-        public int hashCode() {
-            return delegate.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return delegate.toString();
-        }
-
-        @Override
-        public void write(final byte[] arg0, final int arg1, final int arg2) throws IOException {
-            delegate.write(arg0, arg1, arg2);
-        }
-
-        @Override
-        public void write(final byte[] b) throws IOException {
-            delegate.write(b);
         }
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
@@ -41,7 +41,7 @@ import java.util.SortedSet;
 import java.util.function.Function;
 
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.apache.rat.ReportConfiguration.NoCloseOutputStream;
+import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.rat.analysis.IHeaderMatcher;
 import org.apache.rat.config.AddLicenseHeaders;
 import org.apache.rat.config.exclusion.StandardCollection;
@@ -452,7 +452,7 @@ public class ReportConfigurationTest {
 
     @Test
     public void outputTest() throws IOException {
-        assertThat(underTest.getOutput().get()).isExactlyInstanceOf(NoCloseOutputStream.class);
+        assertThat(underTest.getOutput().get()).isExactlyInstanceOf(CloseShieldOutputStream.class);
         assertThat(underTest.getWriter()).isNotNull();
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Report.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.rat.ConfigurationException;
 import org.apache.rat.DeprecationReporter;
 import org.apache.rat.ImplementationException;
@@ -443,7 +444,7 @@ public class Report extends BaseAntTask {
     public void execute() {
         try {
             Reporter r = new Reporter(validate(getConfiguration()));
-            r.output(StyleSheets.PLAIN.getStyleSheet(), () -> new ReportConfiguration.NoCloseOutputStream(System.out));
+            r.output(StyleSheets.PLAIN.getStyleSheet(), () -> CloseShieldOutputStream.wrap(System.out));
             r.output();
         } catch (BuildException e) {
             throw e;

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-551" type="add" dev="claudenw">
+        Replace NoCloseOutputStream with Apache Commons CloseShieldOutputStream.
+      </action>
       <action issue="RAT-536" type="fix" dev="pottlinger" due-to="Hervé Boutemy">
         Enable reproducible build and keep a changing timestamp for webpage generation.
       </action>


### PR DESCRIPTION
Removes custom NoCloseOutputStream with the Apache commons CloseShieldOutputStream