### PR TITLE
RAT-502: Map XSLT to standard instead of binary files 

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/TikaProcessor.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/TikaProcessor.java
@@ -95,6 +95,7 @@ public final class TikaProcessor {
         DOCUMENT_TYPE_MAP.put("application/x-xliff+zip", Document.Type.ARCHIVE);
 //        org.apache.tika.parser.xml.DcXMLParser
         DOCUMENT_TYPE_MAP.put("application/xml", Document.Type.STANDARD);
+        DOCUMENT_TYPE_MAP.put("application/xslt+xml", Document.Type.STANDARD);
         DOCUMENT_TYPE_MAP.put("image/svg+xml", Document.Type.STANDARD);
 //        org.apache.tika.parser.xml.FictionBookParser
         DOCUMENT_TYPE_MAP.put("application/x-fictionbook+xml", Document.Type.STANDARD);

--- a/apache-rat-core/src/test/java/org/apache/rat/analysis/TikaProcessorTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/analysis/TikaProcessorTest.java
@@ -137,7 +137,7 @@ public class TikaProcessorTest {
                 }
             }
         }
-        System.out.println("untested mime types");
+        System.out.println("** Untested mime types");
         unseenMime.keySet().forEach(System.out::println);
         for (Document.Type type : Document.Type.values()) {
             System.out.format("Tested %s %s files%n", statistic.getCounter(type), type);

--- a/apache-rat-core/src/test/resources/tikaFiles/README.md
+++ b/apache-rat-core/src/test/resources/tikaFiles/README.md
@@ -1,6 +1,6 @@
 Files in this directory are parsed by Tika process and verified that the proper type is returned.
 
-the `standard` subsirectory contains files that are returned as STANDARD document types.
+the `standard` subdirectory contains files that are returned as STANDARD document types.
 
 the `binary` subdirectory contains files that are returned as BINARY types.
 
@@ -8,4 +8,4 @@ the `notice` subdirectory contains files that are NOTICE types
 
 the `archive` subdirectory contains files that are ARCHIVE types.
 
-The `TikeProcessorTest.testTikaFiles()` automatically runs against the files in the directories. To add a new file to test just place it in the proper directory.
+The `TikaProcessorTest.testTikaFiles()` automatically runs against the files in the directories. To add a new file to test just place it in the proper directory.

--- a/apache-rat-core/src/test/resources/tikaFiles/standard/example.xslt
+++ b/apache-rat-core/src/test/resources/tikaFiles/standard/example.xslt
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+***************************************************************
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+ *
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+***************************************************************
+-->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <xsl:template match="/">
+        <html>
+            <body>
+                <h2>My File Collection</h2>
+                <table border="1">
+                    <tr bgcolor="#9acd32">
+                        <th>Title</th>
+                        <th>Artist</th>
+                    </tr>
+                    <xsl:for-each select="catalog/file">
+                        <tr>
+                            <td><xsl:value-of select="title"/></td>
+                            <td><xsl:value-of select="author"/></td>
+                        </tr>
+                    </xsl:for-each>
+                </table>
+            </body>
+        </html>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-502" type="fix" dev="pottlinger">
+        Add XSLT (application/xslt+xml) to the files that are scanned for licenses, was treated/ignored as binary before.
+      </action>
       <action issue="RAT-527" type="add" dev="pottlinger">
         Migrate from old groovy-all to current ASF groovy in integration tests.
       </action>


### PR DESCRIPTION
Scan XSLT fopr licenses instead of ignore them as binary.
Fixed regression from 0.17 and fixed some typos as well.