### PR TITLE
RAT-572: Maven build improvements after dropping JDK8 in RAT 0.18

### DIFF
--- a/apache-rat-plugin/pom.xml
+++ b/apache-rat-plugin/pom.xml
@@ -326,13 +326,13 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${minimalMavenBuildVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${minimalMavenBuildVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -343,19 +343,19 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${minimalMavenBuildVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${minimalMavenBuildVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
+      <version>${minimalMavenBuildVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -461,12 +461,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>${mavenPluginPluginVersion}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-report-plugin</artifactId>
-        <version>${mavenPluginPluginVersion}</version>
       </plugin>
     </plugins>
   </reporting>

--- a/apache-rat-testdata/pom.xml
+++ b/apache-rat-testdata/pom.xml
@@ -24,11 +24,6 @@
   </parent>
   <artifactId>apache-rat-testdata</artifactId>
   <name>Apache Creadur RAT::Testdata</name>
-  <properties>
-    <maven.compiler.source>${javaVersion}</maven.compiler.source>
-    <maven.compiler.target>${javaVersion}</maven.compiler.target>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
   <build>
     <pluginManagement>
       <plugins>

--- a/apache-rat/pom.xml
+++ b/apache-rat/pom.xml
@@ -159,19 +159,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- This subproject has no source code, so we need to skip animal sniffer -->
-            <id>check-java-1.8-compat</id>
-            <configuration>
-              <skip>true</skip>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,27 +45,25 @@ agnostic home for software distribution comprehension and audit tools.
   <properties>
     <sonar.organization>apache</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- taken from https://maven.apache.org/guides/mini/guide-reproducible-builds.html, updated by maven-release-plugin -->
     <project.build.outputTimestamp>2026-03-11T23:25:45Z</project.build.outputTimestamp>
     <ant.version>1.10.17</ant.version>
     <assertj.version>4.0.0-M1</assertj.version>
+    <!-- this is the target Java version that this project supports at runtime -->
     <javaVersion>17</javaVersion>
     <tika.version>3.3.1</tika.version>
     <mockito.version>5.23.0</mockito.version>
-    <maven.compiler.source>${javaVersion}</maven.compiler.source>
-    <maven.compiler.target>${javaVersion}</maven.compiler.target>
     <!-- This is the version of Maven required to use the RAT Maven Plugin -->
     <mavenMinVersion>3.9</mavenMinVersion>
-    <mavenVersion>3.9.16</mavenVersion>
+    <!-- minimal versions to build this projects, enforced in parent POM by enforcer plugin -->
+    <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
+    <minimalMavenBuildVersion>3.9.16</minimalMavenBuildVersion>
     <creadur.jira.id>RAT</creadur.jira.id>
     <velocity.core.version>2.4.1</velocity.core.version>
     <velocity.tools.version>3.1</velocity.tools.version>
     <!-- maven plugin versions -->
     <mavenPluginTestingVersion>3.5.1</mavenPluginTestingVersion>
-    <mavenPluginPluginVersion>3.15.2</mavenPluginPluginVersion>
     <mavenChangesVersion>3.0.0-M3</mavenChangesVersion>
-    <mavenJavadocPluginVersion>3.12.0</mavenJavadocPluginVersion>
     <mavenPmdPluginVersion>3.28.0</mavenPmdPluginVersion>
     <!-- Used to generate download page for RAT during site builds, please adapt versions manually BEFORE doing a release -->
     <!-- START - adapt manually before doing a release -->
@@ -213,9 +211,10 @@ agnostic home for software distribution comprehension and audit tools.
         <scope>test</scope>
       </dependency>
       <dependency>
+        <!-- version defined in parent pom -->
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${mavenPluginPluginVersion}</version>
+        <version>${version.maven-plugin-tools}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -227,7 +226,7 @@ agnostic home for software distribution comprehension and audit tools.
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>${mavenVersion}</version>
+        <version>${minimalMavenBuildVersion}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -376,7 +375,6 @@ agnostic home for software distribution comprehension and audit tools.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${mavenJavadocPluginVersion}</version>
         <configuration>
           <tags>
             <tag>
@@ -435,7 +433,6 @@ agnostic home for software distribution comprehension and audit tools.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.9.0</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -503,39 +500,6 @@ agnostic home for software distribution comprehension and audit tools.
       -->
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.27</version>
-          <executions>
-            <execution>
-              <!-- This checks the source code of our project -->
-              <!--
-                Note that this cannot use our ${javaVersion} property, so it must
-                be changed manually when we decide to move to a higher version of
-                Java
-                RAT-478: Opened https://github.com/mojohaus/animal-sniffer/issues/316 to ask how to proceed here
-              <id>check-java-17-compat</id>
-              <phase>process-classes</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <configuration>
-                <signature>
-                  <groupId>org.codehaus.mojo.signature</groupId>
-                  <artifactId>java18</artifactId>
-                  <version>1.0</version>
-                </signature>
-              </configuration>
-              -->
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.6.0</version>
-        </plugin>
-        <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.10.2.0</version>
@@ -565,7 +529,6 @@ agnostic home for software distribution comprehension and audit tools.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>3.2.0</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.ant</groupId>
@@ -573,31 +536,6 @@ agnostic home for software distribution comprehension and audit tools.
               <version>${ant.version}</version>
             </dependency>
           </dependencies>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.15.0</version>
-          <configuration>
-            <release>${javaVersion}</release>
-            <source>${javaVersion}</source>
-            <target>${javaVersion}</target>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${mavenJavadocPluginVersion}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.11.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-invoker-plugin</artifactId>
-          <version>3.10.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -609,18 +547,7 @@ agnostic home for software distribution comprehension and audit tools.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-plugin</artifactId>
-          <version>${mavenPluginPluginVersion}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-plugin-report-plugin</artifactId>
-          <version>${mavenPluginPluginVersion}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.22.0</version>
           <configuration>
             <!-- RAT-536 keep site generation timestamp instead of release timestamp -->
             <outputTimestamp>x</outputTimestamp>
@@ -650,13 +577,7 @@ agnostic home for software distribution comprehension and audit tools.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>3.3.0</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.3.1</version>
           <configuration>
             <!-- Only prompt once for the release version -->
             <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -666,7 +587,6 @@ agnostic home for software distribution comprehension and audit tools.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.5.0</version>
           <configuration>
             <propertiesEncoding>ISO-8859-1</propertiesEncoding>
             <addDefaultExcludes>false</addDefaultExcludes>
@@ -674,44 +594,11 @@ agnostic home for software distribution comprehension and audit tools.
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.5.6</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.6</version>
           <configuration>
             <forkCount>1</forkCount>
             <!-- RAT-293: We need to append to the existing arguments in order for code coverage to work -->
             <argLine>${argLine} -Dfile.encoding=ISO-8859-1</argLine>
-          </configuration>
-        </plugin>
-        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.rat</groupId>
-                    <artifactId>
-                      apache-rat-plugin
-                    </artifactId>
-                    <versionRange>[0.18,)</versionRange>
-                    <goals>
-                      <goal>check</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore/>
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
           </configuration>
         </plugin>
         <plugin>
@@ -723,11 +610,6 @@ agnostic home for software distribution comprehension and audit tools.
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>3.6.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.jacoco</groupId>
@@ -828,9 +710,6 @@ agnostic home for software distribution comprehension and audit tools.
                 <enforceBytecodeVersion>
                   <maxJdkVersion>${javaVersion}</maxJdkVersion>
                 </enforceBytecodeVersion>
-                <requireMavenVersion>
-                  <version>${mavenMinVersion}</version>
-                </requireMavenVersion>
               </rules>
               <fail>true</fail>
             </configuration>
@@ -859,10 +738,6 @@ agnostic home for software distribution comprehension and audit tools.
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -1060,10 +935,9 @@ agnostic home for software distribution comprehension and audit tools.
   </modules>
   <licenses>
     <license>
-      <name>Apache License, Version 2</name>
+      <name>Apache-2.0</name>
       <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
-      <comments>An OSI approved open source license.</comments>
     </license>
   </licenses>
   <organization>
@@ -1072,18 +946,43 @@ agnostic home for software distribution comprehension and audit tools.
   </organization>
   <profiles>
     <profile>
-      <id>maven.compiler.release</id>
+      <id>only-eclipse</id>
       <activation>
-        <jdk>[9,)</jdk>
+        <property>
+          <name>m2e.version</name>
+        </property>
       </activation>
-      <properties>
-        <!--
-          Note that this cannot use our ${javaVersion} property, so it must
-          be changed manually when we decide to move to a higher version of
-          Java
-        -->
-        <maven.compiler.release>17</maven.compiler.release>
-      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.rat</groupId>
+                        <artifactId>apache-rat-plugin</artifactId>
+                        <versionRange>[0,)</versionRange>
+                        <goals>
+                          <goal>check</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore/>
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <profile>
       <id>apache-release</id>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -68,6 +68,9 @@ in order to be properly linked in site reports.
     </release>
     -->
     <release version="1.0.0-SNAPSHOT" date="xxxx-yy-zz" description="Current SNAPSHOT - release to be done">
+      <action issue="RAT-572" type="add" dev="pottlinger" due-to="Christopher Tubbs">
+        After dropping JDK8 support in r0.18 we rely on ASF parent pom to enforce minimal Maven version 3.9.16 and minimal JDK version 17. Cleanup build and dependency management to rely more on ASF parent pom.
+      </action>
       <action issue="RAT-568" type="add" dev="claudenw">
         Internal change to prepare a better UI testing: create and utilize an IODescriptor that will have a name associated with the current IOSupplier that is in use.
       </action>

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -126,7 +126,7 @@ git clone https://gitbox.apache.org/repos/asf/creadur-rat.git
 
 ** Building RAT
 
- Build RAT with {{{https://maven.apache.org/}Apache Maven}} preferably version ${mavenVersion} or later.
+ Build RAT with {{{https://maven.apache.org/}Apache Maven}} preferably version ${minimalMavenBuildVersion} or later.
 
  RAT requires Java 17, but due to an existing JDK-error ({{{https://issues.apache.org/jira/browse/RAT-497}RAT-497}}) Javadoc cannot be generated with Java 17, use Java 21 instead.
 


### PR DESCRIPTION
RAT-478 updated the Java version to 17 for the minimal build JDK and the target runtime JRE, but left some things in place that are no longer needed. This cleans some of that up.

* Replace `mavenVersion` property with `minimalMavenBuildVersion` property defined in ASF parent POM
* Remove unneeded managed plugin versions and version properties from plugins defined to the same or newer version in the ASF parent POM
* Remove other properties and plugin config that use those properties (like `maven.compiler.*`) when they can be inherited from the parent POM instead
* Remove unused animal-sniffer-maven-plugin (no longer needed with JDK 9 and later)
* Override `minimalJavaBuildVersion` property from ASF parent POM so it can be more easily managed separately from the `javaVersion` (target version) property
* Move Eclipse-specific m2e lifecycle configuration to profile that is activated only in Eclipse, to make it easier to manage separately from actual plugin configuration
* Remove redundant Maven version check from enforcer plugin (already defined in ASF parent POM)
* Fix `<license>` element in the POM to correctly name the Apache license using its SPDX identifier and remove unused generic comment that appears to have been copied from an example configuration
* Remove unneeded maven.compiler.release profile, since it was only needed to support building using JDK8, which is no longer possible