### PR TITLE
RAT-532: Update spotbugs plugin and  UTF-8 encoding 

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/annotation/AbstractLicenseAppender.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/annotation/AbstractLicenseAppender.java
@@ -308,7 +308,7 @@ public abstract class AbstractLicenseAppender {
                 // for Java just place the license at the front, for XML add
                 // an XML decl first - don't know how to handle PHP
                 if (expectsPackage || expectsXMLDecl) {
-                    try (FileWriter writer2  = new FileWriter(newDocument)) {
+                    try (FileWriter writer2  = new FileWriter(newDocument, StandardCharsets.UTF_8)) {
                         if (expectsXMLDecl) {
                             writer2.write("<?xml version='1.0'?>");
                             writer2.write(LINE_SEP);

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
@@ -21,6 +21,7 @@ package org.apache.rat.report.xml.writer;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Objects;
@@ -327,7 +328,7 @@ public final class XmlWriter implements IXmlWriter {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             transformer.transform(new DOMSource(document),
                     new StreamResult(baos));
-            appendable.append(baos.toString());
+            appendable.append(baos.toString(StandardCharsets.UTF_8));
         } catch (TransformerException e) {
             throw new IOException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@ agnostic home for software distribution comprehension and audit tools.
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.8.3</version>
+          <version>4.10.2.0</version>
           <configuration>
             <maxAllowedViolations>46</maxAllowedViolations>
             <failOnError>true</failOnError>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-532" type="update" dev="pottlinger" due-to="dependabot">
+        Update to spotbugs-maven-plugin to 4.10.2.0 and use UTF-8 as fallback encoding in LicenseAppender and XmlWriter.
+      </action>
       <action issue="RAT-558" type="add" dev="pottlinger">
         Add a basic security and agents configuration to Apache RAT.
       </action>


### PR DESCRIPTION
Explicitly set UTF-8 in LicenseAppender and XmlWriter to fix additional encoding spotbugs errors with modern JDKs