### PR TITLE
RAT-555: Configure TempDir deletion strategy to ignore I/O failures and skip running on GHA&linux

### DIFF
--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -37,6 +37,7 @@ import org.apache.rat.utils.Log;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.io.TempDirDeletionStrategy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -55,7 +56,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ReportOptionTest  {
     // RAT-475: Do no cleanup in order to prevent random build failures on ASF-Linux/GitHub nodes
-    @TempDir(cleanup = CleanupMode.NEVER)
+    // RAT-555: Try out new deletionStrategie without failing the tests.
+    @TempDir(cleanup = CleanupMode.NEVER, deletionStrategy = TempDirDeletionStrategy.IgnoreFailures.class)
     static Path testPath;
 
     static ReportConfiguration reportConfiguration;

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.cli.Option;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.rat.test.AbstractConfigurationOptionsProvider;
@@ -55,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests to ensure the option setting works correctly.
  */
-@DisabledIf(value = "isRunningOnGitHubActionOrLinux", disabledReason = "RAT-555, RAT-475")
+@DisabledIf(value = "isRunningOnGitHubActionAndLinux", disabledReason = "RAT-555, RAT-475")
 public class ReportOptionTest  {
     // RAT-475: Do no cleanup in order to prevent random build failures on ASF-Linux/GitHub nodes
     // RAT-555: Try out new deletionStrategy without failing the tests.
@@ -64,15 +63,8 @@ public class ReportOptionTest  {
 
     static ReportConfiguration reportConfiguration;
 
-    static boolean isGitHubLinuxOrWindowsWithJava8() {
+    static boolean isRunningOnGitHubActionAndLinux() {
         return System.getenv("GITHUB_ACTION") != null &&
-                (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("linux") ||
-                        (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows") && SystemUtils.IS_JAVA_1_8)
-                );
-    }
-
-    static boolean isRunningOnGitHubActionOrLinux() {
-        return System.getenv("GITHUB_ACTION") != null || 
          System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("linux");
     }
 

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -35,6 +35,7 @@ import org.apache.rat.documentation.options.AntOption;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.io.TempDirDeletionStrategy;
@@ -54,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests to ensure the option setting works correctly.
  */
+@DisabledIf(value = "isRunningOnGitHubActionOrLinux", disabledReason = "RAT-555, RAT-475")
 public class ReportOptionTest  {
     // RAT-475: Do no cleanup in order to prevent random build failures on ASF-Linux/GitHub nodes
     // RAT-555: Try out new deletionStrategie without failing the tests.

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 @DisabledIf(value = "isRunningOnGitHubActionOrLinux", disabledReason = "RAT-555, RAT-475")
 public class ReportOptionTest  {
     // RAT-475: Do no cleanup in order to prevent random build failures on ASF-Linux/GitHub nodes
-    // RAT-555: Try out new deletionStrategie without failing the tests.
+    // RAT-555: Try out new deletionStrategy without failing the tests.
     @TempDir(cleanup = CleanupMode.NEVER, deletionStrategy = TempDirDeletionStrategy.IgnoreFailures.class)
     static Path testPath;
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -69,7 +69,7 @@ in order to be properly linked in site reports.
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
       <action issue="RAT-555" type="fix" dev="pottlinger">
-        Explicitly configure TempDir's deletion strategy to ignore failures in order fix random test failures on GitHubAction runs (ReportOptionTest).
+        Explicitly configure TempDir's deletion strategy to ignore failures and disable ReportOptionTest on GitHubAction and linux combination.
       </action>
       <action issue="RAT-502" type="fix" dev="pottlinger">
         Add XSLT (application/xslt+xml) to the files that are scanned for licenses, was treated/ignored as binary before.

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-555" type="fix" dev="pottlinger">
+        Explicitly configure TempDir's deletion strategy to ignore failures in order fix random test failures on GitHubAction runs (ReportOptionTest).
+      </action>
       <action issue="RAT-502" type="fix" dev="pottlinger">
         Add XSLT (application/xslt+xml) to the files that are scanned for licenses, was treated/ignored as binary before.
       </action>


### PR DESCRIPTION
Random build failures seem to be back on GHA, e.g.
https://github.com/apache/creadur-rat/pull/660

Try out freshly implemented DeletionStrategy in jUnit's TempDir and exclude running the test on (GHA&&linux)