### PR TITLE
RAT-563: Rename IReportable and IReportableListWalker

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -209,12 +209,12 @@ public final class OptionCollection {
     }
 
     /**
-     * Creates an IReportable object from the directory name and ReportConfiguration
+     * Creates a Reportable object from the directory name and ReportConfiguration
      * object.
      *
      * @param base the directory that contains the files to report on.
      * @param config the ReportConfiguration.
-     * @return the IReportable instance containing the files.
+     * @return the Reportable instance containing the files.
      */
     public static Reportable getReportable(final File base, final ReportConfiguration config) {
         File absBase = base.getAbsoluteFile();

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -48,7 +48,7 @@ import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.document.FileDocument;
 import org.apache.rat.help.Licenses;
 import org.apache.rat.license.LicenseSetFactory;
-import org.apache.rat.report.IReportable;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
@@ -190,7 +190,7 @@ public final class OptionCollection {
             }
         }
         for (String s : commandLine.getArgs()) {
-            IReportable reportable = getReportable(new File(s), configuration);
+            Reportable reportable = getReportable(new File(s), configuration);
             if (reportable != null) {
                 configuration.addSource(reportable);
             }
@@ -215,7 +215,7 @@ public final class OptionCollection {
      * @param config the ReportConfiguration.
      * @return the IReportable instance containing the files.
      */
-    public static IReportable getReportable(final File base, final ReportConfiguration config) {
+    public static Reportable getReportable(final File base, final ReportConfiguration config) {
         File absBase = base.getAbsoluteFile();
         DocumentName documentName = DocumentName.builder(absBase).build();
         if (!absBase.exists()) {

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -21,6 +21,7 @@ package org.apache.rat;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -242,6 +243,7 @@ public final class OptionCollection {
      */
     private static final class OptionComparator implements Comparator<Option>, Serializable {
         /** The serial version UID.  */
+        @Serial
         private static final long serialVersionUID = 5305467873966684014L;
 
         private String getKey(final Option opt) {

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
@@ -34,7 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.commandline.Arg;
 import org.apache.rat.commandline.ArgumentContext;
 import org.apache.rat.help.Licenses;
-import org.apache.rat.report.IReportable;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.ui.UIOptionCollection;
 import org.apache.rat.utils.DefaultLog;
 
@@ -126,7 +126,7 @@ public final class OptionCollectionParser {
         final CommandLine commandLine = argumentContext.getCommandLine();
         if (!configuration.hasSource()) {
             for (String s : commandLine.getArgs()) {
-                IReportable reportable = OptionCollection.getReportable(new File(s), configuration);
+                Reportable reportable = OptionCollection.getReportable(new File(s), configuration);
                 if (reportable != null) {
                     configuration.addSource(reportable);
                 }

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
@@ -21,6 +21,7 @@ package org.apache.rat;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
@@ -140,6 +141,7 @@ public final class OptionCollectionParser {
      */
     private static final class OptionComparator implements Comparator<Option>, Serializable {
         /** The serial version UID.  */
+        @Serial
         private static final long serialVersionUID = 5305467873966684014L;
 
         private String getKey(final Option opt) {

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -54,12 +54,12 @@ import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
-import org.apache.rat.report.IReportable;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
 import org.apache.rat.utils.ReportingSet;
 import org.apache.rat.walker.FileListWalker;
-import org.apache.rat.walker.IReportableListWalker;
+import org.apache.rat.walker.ReportableListWalker;
 
 /**
  * A configuration object is used by the front end to invoke the
@@ -131,7 +131,7 @@ public class ReportConfiguration {
     /**
      * A list of reportables to process;
      */
-    private final List<IReportable> reportables;
+    private final List<Reportable> reportables;
 
     /**
      * A predicate to test if a path should be included in the processing.
@@ -210,7 +210,7 @@ public class ReportConfiguration {
      * Adds a Reportable as a source of files to scan.
      * @param reportable the reportable to process.
      */
-    public void addSource(final IReportable reportable) {
+    public void addSource(final Reportable reportable) {
         notNull(reportable, "Reportable may not be null.");
         reportables.add(reportable);
     }
@@ -227,9 +227,9 @@ public class ReportConfiguration {
      * Gets a builder initialized with any files specified as sources.
      * @return a configured builder.
      */
-    public IReportableListWalker.Builder getSources() {
+    public ReportableListWalker.Builder getSources() {
         DocumentName name = DocumentName.builder(new File(".")).build();
-        IReportableListWalker.Builder builder = IReportableListWalker.builder(name);
+        ReportableListWalker.Builder builder = ReportableListWalker.builder(name);
         sources.forEach(file -> builder.addReportable(new FileListWalker(new FileDocument(file, DocumentNameMatcher.MATCHES_ALL))));
         reportables.forEach(builder::addReportable);
         return builder;

--- a/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ReportConfiguration.java
@@ -427,7 +427,7 @@ public class ReportConfiguration {
     }
 
     /**
-     * Get the DocumentNameMatcher that excludes files found in the directory tree..
+     * Get the DocumentNameMatcher that excludes files found in the directory tree.
      * @param baseDir the DocumentName for the base directory.
      * @return the DocumentNameMatcher for the base directory.
      */

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/ExclusionProcessor.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/ExclusionProcessor.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
 
 /**
  * Processes the include and exclude patterns and applies the result against a base directory
- * to return an IReportable that contains all the reportable objects.
+ * to return a Reportable that contains all the reportable objects.
  */
 public class ExclusionProcessor {
     /** Strings that identify the files/directories to exclude */

--- a/apache-rat-core/src/main/java/org/apache/rat/report/Reportable.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/Reportable.java
@@ -21,7 +21,7 @@ package org.apache.rat.report;
 import org.apache.rat.api.RatException;
 import org.apache.rat.document.DocumentName;
 
-public interface IReportable {
+public interface Reportable {
     /**
      * Adds the reportable to the RatReport.
      * @param report the report to add the results to.
@@ -33,5 +33,5 @@ public interface IReportable {
      * Returns the DocumentName for the reportable.
      * @return the DocumentName for the reportable.
      */
-    DocumentName getName();
+    DocumentName name();
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/FileListWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/FileListWalker.java
@@ -34,7 +34,7 @@ import org.apache.rat.report.Reportable;
 import org.apache.rat.utils.DefaultLog;
 
 /**
- * Implementation of IReportable that traverses over a resource collection
+ * Implementation of Reportable that traverses over a resource collection
  * internally.
  */
 public class FileListWalker implements Reportable {

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/FileListWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/FileListWalker.java
@@ -29,15 +29,15 @@ import org.apache.rat.config.exclusion.ExclusionUtils;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.document.FileDocument;
-import org.apache.rat.report.IReportable;
 import org.apache.rat.report.RatReport;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.utils.DefaultLog;
 
 /**
  * Implementation of IReportable that traverses over a resource collection
  * internally.
  */
-public class FileListWalker implements IReportable {
+public class FileListWalker implements Reportable {
     /** The source document name. */
     private final FileDocument source;
     /** The root document name. */
@@ -72,7 +72,7 @@ public class FileListWalker implements IReportable {
     @Override
     public void run(final RatReport report) throws RatException {
         DefaultLog.getInstance().debug(String.format("Reading file name: %s due to option %s", source, Arg.SOURCE.option()));
-        DocumentName sourceName = getName();
+        DocumentName sourceName = name();
         try (Reader reader = source.reader()) {
             for (String docName : IOUtils.readLines(reader)) {
                 try {
@@ -93,7 +93,7 @@ public class FileListWalker implements IReportable {
     }
 
     @Override
-    public DocumentName getName() {
+    public DocumentName name() {
         return source.getName();
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/ReportableListWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/ReportableListWalker.java
@@ -24,18 +24,18 @@ import java.util.Objects;
 
 import org.apache.rat.api.RatException;
 import org.apache.rat.document.DocumentName;
-import org.apache.rat.report.IReportable;
 import org.apache.rat.report.RatReport;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.utils.DefaultLog;
 
 /**
  * A Reportable that walks a list of IReportables and executes the run on each.
  */
-public final class IReportableListWalker implements IReportable {
+public final class ReportableListWalker implements Reportable {
     /** The document name for this walker. */
     private final DocumentName documentName;
     /** The list of reportables for this walker. */
-    private final List<IReportable> reportables;
+    private final List<Reportable> reportables;
 
     /**
      * Create a builder for the list walker.
@@ -50,24 +50,24 @@ public final class IReportableListWalker implements IReportable {
      * Construct the builder.
      * @param builder for the reportable.
      */
-    private IReportableListWalker(final Builder builder) {
+    private ReportableListWalker(final Builder builder) {
         this.documentName = builder.documentName;
         this.reportables = builder.reportables;
     }
 
     @Override
     public void run(final RatReport report) {
-        for (IReportable reportable : reportables) {
+        for (Reportable reportable : reportables) {
             try {
                 reportable.run(report);
             } catch (RatException e) {
-                DefaultLog.getInstance().error("Error processing " + reportable.getName(), e);
+                DefaultLog.getInstance().error("Error processing " + reportable.name(), e);
             }
         }
     }
 
     @Override
-    public DocumentName getName() {
+    public DocumentName name() {
         return documentName;
     }
 
@@ -78,7 +78,7 @@ public final class IReportableListWalker implements IReportable {
         /** The document name for the walker. */
         private final DocumentName documentName;
         /** The list of IReportable objects to execute. */
-        private List<IReportable> reportables = new ArrayList<>();
+        private List<Reportable> reportables = new ArrayList<>();
 
         /**
          * Constructs the builder.
@@ -94,7 +94,7 @@ public final class IReportableListWalker implements IReportable {
          * @param reportable the reportable to run.
          * @return this.
          */
-        public Builder addReportable(final IReportable reportable) {
+        public Builder addReportable(final Reportable reportable) {
             this.reportables.add(reportable);
             return this;
         }
@@ -104,11 +104,11 @@ public final class IReportableListWalker implements IReportable {
          * @return the reportable.
          * @throws RatException on error.
          */
-        public IReportable build() throws RatException {
+        public Reportable build() throws RatException {
             if (reportables == null) {
                 throw new RatException("Builder may only be used once");
             }
-            IReportable result = new IReportableListWalker(this);
+            Reportable result = new ReportableListWalker(this);
             this.reportables = null;
             return result;
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/ReportableListWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/ReportableListWalker.java
@@ -104,11 +104,11 @@ public final class ReportableListWalker implements Reportable {
          * @return the reportable.
          * @throws RatException on error.
          */
-        public Reportable build() throws RatException {
+        public ReportableListWalker build() throws RatException {
             if (reportables == null) {
                 throw new RatException("Builder may only be used once");
             }
-            Reportable result = new ReportableListWalker(this);
+            ReportableListWalker result = new ReportableListWalker(this);
             this.reportables = null;
             return result;
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/ReportableListWalker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/ReportableListWalker.java
@@ -29,7 +29,7 @@ import org.apache.rat.report.Reportable;
 import org.apache.rat.utils.DefaultLog;
 
 /**
- * A Reportable that walks a list of IReportables and executes the run on each.
+ * A Reportable that walks a list of Reportables and executes the run on each.
  */
 public final class ReportableListWalker implements Reportable {
     /** The document name for this walker. */
@@ -77,7 +77,7 @@ public final class ReportableListWalker implements Reportable {
     public static final class Builder {
         /** The document name for the walker. */
         private final DocumentName documentName;
-        /** The list of IReportable objects to execute. */
+        /** The list of Reportable objects to execute. */
         private List<Reportable> reportables = new ArrayList<>();
 
         /**

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/Walker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/Walker.java
@@ -28,11 +28,11 @@ import org.apache.rat.report.Reportable;
  */
 public abstract class Walker implements Reportable {
 
-    /** The document this walker is walking */
+    /** The document this walker is walking. */
     private final Document document;
 
     /**
-     * Creates the walker
+     * Creates the walker.
      * @param document The document the walker is walking.
      */
     protected Walker(final Document document) {

--- a/apache-rat-core/src/main/java/org/apache/rat/walker/Walker.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/walker/Walker.java
@@ -21,12 +21,12 @@ package org.apache.rat.walker;
 
 import org.apache.rat.api.Document;
 import org.apache.rat.document.DocumentName;
-import org.apache.rat.report.IReportable;
+import org.apache.rat.report.Reportable;
 
 /**
  * Abstract walker.
  */
-public abstract class Walker implements IReportable {
+public abstract class Walker implements Reportable {
 
     /** The document this walker is walking */
     private final Document document;
@@ -48,7 +48,7 @@ public abstract class Walker implements IReportable {
     }
 
     @Override
-    public DocumentName getName() {
+    public DocumentName name() {
         return document.getName();
     }
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
@@ -38,7 +38,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.rat.commandline.ArgumentContext;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.license.LicenseSetFactory;
-import org.apache.rat.report.IReportable;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.test.AbstractConfigurationOptionsProvider;
 import org.apache.rat.test.utils.OptionFormatter;
 import org.apache.rat.testhelpers.TestingLog;
@@ -233,9 +233,9 @@ public class OptionCollectionTest {
         DocumentName.FSInfo fsInfo = new DocumentName.FSInfo(testPath.getFileSystem());
         String expected = fsInfo.normalize(base.getAbsolutePath());
         ReportConfiguration config = OptionCollection.parseCommands(testPath.toFile(), new String[]{fName}, o -> fail("Help called"), false);
-        IReportable reportable = OptionCollection.getReportable(base, config);
+        Reportable reportable = OptionCollection.getReportable(base, config);
         assertThat(reportable).as(() -> format("'%s' returned null", fName)).isNotNull();
-        assertThat(reportable.getName().getName()).isEqualTo(expected);
+        assertThat(reportable.name().getName()).isEqualTo(expected);
     }
 
     @Test
@@ -250,7 +250,7 @@ public class OptionCollectionTest {
         reportConfiguration.addExcludedPatterns(List.of(dir2.getName()));
         assertThat(OptionCollection.getReportable(dir2, reportConfiguration)).isNull();
 
-        IReportable reportable = OptionCollection.getReportable(dir1, new ReportConfiguration());
+        Reportable reportable = OptionCollection.getReportable(dir1, new ReportConfiguration());
         assertThat(reportable).isInstanceOf(DirectoryWalker.class);
 
         File file1 = new File(dir1, "file1");

--- a/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReportConfigurationTest.java
@@ -51,7 +51,7 @@ import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.license.LicenseSetFactory.LicenseFilter;
-import org.apache.rat.report.IReportable;
+import org.apache.rat.report.Reportable;
 import org.apache.rat.testhelpers.TestingLog;
 import org.apache.rat.testhelpers.TestingLicense;
 import org.apache.rat.testhelpers.TestingMatcher;
@@ -468,10 +468,10 @@ public class ReportConfigurationTest {
     @Test
     public void reportableTest() {
         assertThat(underTest.hasSource()).isFalse();
-        IReportable reportable = mock(IReportable.class);
+        Reportable reportable = mock(Reportable.class);
         underTest.addSource(reportable);
         assertThat(underTest.hasSource()).isTrue();
-        assertThatThrownBy(() -> underTest.addSource((IReportable)null)).isExactlyInstanceOf(ConfigurationException.class)
+        assertThatThrownBy(() -> underTest.addSource((Reportable)null)).isExactlyInstanceOf(ConfigurationException.class)
                 .hasMessageContaining("Reportable may not be null.");
     }
 
@@ -524,7 +524,7 @@ public class ReportConfigurationTest {
 
         sb.setLength(0);
         msg = "You must specify at least one license";
-        underTest.addSource(mock(IReportable.class));
+        underTest.addSource(mock(Reportable.class));
 
         assertThatThrownBy(() -> underTest.validate(sb::append)).isExactlyInstanceOf(ConfigurationException.class)
                 .hasMessageContaining(msg);

--- a/apache-rat-core/src/test/java/org/apache/rat/walker/ReportableListWalkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/walker/ReportableListWalkerTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   https://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
 package org.apache.rat.walker;
 
 import org.apache.rat.api.RatException;

--- a/apache-rat-core/src/test/java/org/apache/rat/walker/ReportableListWalkerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/walker/ReportableListWalkerTest.java
@@ -1,0 +1,114 @@
+package org.apache.rat.walker;
+
+import org.apache.rat.api.RatException;
+import org.apache.rat.document.DocumentName;
+import org.apache.rat.report.RatReport;
+import org.apache.rat.report.Reportable;
+import org.apache.rat.testhelpers.TestingLog;
+import org.apache.rat.utils.DefaultLog;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReportableListWalkerTest {
+
+    private static DocumentName testName(final TestInfo testInfo) {
+        String testName = testInfo.getTestMethod().isPresent() ? testInfo.getTestMethod().get().getName() : "unknownMethod";
+        String baseName = testInfo.getTestClass().isPresent() ?
+                testInfo.getTestClass().get().getName().replace(".", DocumentName.FSInfo.getDefault().dirSeparator())
+                : "unknownClass";
+        return DocumentName.builder()
+                .setName(testName)
+                .setBaseName(baseName)
+                .build();
+    }
+
+    ReportableListWalker defaultUnderTest(final TestInfo testInfo) throws RatException {
+        return ReportableListWalker.builder(testName(testInfo))
+                .addReportable(new Reportable() {
+                    @Override
+                    public void run(RatReport report) throws RatException {
+                        throw new RatException("Testing exception");
+                    }
+
+                    @Override
+                    public DocumentName name() {
+                        return DocumentName.builder().setName("exceptionThrowingReportable")
+                                .setBaseName(testName(testInfo)).build();
+                    }
+                }).build();
+    }
+    @Test
+    void ratExceptionDuringRun(TestInfo testInfo) throws RatException {
+        TestingLog log = new TestingLog();
+
+        try {
+            DefaultLog.setInstance(log);
+            ReportableListWalker underTest = defaultUnderTest(testInfo);
+            underTest.run(null);
+            assertThat(log.getCaptured()).contains("RatException: Testing exception");
+            log.clear();
+        } finally {
+            DefaultLog.setInstance(null);
+        }
+    }
+
+    @Test
+    void runtimeExceptionDuringRun(TestInfo testInfo) throws RatException {
+        ReportableListWalker underTest = ReportableListWalker.builder(testName(testInfo))
+                .addReportable(new Reportable() {
+                    @Override
+                    public void run(RatReport report)  {
+                        throw new RuntimeException("Runtime exception");
+                    }
+
+                    @Override
+                    public DocumentName name() {
+                        return DocumentName.builder().setName("exceptionThrowingReportable")
+                                .setBaseName(testName(testInfo)).build();
+                    }
+                }).build();
+        assertThatThrownBy(() -> underTest.run(null))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Runtime exception");
+    }
+
+    @Test
+    void documentNameTest(TestInfo testInfo) throws RatException {
+        ReportableListWalker underTest = defaultUnderTest(testInfo);
+        DocumentName actual = underTest.name();
+        assertThat(actual).isEqualTo(testName(testInfo));
+    }
+
+    @Test
+    void resueBuilderFailsTest(TestInfo testInfo) throws RatException {
+        ReportableListWalker.Builder builder = ReportableListWalker.builder(testName(testInfo))
+                .addReportable(new Reportable() {
+                    @Override
+                    public void run(RatReport report) throws RatException {
+                        throw new RatException("Testing exception");
+                    }
+
+                    @Override
+                    public DocumentName name() {
+                        return DocumentName.builder().setName("exceptionThrowingReportable")
+                                .setBaseName(testName(testInfo)).build();
+                    }
+                });
+
+        builder.build();
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(RatException.class)
+                .hasMessageContaining("Builder may only be used once");
+
+    }
+
+    @Test
+    void emptyBuilderDoesNotFail(TestInfo testInfo) {
+        ReportableListWalker.Builder builder = ReportableListWalker.builder(testName(testInfo));
+        assertThatNoException().isThrownBy(builder::build);
+    }
+}

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/ResourceCollectionContainer.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/ResourceCollectionContainer.java
@@ -29,15 +29,15 @@ import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
 
 /**
- * Implementation of IReportable that traverses over a resource collection
+ * Implementation of Reportable that traverses over a resource collection
  * internally.
  */
 class ResourceCollectionContainer implements Reportable {
-    /** The resources as collected by Ant */
+    /** The resources as collected by Ant. */
     private final ResourceCollection resources;
-    /** The report configuration being used for the report */
+    /** The report configuration being used for the report. */
     private final ReportConfiguration configuration;
-    /** The document name */
+    /** The document name. */
     private final DocumentName name;
 
     ResourceCollectionContainer(final DocumentName name, final ReportConfiguration configuration, final ResourceCollection resources) {

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/ResourceCollectionContainer.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/ResourceCollectionContainer.java
@@ -22,8 +22,8 @@ import org.apache.rat.ReportConfiguration;
 import org.apache.rat.api.RatException;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.document.FileDocument;
-import org.apache.rat.report.IReportable;
 import org.apache.rat.report.RatReport;
+import org.apache.rat.report.Reportable;
 import org.apache.tools.ant.types.Resource;
 import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
@@ -32,7 +32,7 @@ import org.apache.tools.ant.types.resources.FileResource;
  * Implementation of IReportable that traverses over a resource collection
  * internally.
  */
-class ResourceCollectionContainer implements IReportable {
+class ResourceCollectionContainer implements Reportable {
     /** The resources as collected by Ant */
     private final ResourceCollection resources;
     /** The report configuration being used for the report */
@@ -59,7 +59,7 @@ class ResourceCollectionContainer implements IReportable {
     }
 
     @Override
-    public DocumentName getName() {
+    public DocumentName name() {
         return name;
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-563" type="add" dev="claudenw">
+        Internal change: rename IReportable and IReportableListWalker to clarify interface structure, when doing RAT scans.
+      </action>
       <action issue="RAT-559" type="fix" dev="claudenw">
         Fix issues with DocumentName and DocumentNameBuilder that address errors in archive handling and Windows as operating system.
       </action>

--- a/src/site/markdown/architecture.md
+++ b/src/site/markdown/architecture.md
@@ -87,10 +87,10 @@ The `out` parameter specifies an `OutputStream` IOSupplier that is used to creat
 
 The `styleSheet` parameter specifies the `InputStream` IOSupplier that is used to read the stylesheet that styles the XML output.
 
-## IReportable
+## Reportable
 
-The `IReportable` parameter identifies the objects that the report should run against.
-Implementations of `IReportable` generally do things like walk directory trees, or archives.
+The `Reportable` parameter identifies the objects that the report should run against.
+Implementations of `Reportable` generally do things like walk directory trees, or archives.
 
 # Reporter
 


### PR DESCRIPTION
Rename IReportable and IReportableListWalker

IReportable is an interface 

IReportableListWalker is a class with a builder.  The name would indicate an interface but that is because it is walking lists of IReportable.

This changes is an internal change that rename IReportable to Reportable and IReportableListWalker with ReportableListWalker