### PR TITLE
RAT-560, RAT-558: Fix XXE warning 

### DIFF
--- a/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
@@ -28,7 +28,6 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
-import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -135,8 +134,7 @@ public class Reporter {
         ClaimStatistic result = execute();
         try (OutputStream out = output.get();
              InputStream styleIn = stylesheet.get()) {
-            Transformer transformer = StandardXmlFactory.createTransformer(styleIn);
-            transformer.transform(new DOMSource(document),
+            StandardXmlFactory.createTransformer(styleIn).transform(new DOMSource(document),
                     new StreamResult(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
             return result;
         } catch (TransformerException | IOException e) {

--- a/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/Reporter.java
@@ -28,13 +28,10 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
-import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.transform.stream.StreamSource;
 
 import org.apache.commons.io.function.IOSupplier;
 import org.apache.rat.api.RatException;
@@ -136,16 +133,9 @@ public class Reporter {
      */
     public ClaimStatistic output(final IOSupplier<InputStream> stylesheet, final IOSupplier<OutputStream> output) throws RatException {
         ClaimStatistic result = execute();
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Transformer transformer;
         try (OutputStream out = output.get();
              InputStream styleIn = stylesheet.get()) {
-            transformer = tf.newTransformer(new StreamSource(styleIn));
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-            transformer.setOutputProperty(OutputKeys.METHOD, "xml");
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+            Transformer transformer = StandardXmlFactory.createTransformer(styleIn);
             transformer.transform(new DOMSource(document),
                     new StreamResult(new OutputStreamWriter(out, StandardCharsets.UTF_8)));
             return result;

--- a/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/report/xml/writer/XmlWriter.java
@@ -356,7 +356,7 @@ public final class XmlWriter implements AutoCloseable {
         appendable.append(System.lineSeparator());
         currentAttributes.clear();
         try {
-            Transformer transformer = StandardXmlFactory.create();
+            Transformer transformer = StandardXmlFactory.createTransformer();
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             transformer.transform(new DOMSource(document),
                     new StreamResult(baos));

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/StandardXmlFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/StandardXmlFactory.java
@@ -52,8 +52,8 @@ public final class StandardXmlFactory {
      * @return the transformer.
      * @throws TransformerConfigurationException on error.
      */
-    public static Transformer create() throws TransformerConfigurationException {
-        return create(null);
+    public static Transformer createTransformer() throws TransformerConfigurationException {
+        return createTransformer(null);
     }
 
     /**
@@ -62,8 +62,8 @@ public final class StandardXmlFactory {
      * @return the transformer.
      * @throws TransformerConfigurationException on error.
      */
-    public static Transformer create(final InputStream styleIn) throws TransformerConfigurationException {
-        TransformerFactory factory = TransformerFactory.newInstance();
+    public static Transformer createTransformer(final InputStream styleIn) throws TransformerConfigurationException {
+        TransformerFactory factory = TransformerFactory.newInstance(); // NOSONAR
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
         factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");

--- a/apache-rat-core/src/test/java/org/apache/rat/utils/StandardXmlFactoryTests.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/utils/StandardXmlFactoryTests.java
@@ -37,12 +37,12 @@ class StandardXmlFactoryTests {
 
     @Test
     void noArg() throws TransformerConfigurationException {
-        assertThat(StandardXmlFactory.create()).isNotNull();
+        assertThat(StandardXmlFactory.createTransformer()).isNotNull();
     }
 
     @Test
     void noEmptyInput() {
-        assertThatThrownBy(() -> StandardXmlFactory.create(InputStream.nullInputStream()))
+        assertThatThrownBy(() -> StandardXmlFactory.createTransformer(InputStream.nullInputStream()))
                 .isInstanceOf(TransformerConfigurationException.class);
     }
 

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdGenerator.java
@@ -72,7 +72,7 @@ public class XsdGenerator {
 
         try (InputStream in = generator.getInputStream();
              InputStream styleIn = StyleSheets.XML.getStyleSheet().get()) {
-            Transformer transformer = StandardXmlFactory.create(styleIn);
+            Transformer transformer = StandardXmlFactory.createTransformer(styleIn);
             transformer.transform(new StreamSource(in),
                     new StreamResult(new OutputStreamWriter(System.out, StandardCharsets.UTF_8)));
         }

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/xsd/XsdGenerator.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
@@ -72,8 +71,7 @@ public class XsdGenerator {
 
         try (InputStream in = generator.getInputStream();
              InputStream styleIn = StyleSheets.XML.getStyleSheet().get()) {
-            Transformer transformer = StandardXmlFactory.createTransformer(styleIn);
-            transformer.transform(new StreamSource(in),
+            StandardXmlFactory.createTransformer(styleIn).transform(new StreamSource(in),
                     new StreamResult(new OutputStreamWriter(System.out, StandardCharsets.UTF_8)));
         }
     }


### PR DESCRIPTION
Fixes XXE warning while processing stylesheets:
https://github.com/apache/creadur-rat/security/code-scanning/2

and changes initialisation to use StandardXmlFactory.java