### PR TITLE
RAT-482: Re-enable version 3.0.0-M2 of changelog plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,12 +293,11 @@ agnostic home for software distribution comprehension and audit tools.
           </reportSet>
         </reportSets>
       </plugin>
-      <!-- Disabled until https://github.com/apache/maven-changelog-plugin/issues/200 is fixed
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changelog-plugin</artifactId>
-        <version>2.3</version>
-      </plugin-->
+        <version>3.0.0-M2</version>
+      </plugin>
       <!-- catch code tags -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-482" type="fix" dev="pottlinger">
+        Re-enable maven-changelog-plugin v3.0.0-M2, which adds a large Apache Creadur RAT changelog report to the website.
+      </action>
       <action issue="RAT-502" type="fix" dev="pottlinger">
         Add XSLT (application/xslt+xml) to the files that are scanned for licenses, was treated/ignored as binary before.
       </action>


### PR DESCRIPTION
Waiting for upstream changes on changelog plugin to allow generation of a readable report again.

Relates to:
* https://github.com/apache/maven-changelog-plugin/pull/210#issuecomment-3740661106
* https://github.com/apache/maven-changelog-plugin/issues/200#event-25691975532
and the upcoming 3.0.0-M2 release in order to be verified.

2026-05-24: After the release is done I asked if the result is expected (=one big changelog) or not:
https://github.com/apache/maven-changelog-plugin/issues/200#issuecomment-4529901134
