### PR TITLE
RAT-541: Refactor UIOption

### DIFF
--- a/apache-rat-core/pom.xml
+++ b/apache-rat-core/pom.xml
@@ -240,6 +240,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/apache-rat-core/src/main/java/org/apache/rat/CLIOption.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/CLIOption.java
@@ -18,19 +18,21 @@
  */
 package org.apache.rat;
 
+import java.util.function.Function;
+
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.ui.ArgumentTracker;
 import org.apache.rat.ui.UIOption;
-import org.apache.rat.ui.UIOptionCollection;
+import org.apache.rat.utils.CasedString;
 
 /**
  * The CLI option definition.
  */
 public final class CLIOption extends UIOption<CLIOption> {
 
-    public CLIOption(final UIOptionCollection<CLIOption> collection, final Option option) {
-        super(collection, option, ArgumentTracker.extractName(option));
+    private CLIOption(final CLIBuilder builder) {
+        super(builder);
     }
 
     @Override
@@ -69,5 +71,21 @@ public final class CLIOption extends UIOption<CLIOption> {
             }
         }
         return sb.toString();
+    }
+
+    /**
+     * Builder for a CLI Option.
+     */
+    public static class CLIBuilder extends UIOption.Builder<CLIOption, CLIBuilder> {
+
+        @Override
+        protected Function<Option, CasedString> getNameFactory() {
+            return ArgumentTracker::extractName;
+        }
+
+        @Override
+        protected CLIOption doBuild() {
+            return new CLIOption(this);
+        }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/CLIOptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/CLIOptionCollection.java
@@ -21,20 +21,23 @@ package org.apache.rat;
 import org.apache.commons.cli.Option;
 import org.apache.rat.ui.UIOptionCollection;
 
+/**
+ * The collection of CLI Options.
+ */
 public final class CLIOptionCollection extends UIOptionCollection<CLIOption> {
     /** The Help option */
     static final Option HELP = new Option("?", "help", false, "Print help for the RAT command line interface and exit.");
 
-    /** The instance of the collection */
-    public static final CLIOptionCollection INSTANCE = new CLIOptionCollection();
-
-    private CLIOptionCollection() {
+    /**
+     * Constructs the CLIOption collection.
+     */
+    public CLIOptionCollection() {
         super(new Builder().uiOption(HELP));
     }
 
     private static final class Builder extends UIOptionCollection.Builder<CLIOption, Builder> {
         private Builder() {
-            super(CLIOption::new);
+            super(CLIOption.CLIBuilder::new);
         }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -51,6 +51,8 @@ import org.apache.rat.help.Licenses;
 import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.report.Reportable;
 import org.apache.rat.report.claim.ClaimStatistic;
+import org.apache.rat.ui.ArgumentTracker;
+import org.apache.rat.ui.UIOptionCollection;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
 import org.apache.rat.walker.ArchiveWalker;
@@ -67,6 +69,11 @@ public final class OptionCollection {
     private OptionCollection() {
         // do not instantiate
     }
+
+    /**
+     * The collection of UI Options.
+     */
+    private static UIOptionCollection baseOptionCollection = new CLIOptionCollection();
 
     /**
      * The Option comparator to sort the help.
@@ -122,8 +129,8 @@ public final class OptionCollection {
      * Parses the standard options to create a ReportConfiguration.
      * <p>
      * This method is {@code synchronized} because it uses shared mutable state:
-     * the {@link Arg} enum's {@code OptionGroup} instances (whose {@code selected}
-     * field is mutated by {@link DefaultParser#parse}), and
+     * the {@link #baseOptionCollection}'s {@code OptionGroup} instances (whose {@code selected}
+     * field is mutated by {@link DefaultParser#parse(Options, String[])}), and
      * {@link org.apache.rat.commandline.Converters#FILE_CONVERTER} (whose
      * {@code workingDirectory} field is set during argument processing).
      * Without synchronization, parallel Maven reactor threads (e.g. {@code mvn -T4})
@@ -140,29 +147,23 @@ public final class OptionCollection {
      */
     public static synchronized ReportConfiguration parseCommands(final File workingDirectory, final String[] args,
                                                     final Consumer<Options> helpCmd, final boolean noArgs) throws IOException {
-
         Options opts = buildOptions();
-        CommandLine commandLine;
+        ArgumentContext argumentContext;
         try {
-            commandLine = DefaultParser.builder().setDeprecatedHandler(DeprecationReporter.getLogReporter())
-                    .setAllowPartialMatching(true).build().parse(opts, args);
+            argumentContext = new ArgumentContext(workingDirectory, opts, args);
         } catch (ParseException e) {
-            DefaultLog.getInstance().error(e.getMessage());
-            DefaultLog.getInstance().error("Please use the \"--help\" option to see a list of valid commands and options.", e);
             System.exit(1);
             return null; // dummy return (won't be reached) to avoid Eclipse complaint about possible NPE
             // for "commandLine"
         }
+        Arg.processLogLevel(argumentContext, baseOptionCollection);
 
-        ArgumentContext argumentContext = new ArgumentContext(workingDirectory, commandLine);
-        Arg.processLogLevel(argumentContext, CLIOptionCollection.INSTANCE);
-
-        if (commandLine.hasOption(HELP)) {
+        if (argumentContext.getCommandLine().hasOption(HELP)) {
             helpCmd.accept(opts);
             return null;
         }
 
-        if (commandLine.hasOption(Arg.HELP_LICENSES.option())) {
+        if (argumentContext.getCommandLine().hasOption(Arg.HELP_LICENSES.option())) {
             new Licenses(createConfiguration(argumentContext), new PrintWriter(System.out, false, StandardCharsets.UTF_8)).printHelp();
             return null;
         }
@@ -188,25 +189,38 @@ public final class OptionCollection {
      * @see #parseCommands(File, String[], Consumer, boolean)
      */
     public static ReportConfiguration createConfiguration(final ArgumentContext argumentContext) {
-        argumentContext.processArgs(CLIOptionCollection.INSTANCE);
-        final ReportConfiguration configuration = argumentContext.getConfiguration();
-        final CommandLine commandLine = argumentContext.getCommandLine();
-        Optional<Option> dirOpt = CLIOptionCollection.INSTANCE.getSelected(Arg.DIR);
-        if (dirOpt.isPresent()) {
-            try {
-                configuration.addSource(getReportable(commandLine.getParsedOptionValue(
-                        dirOpt.get()), configuration));
-            } catch (ParseException e) {
-                throw new ConfigurationException("Unable to set parse " + dirOpt.get(), e);
+        try {
+            argumentContext.processArgs(baseOptionCollection);
+            final ReportConfiguration configuration = argumentContext.getConfiguration();
+            final CommandLine commandLine = argumentContext.getCommandLine();
+            Optional<Option> dirOpt = baseOptionCollection.getSelected(Arg.DIR);
+            dirOpt.ifPresent(opt -> {
+                try {
+                    File directoryName = commandLine.getParsedOptionValue(opt);
+                    configuration.addSource(getReportable(directoryName, configuration));
+                } catch (ParseException e) {
+                    throw new ConfigurationException("Unable to set parse " + dirOpt.get(), e);
+                }
+            });
+            for (String s : commandLine.getArgs()) {
+                Reportable reportable = getReportable(new File(s), configuration);
+                if (reportable != null) {
+                    configuration.addSource(reportable);
+                }
             }
-        }
-        for (String s : commandLine.getArgs()) {
-            Reportable reportable = getReportable(new File(s), configuration);
-            if (reportable != null) {
-                configuration.addSource(reportable);
+            return configuration;
+        } catch (RuntimeException e) {
+            try (PrintWriter pw = new PrintWriter(DefaultLog.getInstance().asWriter(Level.ERROR))) {
+                pw.println("Unable to create Configuration: " + e.getMessage());
+                pw.println("=== Command line options ===");
+                for (Option opt : argumentContext.getCommandLine().getOptions()) {
+                    String[] values = opt.getValues();
+                    pw.printf("   %s: %s%n", ArgumentTracker.extractKey(opt), values == null ? "" : String.join(", ", values));
+                }
             }
+            throw new ConfigurationException("Unable to create Configuration", e);
         }
-        return configuration;
+
     }
 
     /**
@@ -215,7 +229,8 @@ public final class OptionCollection {
      * @return the Options comprised of the Options defined in this class.
      */
     public static Options buildOptions() {
-        return CLIOptionCollection.INSTANCE.getOptions();
+        baseOptionCollection.resetSelected();
+        return baseOptionCollection.getOptions();
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -73,7 +73,7 @@ public final class OptionCollection {
     /**
      * The collection of UI Options.
      */
-    private static UIOptionCollection baseOptionCollection = new CLIOptionCollection();
+    private static final UIOptionCollection BASE_OPTION_COLLECTION = new CLIOptionCollection();
 
     /**
      * The Option comparator to sort the help.
@@ -129,7 +129,7 @@ public final class OptionCollection {
      * Parses the standard options to create a ReportConfiguration.
      * <p>
      * This method is {@code synchronized} because it uses shared mutable state:
-     * the {@link #baseOptionCollection}'s {@code OptionGroup} instances (whose {@code selected}
+     * the {@link #BASE_OPTION_COLLECTION}'s {@code OptionGroup} instances (whose {@code selected}
      * field is mutated by {@link DefaultParser#parse(Options, String[])}), and
      * {@link org.apache.rat.commandline.Converters#FILE_CONVERTER} (whose
      * {@code workingDirectory} field is set during argument processing).
@@ -156,7 +156,7 @@ public final class OptionCollection {
             return null; // dummy return (won't be reached) to avoid Eclipse complaint about possible NPE
             // for "commandLine"
         }
-        Arg.processLogLevel(argumentContext, baseOptionCollection);
+        Arg.processLogLevel(argumentContext, BASE_OPTION_COLLECTION);
 
         if (argumentContext.getCommandLine().hasOption(HELP)) {
             helpCmd.accept(opts);
@@ -181,8 +181,8 @@ public final class OptionCollection {
 
     /**
      * Create the report configuration.
-     * Note: this method is package private for testing.
-     * You probably want one of the {@code ParseCommands} methods.
+     * Note: this method is visible for testing.
+     * You probably want one of the {@code parseCommands(...)} methods instead.
      * @param argumentContext The context to execute in.
      * @return a ReportConfiguration
      * @see #parseCommands(File, String[], Consumer)
@@ -190,10 +190,10 @@ public final class OptionCollection {
      */
     public static ReportConfiguration createConfiguration(final ArgumentContext argumentContext) {
         try {
-            argumentContext.processArgs(baseOptionCollection);
+            argumentContext.processArgs(BASE_OPTION_COLLECTION);
             final ReportConfiguration configuration = argumentContext.getConfiguration();
             final CommandLine commandLine = argumentContext.getCommandLine();
-            Optional<Option> dirOpt = baseOptionCollection.getSelected(Arg.DIR);
+            Optional<Option> dirOpt = BASE_OPTION_COLLECTION.getSelected(Arg.DIR);
             dirOpt.ifPresent(opt -> {
                 try {
                     File directoryName = commandLine.getParsedOptionValue(opt);
@@ -211,14 +211,14 @@ public final class OptionCollection {
             return configuration;
         } catch (RuntimeException e) {
             try (PrintWriter pw = new PrintWriter(DefaultLog.getInstance().asWriter(Level.ERROR))) {
-                pw.println("Unable to create Configuration: " + e.getMessage());
+                pw.println("Unable to create configuration: " + e.getMessage());
                 pw.println("=== Command line options ===");
                 for (Option opt : argumentContext.getCommandLine().getOptions()) {
                     String[] values = opt.getValues();
                     pw.printf("   %s: %s%n", ArgumentTracker.extractKey(opt), values == null ? "" : String.join(", ", values));
                 }
             }
-            throw new ConfigurationException("Unable to create Configuration", e);
+            throw new ConfigurationException("Unable to create configuration", e);
         }
 
     }
@@ -229,8 +229,8 @@ public final class OptionCollection {
      * @return the Options comprised of the Options defined in this class.
      */
     public static Options buildOptions() {
-        baseOptionCollection.resetSelected();
-        return baseOptionCollection.getOptions();
+        BASE_OPTION_COLLECTION.resetSelected();
+        return BASE_OPTION_COLLECTION.getOptions();
     }
 
     /**
@@ -312,7 +312,7 @@ public final class OptionCollection {
         EXPRESSION("Expression", () -> "A file matching pattern usually of the form used in Ant build files and " +
                 "'.gitignore' files (see https://ant.apache.org/manual/dirtasks.html#patterns for examples). " +
                 "Regular expression patterns may be specified by surrounding the pattern with '%regex[' and ']'. " +
-                "For example '%regex[[A-Z].*]' would match files and directories that start with uppercase latin letters."),
+                "For example '%regex[[A-Z].*]' would match files and directories that start with uppercase Latin letters."),
         /**
          * A license filter.
          */

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollection.java
@@ -52,6 +52,7 @@ import org.apache.rat.license.LicenseSetFactory;
 import org.apache.rat.report.Reportable;
 import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.ui.ArgumentTracker;
+import org.apache.rat.ui.UIOption;
 import org.apache.rat.ui.UIOptionCollection;
 import org.apache.rat.utils.DefaultLog;
 import org.apache.rat.utils.Log.Level;
@@ -73,7 +74,7 @@ public final class OptionCollection {
     /**
      * The collection of UI Options.
      */
-    private static final UIOptionCollection BASE_OPTION_COLLECTION = new CLIOptionCollection();
+    private static final UIOptionCollection<? extends UIOption<?>> BASE_OPTION_COLLECTION = new CLIOptionCollection();
 
     /**
      * The Option comparator to sort the help.

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
@@ -32,10 +32,12 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.rat.api.RatException;
 import org.apache.rat.commandline.Arg;
 import org.apache.rat.commandline.ArgumentContext;
 import org.apache.rat.help.Licenses;
 import org.apache.rat.report.Reportable;
+import org.apache.rat.ui.UIOption;
 import org.apache.rat.ui.UIOptionCollection;
 import org.apache.rat.utils.DefaultLog;
 
@@ -44,15 +46,21 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * Uses the AbstractOptionCollection to parse the command line options.
  * Contains utility methods to ReportConfiguration from the options and an array of arguments.
+ *
+ * @param <T> The UIOption type that this parser is handeling.
  */
 @SuppressFBWarnings("EI_EXPOSE_REP2")
-public final class OptionCollectionParser {
+public final class OptionCollectionParser<T extends UIOption<T>> {
     /**
      * The OptionCollection that we are working with.
      */
-    private final UIOptionCollection<?> uiOptionCollection;
+    private final UIOptionCollection<T> uiOptionCollection;
 
-    public OptionCollectionParser(final UIOptionCollection<?> optionCollection) {
+    /**
+     * Constructor.
+     * @param optionCollection  The option collection to use for
+     */
+    public OptionCollectionParser(final UIOptionCollection<T> optionCollection) {
         this.uiOptionCollection = optionCollection;
     }
 
@@ -62,11 +70,10 @@ public final class OptionCollectionParser {
      * @param workingDirectory The directory to resolve relative file names against.
      * @param args the arguments to parse
      * @return the ArgumentContext for the process.
-     * @throws IOException on error.
-     * @throws ParseException on option parsing error.
+     * @throws RatException on error.
      */
     public ArgumentContext parseCommands(final File workingDirectory, final String[] args)
-            throws IOException, ParseException {
+            throws RatException {
         return parseCommands(workingDirectory, args, uiOptionCollection.getOptions());
     }
 
@@ -77,8 +84,7 @@ public final class OptionCollectionParser {
      * @return the CommandLine
      * @throws ParseException on option parsing error.
      */
-    //@VisibleForTesting
-    CommandLine parseCommandLine(final Options opts, final String[] args) throws ParseException {
+    public static CommandLine parseCommandLine(final Options opts, final String[] args) throws ParseException {
         try {
             return DefaultParser.builder().setDeprecatedHandler(DeprecationReporter.getLogReporter())
                     .setAllowPartialMatching(true).build().parse(opts, args);
@@ -89,6 +95,16 @@ public final class OptionCollectionParser {
         }
     }
 
+    // visible for testing
+    void printHelp(final ArgumentContext argumentContext) throws RatException {
+        try {
+            new Licenses(argumentContext.getConfiguration(),
+                    new PrintWriter(argumentContext.getConfiguration().getOutput().get(),
+                            false, StandardCharsets.UTF_8)).printHelp();
+        } catch (IOException e) {
+            throw new RatException("Unable to print help: " + e.getMessage(), e);
+        }
+    }
     /**
      * Parses the standard options to create a ReportConfiguration.
      *
@@ -96,22 +112,22 @@ public final class OptionCollectionParser {
      * @param args the arguments to parse.
      * @param options An Options object containing Apache command line options.
      * @return the ArgumentContext for the process.
-     * @throws IOException on error.
-     * @throws ParseException on option parsing error.
+     * @throws RatException on error.
      */
-    private ArgumentContext parseCommands(final File workingDirectory, final String[] args,
-                                                                       final Options options) throws IOException, ParseException {
-        CommandLine commandLine = parseCommandLine(options, args);
-        ArgumentContext argumentContext = new ArgumentContext(workingDirectory, commandLine);
-        Arg.processLogLevel(argumentContext, uiOptionCollection);
-        populateConfiguration(argumentContext);
-        if (uiOptionCollection.isSelected(Arg.HELP_LICENSES)) {
-            new Licenses(argumentContext.getConfiguration(),
-                    new PrintWriter(argumentContext.getConfiguration().getOutput().get(),
-                            false, StandardCharsets.UTF_8)).printHelp();
+    // visible for testing
+    ArgumentContext parseCommands(final File workingDirectory, final String[] args,
+                                                                       final Options options) throws RatException {
+        try {
+            ArgumentContext argumentContext = new ArgumentContext(workingDirectory, options, args);
+            Arg.processLogLevel(argumentContext, uiOptionCollection);
+            populateConfiguration(argumentContext);
+            if (uiOptionCollection.isSelected(Arg.HELP_LICENSES)) {
+                printHelp(argumentContext);
+            }
+            return argumentContext;
+        } catch (ParseException e) {
+            throw new RatException("Unable to parse command line: " + e.getMessage(), e);
         }
-
-        return argumentContext;
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
@@ -21,17 +21,12 @@ package org.apache.rat;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.io.Serial;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.Comparator;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.api.RatException;
 import org.apache.rat.commandline.Arg;
 import org.apache.rat.commandline.ArgumentContext;
@@ -151,33 +146,5 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
             }
         }
         return configuration;
-    }
-
-    /**
-     * This class implements the {@code Comparator} interface for comparing options.
-     */
-    private static final class OptionComparator implements Comparator<Option>, Serializable {
-        /** The serial version UID.  */
-        @Serial
-        private static final long serialVersionUID = 5305467873966684014L;
-
-        private String getKey(final Option opt) {
-            return StringUtils.defaultIfBlank(opt.getOpt(), opt.getLongOpt());
-        }
-
-        /**
-         * Compares its two arguments for order. Returns a negative integer, zero, or a
-         * positive integer as the first argument is less than, equal to, or greater
-         * than the second.
-         *
-         * @param opt1 the first Option to be compared.
-         * @param opt2 the second Option to be compared.
-         * @return a negative integer, zero, or a positive integer as the first argument
-         * is less than, equal to, or greater than the second.
-         */
-        @Override
-        public int compare(final Option opt1, final Option opt2) {
-            return getKey(opt1).compareToIgnoreCase(getKey(opt2));
-        }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/OptionCollectionParser.java
@@ -47,7 +47,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * Uses the AbstractOptionCollection to parse the command line options.
  * Contains utility methods to ReportConfiguration from the options and an array of arguments.
  *
- * @param <T> The UIOption type that this parser is handeling.
+ * @param <T> The UIOption type that this parser is handling.
  */
 @SuppressFBWarnings("EI_EXPOSE_REP2")
 public final class OptionCollectionParser<T extends UIOption<T>> {
@@ -58,7 +58,7 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
 
     /**
      * Constructor.
-     * @param optionCollection  The option collection to use for
+     * @param optionCollection the option collection to use for.
      */
     public OptionCollectionParser(final UIOptionCollection<T> optionCollection) {
         this.uiOptionCollection = optionCollection;
@@ -67,8 +67,8 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
     /**
      * Parses the standard options to create a ReportConfiguration.
      *
-     * @param workingDirectory The directory to resolve relative file names against.
-     * @param args the arguments to parse
+     * @param workingDirectory the directory to resolve relative file names against.
+     * @param args the arguments to parse.
      * @return the ArgumentContext for the process.
      * @throws RatException on error.
      */
@@ -105,12 +105,13 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
             throw new RatException("Unable to print help: " + e.getMessage(), e);
         }
     }
+
     /**
      * Parses the standard options to create a ReportConfiguration.
      *
      * @param workingDirectory The directory to resolve relative file names against.
      * @param args the arguments to parse.
-     * @param options An Options object containing Apache command line options.
+     * @param options an Options object containing Apache command line options.
      * @return the ArgumentContext for the process.
      * @throws RatException on error.
      */
@@ -133,7 +134,7 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
     /**
      * Create the report configuration.
      * Note: this method is package private for testing.
-     * You probably want one of the {@code ParseCommands} methods.
+     * You probably want one of the {@code parseCommands(..)} methods.
      * @param argumentContext The context to execute in.
      * @return a ReportConfiguration
      */
@@ -153,7 +154,7 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
     }
 
     /**
-     * This class implements the {@code Comparator} interface for comparing Options.
+     * This class implements the {@code Comparator} interface for comparing options.
      */
     private static final class OptionComparator implements Comparator<Option>, Serializable {
         /** The serial version UID.  */
@@ -169,8 +170,8 @@ public final class OptionCollectionParser<T extends UIOption<T>> {
          * positive integer as the first argument is less than, equal to, or greater
          * than the second.
          *
-         * @param opt1 The first Option to be compared.
-         * @param opt2 The second Option to be compared.
+         * @param opt1 the first Option to be compared.
+         * @param opt2 the second Option to be compared.
          * @return a negative integer, zero, or a positive integer as the first argument
          * is less than, equal to, or greater than the second.
          */

--- a/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SPDXMatcherFactory.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/analysis/matchers/SPDXMatcherFactory.java
@@ -62,7 +62,7 @@ public final class SPDXMatcherFactory {
      * @deprecated Not thread-safe. Use {@link #newInstance()} to create
      * per-thread instances instead. Will be removed in 1.0.0.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static final SPDXMatcherFactory INSTANCE = new SPDXMatcherFactory();
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -977,8 +977,8 @@ public enum Arg {
         try {
             Class<? extends T> clazz = (Class<? extends T>) selected.getType();
             String[] values = commandLine.getOptionValues(selected);
-            T[] result = (T[]) Array.newInstance(clazz, values.length);
-            for (int i = 0; i < values.length; i++) {
+            T[] result = (T[]) Array.newInstance(clazz, values == null ? 0 : values.length);
+            for (int i = 0; i < result.length; i++) {
                 result[i] = clazz.cast(selected.getConverter().apply(values[i]));
             }
             return result;

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/Arg.java
@@ -977,7 +977,12 @@ public enum Arg {
         try {
             Class<? extends T> clazz = (Class<? extends T>) selected.getType();
             String[] values = commandLine.getOptionValues(selected);
-            T[] result = (T[]) Array.newInstance(clazz, values == null ? 0 : values.length);
+            if (values == null) {
+                // this should not happen since w should only get into this method when an option is selected and has already passed
+                // the "it has data" check.
+                throw new ConfigurationException(format("'%s' command line option did not have any values", selected));
+            }
+            T[] result = (T[]) Array.newInstance(clazz, values.length);
             for (int i = 0; i < result.length; i++) {
                 result[i] = clazz.cast(selected.getConverter().apply(values[i]));
             }

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
@@ -20,9 +20,13 @@ package org.apache.rat.commandline;
 
 import java.io.File;
 
+import org.apache.commons.cli.AlreadySelectedException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.OptionGroup;
+import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.rat.OptionCollectionParser;
 import org.apache.rat.ReportConfiguration;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.ui.UIOptionCollection;
@@ -46,28 +50,51 @@ public final class ArgumentContext {
      * Creates a context with the specified configuration.
      * @param workingDirectory the directory from which relative file names will be resolved.
      * @param configuration The configuration that is being built.
-     * @param commandLine The command line that is building the configuration.
+     * @param opts the Options for the command line.
+     * @param args the arguments for the options.
+     * @throws ParseException if the options can not parse the arguments.
      */
-    public ArgumentContext(final File workingDirectory, final ReportConfiguration configuration, final CommandLine commandLine) {
+    public ArgumentContext(final File workingDirectory, final ReportConfiguration configuration, final Options opts, final String[] args)
+            throws ParseException {
         this.workingDirectory = DocumentName.builder(workingDirectory).build();
-        this.commandLine = commandLine;
+        this.commandLine = OptionCollectionParser.parseCommandLine(clearSelected(opts), args);
         this.configuration = configuration;
     }
 
     /**
      * Creates a context with an empty configuration.
      * @param workingDirectory The directory from which to resolve relative file names.
-     * @param commandLine The command line.
+     * @param opts the Options for the command line.
+     * @param args the arguments for the options.
+     * @throws ParseException if the options can not parse the arguments.
      */
-    public ArgumentContext(final File workingDirectory, final CommandLine commandLine) {
-        this(workingDirectory, new ReportConfiguration(), commandLine);
+    public ArgumentContext(final File workingDirectory, final Options opts, final String[] args) throws ParseException {
+        this(workingDirectory, new ReportConfiguration(), opts, args);
     }
 
+    /**
+     * Clears the group selections in the options.
+     * @param options the options to clear.
+     * @return the options with all selections cleared.
+     */
+    private static Options clearSelected(final Options options) {
+        for (Option opt : options.getOptions()) {
+            OptionGroup group = options.getOptionGroup(opt);
+            if (group != null) {
+                try {
+                    group.setSelected(null);
+                } catch (AlreadySelectedException e) {
+                    throw new RuntimeException("Unexpected error with null argument", e);
+                }
+            }
+        }
+        return options;
+    }
     /**
      * Process the arguments specified in this context.
      */
     public void processArgs(final UIOptionCollection<?> uiOptionCollection) {
-        Arg.processArgs(this,  uiOptionCollection);
+        Arg.processArgs(this, uiOptionCollection);
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/commandline/ArgumentContext.java
@@ -49,7 +49,7 @@ public final class ArgumentContext {
     /**
      * Creates a context with the specified configuration.
      * @param workingDirectory the directory from which relative file names will be resolved.
-     * @param configuration The configuration that is being built.
+     * @param configuration the configuration that is being built.
      * @param opts the Options for the command line.
      * @param args the arguments for the options.
      * @throws ParseException if the options can not parse the arguments.
@@ -63,7 +63,7 @@ public final class ArgumentContext {
 
     /**
      * Creates a context with an empty configuration.
-     * @param workingDirectory The directory from which to resolve relative file names.
+     * @param workingDirectory the directory from which to resolve relative file names.
      * @param opts the Options for the command line.
      * @param args the arguments for the options.
      * @throws ParseException if the options can not parse the arguments.
@@ -90,6 +90,7 @@ public final class ArgumentContext {
         }
         return options;
     }
+
     /**
      * Process the arguments specified in this context.
      */
@@ -99,7 +100,7 @@ public final class ArgumentContext {
 
     /**
      * Gets the configuration.
-     * @return The configuration that is being built.
+     * @return the configuration that is being built.
      */
     public ReportConfiguration getConfiguration() {
         return configuration;
@@ -107,7 +108,7 @@ public final class ArgumentContext {
 
     /**
      * Gets the command line.
-     * @return The command line that is driving the configuration.
+     * @return the command line that is driving the configuration.
      */
     public CommandLine getCommandLine() {
         return commandLine;
@@ -115,7 +116,7 @@ public final class ArgumentContext {
 
     /**
      * Gets the directory name from which relative file names will be resolved.
-     * @return The directory name from which relative file names will be resolved.
+     * @return the directory name from which relative file names will be resolved.
      */
     public DocumentName getWorkingDirectory() {
         return workingDirectory;
@@ -123,8 +124,8 @@ public final class ArgumentContext {
 
     /**
      * Logs a ParseException as a warning.
-     * @param exception the parse exception to log
-     * @param opt the option being processed
+     * @param exception the parse exception to log.
+     * @param opt the option being processed.
      * @param defaultValue The default value the option is being set to.
      */
     public void logParseException(final ParseException exception, final Option opt, final Object defaultValue) {

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/StandardCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/StandardCollection.java
@@ -29,11 +29,11 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.apache.rat.config.exclusion.fileProcessors.AbstractFileProcessorBuilder;
-import org.apache.rat.config.exclusion.fileProcessors.BazaarIgnoreBuilder;
-import org.apache.rat.config.exclusion.fileProcessors.CVSIgnoreBuilder;
-import org.apache.rat.config.exclusion.fileProcessors.GitIgnoreBuilder;
-import org.apache.rat.config.exclusion.fileProcessors.HgIgnoreBuilder;
+import org.apache.rat.config.exclusion.fileprocessors.AbstractFileProcessorBuilder;
+import org.apache.rat.config.exclusion.fileprocessors.BazaarIgnoreBuilder;
+import org.apache.rat.config.exclusion.fileprocessors.CVSIgnoreBuilder;
+import org.apache.rat.config.exclusion.fileprocessors.GitIgnoreBuilder;
+import org.apache.rat.config.exclusion.fileprocessors.HgIgnoreBuilder;
 import org.apache.rat.document.DocumentName;
 import org.apache.rat.document.DocumentNameMatcher;
 import org.apache.rat.utils.ExtendedIterator;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/AbstractFileProcessorBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/AbstractFileProcessorBuilder.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/BazaarIgnoreBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/BazaarIgnoreBuilder.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.util.Optional;
 import java.util.function.Consumer;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/CVSIgnoreBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/CVSIgnoreBuilder.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.io.File;
 import java.util.HashSet;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/GitIgnoreBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/GitIgnoreBuilder.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/HgIgnoreBuilder.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/HgIgnoreBuilder.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.util.Locale;
 import java.util.Optional;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/package-info.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/exclusion/fileprocessors/package-info.java
@@ -19,4 +19,4 @@
 /**
  * Custom file processors to handles exclusions defined in various formats.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;

--- a/apache-rat-core/src/main/java/org/apache/rat/config/results/ClaimValidator.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/config/results/ClaimValidator.java
@@ -147,8 +147,7 @@ public final class ClaimValidator {
         min.compute(counter, (k, v) ->
             v == null ? new MutableInt(value) : newValue(v, value));
         max.compute(counter, (k, v) ->
-                v == null ? setMaxValue(new MutableInt(k.getDefaultMaxValue()), value) :
-                setMaxValue(v, value));
+                setMaxValue(v == null ? new MutableInt(k.getDefaultMaxValue()) : v, value));
     }
 
     /**

--- a/apache-rat-core/src/main/java/org/apache/rat/help/AbstractHelp.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/help/AbstractHelp.java
@@ -160,7 +160,7 @@ public abstract class AbstractHelp {
                 if (option.hasArg()) {
                     final String argName = option.getArgName();
                     if (argName != null && argName.isEmpty()) {
-                        // if the option has a blank argname
+                        // if the option has a blank argName
                         optBuf.append(' ');
                     } else {
                         optBuf.append(option.hasLongOpt() ? helpFormatter.getLongOptSeparator() : " ");

--- a/apache-rat-core/src/main/java/org/apache/rat/help/AbstractHelp.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/help/AbstractHelp.java
@@ -55,6 +55,11 @@ public abstract class AbstractHelp {
     protected final VersionInfo versionInfo;
 
     /**
+     * The collection of client options.
+     */
+    protected final CLIOptionCollection cliOptionCollection = new CLIOptionCollection();
+
+    /**
      * Base class to perform help output.
      */
     protected AbstractHelp() {
@@ -185,7 +190,7 @@ public abstract class AbstractHelp {
                     optBuf.append(END_OF_OPTION_MSG);
                 }
                 // check for default value
-                String defaultValue = CLIOptionCollection.INSTANCE.defaultValue(option);
+                String defaultValue = cliOptionCollection.defaultValue(option);
                 if (defaultValue != null) {
                     optBuf.append(format(" (Default value = %s)", defaultValue));
                 }

--- a/apache-rat-core/src/main/java/org/apache/rat/help/Help.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/help/Help.java
@@ -22,7 +22,6 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.cli.Options;
@@ -39,12 +38,11 @@ public class Help extends AbstractHelp {
     /**
      * An array of notes to go at the bottom of the help output
      */
-    protected static final List<String> NOTES = Collections.unmodifiableList(List.of(
+    protected static final List<String> NOTES = List.of(
             "RAT highlights possible issues.",
             "RAT reports require interpretation.",
             "RAT often requires some tuning before it runs well against a project.",
-            "RAT relies on heuristics: it may miss issues")
-    );
+            "RAT relies on heuristics: it may miss issues");
 
     /** The writer this instance writes to */
     protected final PrintWriter writer;

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UIOption.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UIOption.java
@@ -21,7 +21,9 @@ package org.apache.rat.ui;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -38,27 +40,37 @@ import static java.lang.String.format;
  * @param <T> the concrete implementation of AbstractOption.
  */
 public abstract class UIOption<T extends UIOption<T>> {
-    /** The pattern to match CLI options in text */
+    /**
+     * The pattern to match CLI options in text
+     */
     protected static final Pattern PATTERN = Pattern.compile("-?-([A-Za-z0-9]+-?)+"); // NOSONAR
-    /** The actual UI-specific name for the option */
+    /**
+     * The actual UI-specific name for the option
+     */
     protected final Option option;
-    /** The name for the option */
+    /**
+     * The name for the option
+     */
     protected final CasedString name;
-    /** The argument type for this option */
+    /**
+     * The argument type for this option
+     */
     protected final OptionCollection.ArgumentType argumentType;
-    /** The AbstractOptionCollection associated with this AbstractOption */
+    /**
+     * The AbstractOptionCollection associated with this AbstractOption
+     */
     protected final UIOptionCollection<T> optionCollection;
 
     /**
      * Constructor.
      *
-     * @param option The CLI option
-     * @param name the UI-specific name for the option
+     * @param builder UIOption builder.
      */
-    protected <C extends UIOptionCollection<T>> UIOption(final C optionCollection, final Option option, final CasedString name) {
-        this.optionCollection = optionCollection;
-        this.option = option;
-        this.name = name;
+    protected UIOption(final Builder<T, ?> builder) {
+        this.optionCollection = builder.optionCollection;
+        this.option = builder.option;
+        this.name = builder.name;
+
         OptionCollection.ArgumentType argType;
         if (option.hasArg()) {
             if (option.getArgName() == null) {
@@ -77,9 +89,24 @@ public abstract class UIOption<T extends UIOption<T>> {
         this.argumentType = argType;
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UIOption<?> uiOption = (UIOption<?>) o;
+        return getOption().equals(uiOption.getOption()) && name.equals(uiOption.name) && argumentType == uiOption.argumentType;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
     /**
      * Gets the AbstractOptionCollection that this option is a member of.
      * @return the AbstractOptionCollection that this option is a member of.
+     * @param <X> The collection type to return.
      */
     public final <X extends UIOptionCollection<T>> X getOptionCollection() {
         return (X) optionCollection;
@@ -240,6 +267,108 @@ public abstract class UIOption<T extends UIOption<T>> {
      * @return the deprecated string if the option is deprecated, or an empty string otherwise.
      */
     public final String getDeprecated() {
-        return  option.isDeprecated() ? cleanup(StringUtils.defaultIfEmpty(option.getDeprecated().toString(), StringUtils.EMPTY)) : StringUtils.EMPTY;
+        return option.isDeprecated() ? cleanup(StringUtils.defaultIfEmpty(option.getDeprecated().toString(), StringUtils.EMPTY)) : StringUtils.EMPTY;
+    }
+
+    /**
+     * The abstract UIOption Builder.
+     * @param <T> the concrete type of the UIOption this builder produces.
+     * @param <B> the concrete type of this builder.
+     */
+    public abstract static class Builder<T extends UIOption<T>, B extends Builder<T, B>> {
+        /**
+         * The collection to add the new UI Option to.
+         */
+        private UIOptionCollection<T> optionCollection;
+        /**
+         * THe base option that is being mapped.
+         */
+        private Option option;
+        /**
+         * The UI name of this option.
+         */
+        private CasedString name = CasedString.NULL;
+        /**
+         * Constructor.
+         */
+        protected Builder() {
+        }
+
+        /**
+         * Returns a function to convert an Option to a CasedString that is the native name for the option.
+         * @return a function to convert an Option to a CasedString that is the native name for the option.
+         */
+        protected abstract Function<Option, CasedString> getNameFactory();
+
+        /**
+         * Gets the option.
+         * @return the option or {@code null} if the option is not set.
+         */
+        protected final Option option() {
+            return option;
+        }
+
+        /**
+         * Gets the UIOptionCollection that the options will be added to.
+         * @return UIOptionCollection that the options will be added to.
+         */
+        protected final UIOptionCollection<T> optionCollection() {
+            return optionCollection;
+        }
+
+        /**
+         * Returns this builder cast to the builder type.
+         * Useful for implementing fluent builders.
+         * @return this builder.
+         */
+        protected final B self() {
+            return (B) this;
+        }
+
+        /**
+         * Sets the UIOptionCollection that the UIOptions will be added to.
+         * @param optionCollection the UIOptionCollection that the UIOptions will be added to.
+         * @return this
+         */
+        public B optionCollection(final UIOptionCollection<T> optionCollection) {
+            this.optionCollection = optionCollection;
+            return self();
+        }
+
+        /**
+         * Sets the Option that the UIOption will be generated from.
+         * @param option to build the UIOption from.
+         * @return this
+         */
+        public B option(final Option option) {
+            Objects.requireNonNull(option, "Option may not be null");
+            this.option = option;
+            this.name = getNameFactory().apply(option);
+            if (this.name == null || this.name.isNull()) {
+                throw new IllegalArgumentException("name for " + option + " may not be null or contain a null value");
+            }
+            return self();
+        }
+
+        /**
+         * Executes the final build.
+         * @return An instance of the UIOption.
+         * @throws IllegalArgumentException if values are not set correctly.
+         */
+        protected abstract T doBuild() throws IllegalArgumentException;
+
+        /**
+         * Builds the UIOption.
+         * @return the UIOption.
+         * @throws IllegalArgumentException if values are not set correctly.
+         */
+        public final T build() throws IllegalArgumentException {
+            Objects.requireNonNull(optionCollection, "OptionCollection may not be null");
+            Objects.requireNonNull(option, "Option may not be null");
+            if (name == null || name.isNull()) {
+                throw new IllegalArgumentException("name may not be null or contain a null value");
+            }
+            return doBuild();
+        }
     }
 }

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UIOption.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UIOption.java
@@ -153,7 +153,7 @@ public abstract class UIOption<T extends UIOption<T>> {
             Matcher matcher = PATTERN.matcher(workingStr);
             while (matcher.find()) {
                 String key = matcher.group();
-                String optKey = (1 == key.indexOf('-', 1)) ?  key.substring(2) : key.substring(1);
+                String optKey = key.substring(1 == key.indexOf('-', 1) ?  2 : 1);
                 Optional<Option> maybeResult = getOptionCollection().getOptions().getOptions().stream()
                                 .filter(o -> optKey.equals(o.getOpt()) || optKey.equals(o.getLongOpt())).findFirst();
                 maybeResult.ifPresent(value -> maps.put(key, cleanupName(value)));

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UIOption.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UIOption.java
@@ -366,7 +366,7 @@ public abstract class UIOption<T extends UIOption<T>> {
             Objects.requireNonNull(optionCollection, "OptionCollection may not be null");
             Objects.requireNonNull(option, "Option may not be null");
             if (name == null || name.isNull()) {
-                throw new IllegalArgumentException("name may not be null or contain a null value");
+                throw new IllegalArgumentException("name must not be null or contain a null value");
             }
             return doBuild();
         }

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UIOptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UIOptionCollection.java
@@ -169,7 +169,7 @@ public class UIOptionCollection<T extends UIOption<T>> {
 
     /**
      * Gets a map client option name to the specified UIOption implementation.
-     * @return a map client option name to thge specified UIOption implementation.
+     * @return a map client option name to the specified UIOption implementation.
      */
     public final Map<String, T> getOptionMap() {
         Map<String, T> result = new TreeMap<>();
@@ -221,7 +221,7 @@ public class UIOptionCollection<T extends UIOption<T>> {
      * @param <B> the concrete type the Builder.
      */
     protected static class Builder<T extends UIOption<T>, B extends Builder<T, B>> {
-        /** set of additional UI specific options */
+        /** Set of additional UI specific options. */
         private final List<Option> uiOptions;
         /**
          * Map of option to overridden default value. Generally applies to supported RAT options but may be

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UIOptionCollection.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UIOptionCollection.java
@@ -26,18 +26,20 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.apache.commons.cli.AlreadySelectedException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.Defaults;
 import org.apache.rat.commandline.Arg;
 import org.apache.rat.utils.Log;
 
 /**
  * A collection of options supported by the UI. This includes RAT options and UI specific options.
- * @param <T> the AbstractOption implementation.
+ * @param <T> the UIOption implementation.
  */
 public class UIOptionCollection<T extends UIOption<T>> {
     /** map of ARG to the associated UpdatableOptionGroup */
@@ -53,18 +55,12 @@ public class UIOptionCollection<T extends UIOption<T>> {
     private final Map <Option, String> defaultValues;
 
     /**
-     * The function to generate a concrete BaseOption instance.
-     */
-    private final BiFunction<UIOptionCollection<T>, Option, T> mapper;
-
-    /**
      * Construct the UIOptionCollection from the builder.
-     * @param builder the builder to build from.
+     * @param builder the Builder to build from.
      */
     protected UIOptionCollection(final Builder<T, ?> builder) {
-        Objects.requireNonNull(builder.mapper, "Builder.mapper");
+        Objects.requireNonNull(builder.uiOptionBuilderSupplier, "Builder.mapper");
         argMap = new TreeMap<>();
-        mapper = builder.mapper;
         supportedRatOptions = new UpdatableOptionGroupCollection();
 
         for (Arg arg : Arg.values()) {
@@ -75,15 +71,28 @@ public class UIOptionCollection<T extends UIOption<T>> {
             supportedRatOptions.findGroups(opt).forEach(group -> group.disableOption(opt));
         }
         uiOptions = new HashMap<>();
+        UIOption.Builder<T, ?> optBuilder = builder.uiOptionBuilderSupplier.get();
+        optBuilder.optionCollection(this);
         supportedRatOptions.options().getOptions()
-                .forEach(option -> uiOptions.put(option, mapper.apply(this, option)));
+                .forEach(option -> uiOptions.put(option, optBuilder.option(option).build()));
         builder.uiOptions.stream().filter(option -> !uiOptions.containsKey(option))
-                .forEach(option -> uiOptions.put(option, mapper.apply(this, option)));
+                .forEach(option -> uiOptions.put(option, optBuilder.option(option).build()));
         defaultValues = new HashMap<>(builder.defaultValues);
     }
 
     /**
-     * Checks if an Arg is selected.
+     * Extracts the UI based name string for an option.
+     * The default implementation return the string returned by {@link ArgumentTracker#extractKey(Option)}
+     *
+     * @param option the option to create the name for.
+     * @return the name for the option in the UICollection name, may be the same as the option name.
+     */
+    public String rename(final Option option) {
+        return ArgumentTracker.extractKey(option);
+    }
+
+    /**
+     * Checks if an {@link Arg} is selected.
      * @param arg the Arg to check.
      * @return {@code true} if the arg is selected.
      */
@@ -93,8 +102,8 @@ public class UIOptionCollection<T extends UIOption<T>> {
     }
 
     /**
-     * Gets the selected Option for the arg.
-     * @param arg the arg to check.
+     * Gets the selected Option for an Arg.
+     * @param arg the Arg to get the Option for..
      * @return an Optional containing the selected option, or an empty Optional if none was selected.
      */
     public final Optional<Option> getSelected(final Arg arg) {
@@ -111,42 +120,56 @@ public class UIOptionCollection<T extends UIOption<T>> {
     }
 
     /**
+     * Resets the groups in the Args so that they are unused and ready to detect the next set of arguments.
+     */
+    public void resetSelected() {
+        argMap.values().forEach(uog -> {
+            try {
+                uog.setSelected(null);
+            } catch (AlreadySelectedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    /**
      * Gets the collection of unsupported Options.
-     * @return the Options comprised for the unsupported options.
+     * @return the Options comprising the unsupported options.
      */
     public final Options getUnsupportedOptions() {
         return supportedRatOptions.unsupportedOptions();
     }
 
     /**
-     * Gets the UiOption instance for the Option.
+     * Gets the UIOption instance for the Option.
      * @param option the option to find the instance of.
-     * @return a UIOption instance that wraps the option.
+     * @return an Optional containing the UIOption for the option, or an empty Optional if the option is not in the UI.
      */
     public final Optional<T> getMappedOption(final Option option) {
         return Optional.ofNullable(uiOptions.get(option));
     }
 
     /**
-     * Gets an Options that contains the RAT Arg defined Option instances that are understood by this collection.
+     * Gets an Options that contains the Options and OptionGroups are understood by this collection.
      * OptionGroups are registered in the resulting Options object.
-     * @return an Options that contains the RAT Arg defined Option instances that are understood by this collection.
+     * @return an Options that contains the {@link Arg} defined Option instances that are understood by this collection as well as
+     * any additional custom Options.
      */
     public final Options getOptions() {
         return supportedRatOptions.options().addOptions(additionalOptions());
     }
 
     /**
-     * Gets the Stream of AbstractOption implementations understood by this collection.
-     * @return the Stream of AbstractOption implementations understood by this collection.
+     * Gets the Stream of UIOption implementations understood by this collection.
+     * @return the Stream of UIOption implementations understood by this collection.
      */
     public final Stream<T> getMappedOptions() {
         return uiOptions.values().stream();
     }
 
     /**
-     * Gets a map client option name to specified AbstractOption implementation.
-     * @return a map client option name to specified AbstractOption implementation
+     * Gets a map client option name to the specified UIOption implementation.
+     * @return a map client option name to thge specified UIOption implementation.
      */
     public final Map<String, T> getOptionMap() {
         Map<String, T> result = new TreeMap<>();
@@ -155,8 +178,8 @@ public class UIOptionCollection<T extends UIOption<T>> {
     }
 
     /**
-     * Gets the additional options understood by this collection.
-     * @return the additional options understood by this collection.
+     * Gets the additional Options understood by this collection.
+     * @return the additional Options understood by this collection.
      */
     public final Options additionalOptions() {
         Options options = new Options();
@@ -176,11 +199,28 @@ public class UIOptionCollection<T extends UIOption<T>> {
     }
 
     /**
-     * Builder for a BaseOptionCollection.
-     * @param <T> the concreate type of the BaseOption.
-     * @param <S> the concrete type being built.
+     * Gets the description for the Option.
+     * Default implementation is based on the description in the option itself as well as the deprecated state.
+     * @param option the option to get the description for.
+     * @return the description of the option.
      */
-    protected static class Builder<T extends UIOption<T>, S extends Builder<T, S>> {
+    public String getDescription(final Option option) {
+        StringBuilder desc = new StringBuilder();
+        getMappedOption(option).ifPresent(uiOption -> {
+            if (uiOption.isDeprecated()) {
+                desc.append("[").append(uiOption.getDeprecated()).append("] ");
+            }
+            desc.append(StringUtils.defaultIfEmpty(uiOption.getDescription(), ""));
+        });
+        return desc.toString();
+    }
+
+    /**
+     * Builder for a UIOptionCollection.
+     * @param <T> the concreate type of the UIOption.
+     * @param <B> the concrete type the Builder.
+     */
+    protected static class Builder<T extends UIOption<T>, B extends Builder<T, B>> {
         /** set of additional UI specific options */
         private final List<Option> uiOptions;
         /**
@@ -191,13 +231,13 @@ public class UIOptionCollection<T extends UIOption<T>> {
         /** The list of unsupported RAT options. */
         protected final List<Option> unsupportedRatOptions;
         /** The function to convert an option into a UIOption. */
-        private final BiFunction<UIOptionCollection<T>, Option, T> mapper;
+        private final Supplier<UIOption.Builder<T, ?>> uiOptionBuilderSupplier;
 
         /**
-         * Constructor for the builder.
+         * Constructor for the UI option collection builder.
          */
-        protected Builder(final BiFunction<UIOptionCollection<T>, Option, T> mapper) {
-            this.mapper = mapper;
+        protected Builder(final Supplier<UIOption.Builder<T, ?>> uiOptionBiulderSupplier) {
+            this.uiOptionBuilderSupplier = uiOptionBiulderSupplier;
             uiOptions = new ArrayList<>();
             defaultValues = new HashMap<>();
             unsupportedRatOptions = new ArrayList<>();
@@ -209,59 +249,51 @@ public class UIOptionCollection<T extends UIOption<T>> {
         }
 
         /**
-         * Build the UIOptionCollection.
-         * @return the UIOptionCollection.
+         * Returns this cast to {@code <B>} class.
+         * @return this as {@code <B>} class.
          */
-        public UIOptionCollection<T> build() {
-            return new UIOptionCollection<>(this);
+        protected final B self() {
+            return (B) this;
         }
 
         /**
-         * Returns this cast to {@code <S>} class.
-         * @return this as {@code <S>} class.
-         */
-        protected final S self() {
-            return (S) this;
-        }
-
-        /**
-         * Add a UI option to the collection.
-         * @param uiOption the UI Option to add.
+         * Add an Option to the collection as a UIOption.
+         * @param option the Option to add.
          * @return this
          */
-        public S uiOption(final Option uiOption) {
-            uiOptions.add(uiOption);
+        public B uiOption(final Option option) {
+            uiOptions.add(option);
             return self();
         }
 
         /**
-         * Add a UI options to the collection.
-         * @param uiOption the UIOptions ({@code <T>} objects) to add.
+         * Add multiple Option instances to the collection as UIOptions.
+         * @param options the Option instances to add.
          * @return this
          */
-        public S uiOptions(final Option... uiOption) {
-            uiOptions.addAll(Arrays.asList(uiOption));
+        public B uiOptions(final Option... options) {
+            uiOptions.addAll(Arrays.asList(options));
             return self();
         }
 
         /**
-         * Register an option as unsupported.
-         * @param option the option that is not be supported. This should be an option in the
+         * Register an Option as unsupported.
+         * @param option the Option that is not be supported. This should be an option in the
          * {@link Arg} collection.
          * @return this
          */
-        public S unsupported(final Option option) {
+        public B unsupported(final Option option) {
             unsupportedRatOptions.add(option);
             return self();
         }
 
         /**
-         * Register multiple options as unsupported.
+         * Register multiple Options as unsupported.
          * Will ignore all the options associated with the specified Arg.
          * @param arg The Arg to ignore.
          * @return this
          */
-        public S unsupported(final Arg arg) {
+        public B unsupported(final Arg arg) {
             unsupportedRatOptions.addAll(arg.group().getOptions());
             return self();
         }
@@ -272,7 +304,7 @@ public class UIOptionCollection<T extends UIOption<T>> {
          * @param value the value for the option.
          * @return this
          */
-        public S defaultValue(final Option option, final String value) {
+        public B defaultValue(final Option option, final String value) {
             defaultValues.put(option, value);
             return self();
         }
@@ -283,7 +315,7 @@ public class UIOptionCollection<T extends UIOption<T>> {
          * @param value the value for the option.
          * @return this
          */
-        public S defaultValue(final Arg arg, final String value) {
+        public B defaultValue(final Arg arg, final String value) {
             return defaultValue(arg.option(), value);
         }
     }

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UpdatableOptionGroup.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UpdatableOptionGroup.java
@@ -48,7 +48,7 @@ public final class UpdatableOptionGroup extends OptionGroup {
 
     /**
      * Disable an option in the group.
-     * @param option The option to disable.
+     * @param option the option to disable.
      */
     public void disableOption(final Option option) {
         disabledOptions.add(option);

--- a/apache-rat-core/src/main/java/org/apache/rat/ui/UpdatableOptionGroup.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/ui/UpdatableOptionGroup.java
@@ -65,6 +65,7 @@ public final class UpdatableOptionGroup extends OptionGroup {
     public Stream<Option> getDisableOptions() {
         return disabledOptions.stream();
     }
+
     /**
      * Reset the group so that all disabled options are re-enabled.
      */

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/CasedString.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/CasedString.java
@@ -45,7 +45,7 @@ public final class CasedString {
         Arrays.stream(strings).map(s -> s == null ? "" : s).forEach(token -> sb.append(WordUtils.capitalize(token.toLowerCase(Locale.ROOT))));
         return sb.toString();
     };
-    /** A null cased string */
+    /** A null cased string. */
     // must follow CAMEL_JOINER def.
     public static final CasedString NULL = new CasedString(StringCase.KEBAB, CasedString.StringCase.NULL_SEGMENT);
 

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/CasedString.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/CasedString.java
@@ -45,6 +45,9 @@ public final class CasedString {
         Arrays.stream(strings).map(s -> s == null ? "" : s).forEach(token -> sb.append(WordUtils.capitalize(token.toLowerCase(Locale.ROOT))));
         return sb.toString();
     };
+    /** A null cased string */
+    // must follow CAMEL_JOINER def.
+    public static final CasedString NULL = new CasedString(StringCase.KEBAB, CasedString.StringCase.NULL_SEGMENT);
 
     /**
      * Creates a cased string by parsing the string argument for the specific case.
@@ -62,7 +65,7 @@ public final class CasedString {
      * @param segments the segments of the string.
      */
     public CasedString(final StringCase stringCase, final String[] segments) {
-        this.segments = segments;
+        this.segments = segments.length == 0 ? StringCase.NULL_SEGMENT : segments;
         this.stringCase = stringCase;
     }
 
@@ -72,7 +75,15 @@ public final class CasedString {
      * @return the new CasedString.
      */
     public CasedString as(final StringCase stringCase) {
-        return stringCase.name.equals(this.stringCase.name) ? this : new CasedString(stringCase, Arrays.copyOf(this.segments, this.segments.length));
+        return stringCase.name.equals(this.stringCase.name) ? this : new CasedString(stringCase, copySegments());
+    }
+
+    private String[] copySegments() {
+        return this.segments.length == 0 ? StringCase.NULL_SEGMENT : Arrays.copyOf(this.segments, this.segments.length);
+    }
+
+    public boolean isNull() {
+        return segments.length == 0;
     }
 
     /**
@@ -103,7 +114,7 @@ public final class CasedString {
             return false;
         }
         CasedString that = (CasedString) o;
-        return Objects.deepEquals(getSegments(), that.getSegments()) && Objects.equals(stringCase, that.stringCase);
+        return Objects.equals(stringCase, that.stringCase) && Objects.deepEquals(getSegments(), that.getSegments());
     }
 
     @Override

--- a/apache-rat-core/src/main/java/org/apache/rat/utils/CasedString.java
+++ b/apache-rat-core/src/main/java/org/apache/rat/utils/CasedString.java
@@ -46,7 +46,6 @@ public final class CasedString {
         return sb.toString();
     };
     /** A null cased string. */
-    // must follow CAMEL_JOINER def.
     public static final CasedString NULL = new CasedString(StringCase.KEBAB, CasedString.StringCase.NULL_SEGMENT);
 
     /**

--- a/apache-rat-core/src/test/java/org/apache/rat/CLIOptionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/CLIOptionTest.java
@@ -26,10 +26,12 @@ import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CLIOptionTest {
-    final CLIOption optionA = new CLIOption(CLIOptionCollection.INSTANCE, new Option("a", false, "short key"));
-    final CLIOption optionB = new CLIOption(CLIOptionCollection.INSTANCE, Option.builder("b").longOpt("bee").hasArg().desc("two key").build());
-    final CLIOption optionC = new CLIOption(CLIOptionCollection.INSTANCE, Option.builder().longOpt("sea").hasArgs().type(File.class).desc("long key").build());
-    final CLIOption optionD = new CLIOption(CLIOptionCollection.INSTANCE, Option.builder().longOpt("dee").hasArgs().argName("dede").desc("long key").build());
+    final CLIOptionCollection cliOptionCollection = new CLIOptionCollection();
+    final CLIOption.CLIBuilder builder = new CLIOption.CLIBuilder().optionCollection(cliOptionCollection);
+    final CLIOption optionA = builder.option(new Option("a", false, "short key")).build();
+    final CLIOption optionB = builder.option(Option.builder("b").longOpt("bee").hasArg().desc("two key").build()).build();
+    final CLIOption optionC = builder.option(Option.builder().longOpt("sea").hasArgs().type(File.class).desc("long key").build()).build();
+    final CLIOption optionD = builder.option(Option.builder().longOpt("dee").hasArgs().argName("dede").desc("long key").build()).build();
 
     @Test
     void getText() {

--- a/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionParserTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionParserTest.java
@@ -19,11 +19,13 @@
 package org.apache.rat;
 
 import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.rat.api.RatException;
 import org.apache.rat.commandline.ArgumentContext;
-import org.apache.rat.ui.UIOption;
+import org.apache.rat.testhelpers.TestingLog;
 import org.apache.rat.ui.UIOptionCollection;
-import org.apache.rat.utils.CasedString;
+import org.apache.rat.utils.DefaultLog;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,6 +34,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OptionCollectionParserTest {
 
@@ -39,10 +42,10 @@ class OptionCollectionParserTest {
     static Path testPath;
 
     private final TestOptionCollection optionCollection = new TestOptionCollection();
-    private final OptionCollectionParser underTest = new OptionCollectionParser(optionCollection);
+    private final OptionCollectionParser<TestOption> underTest = new OptionCollectionParser<>(optionCollection);
 
     @Test
-    void parseCommands() throws IOException, ParseException {
+    void parseCommands() throws RatException {
         String[] args = {"arg1", "arg2"};
         ArgumentContext ctxt = underTest.parseCommands(testPath.toFile(), args);
         assertThat(ctxt.getCommandLine().getArgList()).containsExactly(args);
@@ -55,34 +58,35 @@ class OptionCollectionParserTest {
         assertThat(ctxt.getCommandLine().getArgList()).containsExactly(args);
     }
 
-    static class TestOption extends UIOption<TestOption> {
-
-        /**
-         * Constructor.
-         *
-         * @param optionCollection the collection the UIOption belongs to.
-         * @param option           The CLI option
-         */
-        protected <C extends UIOptionCollection<TestOption>> TestOption(C optionCollection, Option option) {
-            super(optionCollection, option, new CasedString(CasedString.StringCase.CAMEL, option.getKey()));
+    @Test
+    void parseCommandLineParseExceptionTest() {
+        Options options = new Options();
+        options.addOption(Option.builder("req").required().build());
+        TestingLog testingLog = new TestingLog();
+        try {
+            DefaultLog.setInstance(testingLog);
+            assertThatThrownBy(() -> underTest.parseCommandLine(options, new String[0]))
+                    .isInstanceOf(ParseException.class);
+        } finally {
+            DefaultLog.setInstance(null);
         }
-
-        @Override
-        protected String cleanupName(Option option) {
-            return "clean" + option.toString();
-        }
-
-        @Override
-        public String getExample() {
-            return "example " + option.toString();
-        }
-
-        @Override
-        public String getText() {
-            return "text for " + option.toString();
-        }
+        assertThat(testingLog.getCaptured()).containsOnlyOnce("Please use the \"--help\" option to see a list of valid commands and options.");
     }
 
+    @Test
+    void printHelpExceptionTest() throws ParseException {
+        Options options = new Options();
+        ReportConfiguration cfg = new ReportConfiguration();
+        ArgumentContext ctxt = new ArgumentContext(testPath.toFile(), cfg, options, new String[0]);
+        cfg.setOut(new ReportConfiguration.IODescriptor("Bad Supplier", () -> { throw new IOException("Bad Supplier");}));
+        assertThatThrownBy(() -> underTest.printHelp(ctxt))
+                .isInstanceOf(RatException.class)
+                .hasMessageContaining("Unable to print help: Bad Supplier");
+    }
+
+    /**
+     * A UIOptionCollection implementation for testing.  Contains TestOptions.
+     */
     static class TestOptionCollection extends UIOptionCollection<TestOption> {
         /**
          * Construct the UIOptionCollection from the builder.
@@ -93,7 +97,7 @@ class OptionCollectionParserTest {
 
         static class TestCollectionBuilder extends UIOptionCollection.Builder<TestOption, TestCollectionBuilder> {
             TestCollectionBuilder() {
-                super(TestOption::new);
+                super(TestOption.TestOptionBuilder::new);
             }
         }
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionParserTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionParserTest.java
@@ -65,7 +65,7 @@ class OptionCollectionParserTest {
         TestingLog testingLog = new TestingLog();
         try {
             DefaultLog.setInstance(testingLog);
-            assertThatThrownBy(() -> underTest.parseCommandLine(options, new String[0]))
+            assertThatThrownBy(() -> OptionCollectionParser.parseCommandLine(options, new String[0]))
                     .isInstanceOf(ParseException.class);
         } finally {
             DefaultLog.setInstance(null);
@@ -85,7 +85,7 @@ class OptionCollectionParserTest {
     }
 
     /**
-     * A UIOptionCollection implementation for testing.  Contains TestOptions.
+     * A UIOptionCollection implementation for testing. Contains TestOptions.
      */
     static class TestOptionCollection extends UIOptionCollection<TestOption> {
         /**

--- a/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/OptionCollectionTest.java
@@ -30,8 +30,6 @@ import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.lang3.tuple.Pair;
@@ -220,8 +218,7 @@ public class OptionCollectionTest {
     @Test
     public void testDefaultConfiguration() throws ParseException {
         String[] empty = {};
-        CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), empty);
-        ArgumentContext context = new ArgumentContext(new File("."), cl);
+        ArgumentContext context = new ArgumentContext(new File("."), OptionCollection.buildOptions(), empty);
         ReportConfiguration config = OptionCollection.createConfiguration(context);
         ReportConfigurationTest.validateDefault(config);
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
@@ -23,16 +23,23 @@ import static org.assertj.core.api.Fail.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
+import java.util.UUID;
+import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
@@ -45,9 +52,6 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
 import org.apache.rat.api.Document.Type;
 import org.apache.rat.api.RatException;
@@ -58,12 +62,16 @@ import org.apache.rat.license.ILicenseFamily;
 import org.apache.rat.report.claim.ClaimStatistic;
 import org.apache.rat.report.claim.ClaimStatisticTest;
 import org.apache.rat.test.utils.Resources;
-import org.apache.rat.testhelpers.TextUtils;
+import org.apache.rat.testhelpers.BaseOption;
+import org.apache.rat.testhelpers.BaseOptionCollection;
 import org.apache.rat.testhelpers.XmlUtils;
 import org.apache.rat.utils.StandardXmlFactory;
 import org.apache.rat.walker.DirectoryWalker;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.TestInfo;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -72,22 +80,60 @@ import org.xml.sax.SAXException;
  * Tests the output of the Reporter.
  */
 public class ReporterTest {
-    @TempDir
-    File tempDirectory;
+    /**
+     * temporary file.  Not using tempDir because it does not
+     * always work.
+     */
+    private static Path tempPath;
+
+    /**
+     * The directory for the test.
+     */
+    private Path testPath;
+
+    /**
+     * Directory for the test data.
+     */
     final String basedir;
+
+    private final OptionCollectionParser<BaseOption> collectionParser;
 
     ReporterTest() throws URISyntaxException {
         basedir = Resources.getExampleResource("exampleData").getPath();
+        collectionParser = new OptionCollectionParser<>(new BaseOptionCollection());
+    }
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        tempPath = Files.createTempDirectory("ReporterTest");
+    }
+
+    @AfterAll
+    static void cleanup() throws IOException {
+        FileUtils.deleteDirectory(tempPath.toFile());
+    }
+
+    @BeforeEach
+    void setUpTest(TestInfo testInfo) {
+        Optional<Method> testMethod = testInfo.getTestMethod();
+        this.testPath = tempPath.resolve(testMethod.map(Method::getName).orElseGet(() -> UUID.randomUUID().toString()));
+        File file = testPath.toFile();
+        if (!file.exists()) {
+            if (!file.mkdirs()) {
+                throw new RuntimeException("Unable to create temp directory: " + file.getName());
+            }
+        } else {
+            if (!file.isDirectory()) {
+                throw new RuntimeException(file.getName() + " is NOT a directory.");
+            }
+        }
     }
 
     @Test
-    void testExecute() throws RatException, ParseException {
-        File output = new File(tempDirectory, "testExecute");
-
-        CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{"--output-style", "xml", "--output-file", output.getPath(), basedir});
-        ArgumentContext context = new ArgumentContext(new File("."), cl);
-        ReportConfiguration config = OptionCollection.createConfiguration(context);
-        ClaimStatistic statistic = new Reporter(config).execute().getStatistic();
+    void testExecute() throws RatException {
+        File output = testPath.resolve("output.xml").toFile();
+        ArgumentContext ctxt = collectionParser.parseCommands(new File("."), new String[]{"--output-style", "xml", "--output-file", output.getPath(), basedir});
+        ClaimStatistic statistic = new Reporter(ctxt.getConfiguration()).execute().getStatistic();
 
         assertThat(statistic.getCounter(Type.ARCHIVE)).isEqualTo(1);
         assertThat(statistic.getCounter(Type.BINARY)).isEqualTo(2);
@@ -136,11 +182,9 @@ public class ReporterTest {
     }
 
     @Test
-    void testExecuteNoSource() throws ParseException, RatException, TransformerException {
-        File output = new File(tempDirectory, "testExecuteNoSource");
-
-        CommandLine cl = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{"--output-style", "xml", "--output-file", output.getPath()});
-        ArgumentContext context = new ArgumentContext(new File("."), cl);
+    void testExecuteNoSource() throws RatException, TransformerException {
+        File output = testPath.resolve("testExecuteNoSource").toFile();
+        ArgumentContext context = collectionParser.parseCommands(new File("."), new String[]{"--output-style", "xml", "--output-file", output.getPath()});
         ReportConfiguration config = OptionCollection.createConfiguration(context);
         Reporter.Output result = new Reporter(config).execute();
         assertThat(StandardXmlFactory.serializeDocument(result.getDocument())).isEmpty();
@@ -149,43 +193,34 @@ public class ReporterTest {
 
     @Test
     void testOutputOption() throws Exception {
-        File output = new File(tempDirectory, "test");
-        CommandLine commandLine = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{"-o", output.getCanonicalPath(), basedir});
-        ArgumentContext context = new ArgumentContext(new File("."), commandLine);
-
-        ReportConfiguration config = OptionCollection.createConfiguration(context);
-        new Reporter(config).execute().format(config);
+        File output = testPath.resolve("testOutputOption.txt").toFile();
+        ArgumentContext ctxt = collectionParser.parseCommands(new File("."), new String[]{"--output-file", output.getCanonicalPath(), basedir});
+        new Reporter(ctxt.getConfiguration()).execute().format(ctxt.getConfiguration());
         assertThat(output.exists()).isTrue();
         String content = FileUtils.readFileToString(output, StandardCharsets.UTF_8);
-        TextUtils.assertPatternInTarget("^! Unapproved:\\s*2 ", content);
-        assertThat(content).contains("/Source.java");
-        assertThat(content).contains("/sub/Empty.txt");
+        assertThat(content).containsPattern(Pattern.compile("^! Unapproved:\\s*2 ", Pattern.MULTILINE))
+                .contains("/Source.java")
+                .contains("/sub/Empty.txt");
     }
 
     @Test
     void testGetOutputMethod() throws Exception {
-        File output = new File(tempDirectory, "test");
-        CommandLine commandLine = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{"-o", output.getCanonicalPath(), basedir});
-        ArgumentContext context = new ArgumentContext(new File("."), commandLine);
-
-        ReportConfiguration config = OptionCollection.createConfiguration(context);
-        Reporter reporter = new Reporter(config);
+        File output = testPath.resolve("testGetOutputMethod.txt").toFile();
+        ArgumentContext context = collectionParser.parseCommands(new File("."), new String[]{"-o", output.getCanonicalPath(), basedir});
+        Reporter reporter = new Reporter(context.getConfiguration());
         Reporter.Output expected = reporter.execute();
         assertThat(reporter.getOutput()).isEqualTo(expected);
     }
 
     @Test
     void testDefaultOutput() throws Exception {
-        File output = new File(tempDirectory, "testDefaultOutput");
+        File output = testPath.resolve("captured.txt").toFile();
 
         PrintStream origin = System.out;
         try (PrintStream out = new PrintStream(output)) {
             System.setOut(out);
-            CommandLine commandLine = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{basedir});
-            ArgumentContext context = new ArgumentContext(new File("."), commandLine);
-
-            ReportConfiguration config = OptionCollection.createConfiguration(context);
-            new Reporter(config).execute().format(config);
+            ArgumentContext ctxt = collectionParser.parseCommands(new File("."), new String[]{basedir});
+            new Reporter(ctxt.getConfiguration()).execute().format(ctxt.getConfiguration());
         } finally {
             System.setOut(origin);
         }
@@ -233,13 +268,10 @@ public class ReporterTest {
         expected.put("/tri.txt", mapOf("encoding", "ISO-8859-1", "mediaType", "text/plain",
                 "type", "STANDARD"));
 
-        File output = new File(tempDirectory, ".rat/testXMLOutput");
-        output.getParentFile().mkdir();
-        CommandLine commandLine = new DefaultParser().parse(OptionCollection.buildOptions(), new String[]{"--output-style", "xml", "--output-file", output.getPath(), basedir});
-        ArgumentContext context = new ArgumentContext(tempDirectory, commandLine);
-
-        ReportConfiguration config = OptionCollection.createConfiguration(context);
-        new Reporter(config).execute().format(config);
+        File output = testPath.resolve(".rat/testXMLOutput").toFile();
+        output.getParentFile().mkdirs();
+        ArgumentContext ctxt = collectionParser.parseCommands(testPath.toFile(), new String[]{"--output-style", "xml", "--output-file", output.getPath(), basedir});
+        new Reporter(ctxt.getConfiguration()).execute().format(ctxt.getConfiguration());
 
         assertThat(output).exists();
         Document doc = XmlUtils.toDom(java.nio.file.Files.newInputStream(output.toPath()));
@@ -368,56 +400,49 @@ public class ReporterTest {
     }
 
     private void verifyStandardContent(final String document) {
-        TextUtils.assertPatternInTarget("^  Notices:\\s*2 ", document);
-        TextUtils.assertPatternInTarget("^  Binaries:\\s*2 ", document);
-        TextUtils.assertPatternInTarget("^  Archives:\\s*1 ", document);
-        TextUtils.assertPatternInTarget("^  Standards:\\s*8 ", document);
-        TextUtils.assertPatternInTarget("^  Ignored:\\s*2 ", document);
-        TextUtils.assertPatternInTarget("^! Unapproved:\\s*2 ", document);
-        TextUtils.assertPatternInTarget("^  Unknown:\\s*2 ", document);
-
-        TextUtils.assertPatternInTarget("^Apache License 2.0: 5 ", document);
-        TextUtils.assertPatternInTarget("^BSD 3 clause: 1 ", document);
-        TextUtils.assertPatternInTarget("^The MIT License: 1 ", document);
-        TextUtils.assertPatternInTarget("^The Telemanagement Forum License: 1 ", document);
-        TextUtils.assertPatternInTarget("^Unknown license: 2 ", document);
-
-        TextUtils.assertPatternInTarget("^\\Q?????\\E: 2 ", document);
-        TextUtils.assertPatternInTarget("^AL   : 5 ", document);
-        TextUtils.assertPatternInTarget("^BSD-3: 2 ", document);
-        TextUtils.assertPatternInTarget("^MIT  : 1 ", document);
-
-        TextUtils.assertPatternInTarget(
-                "^Files with unapproved licenses\\s+\\*+\\s+" //
+        assertThat(document)
+                .containsPattern(Pattern.compile("^  Notices:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^  Binaries:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^  Archives:\\s*1 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^  Standards:\\s*8 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^  Ignored:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^! Unapproved:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^  Unknown:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^Apache License 2.0: 5 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^BSD 3 clause: 1 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^The MIT License: 1 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^The Telemanagement Forum License: 1 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^Unknown license: 2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^\\Q?????\\E: 2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^AL   : 5 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^BSD-3: 2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^MIT  : 1 ", Pattern.MULTILINE))
+                .containsPattern(
+                        Pattern.compile("^Files with unapproved licenses\\s+\\*+\\s+" //
                         + "\\Q/Source.java\\E\\s+" //
-                        + "\\Q/sub/Empty.txt\\E\\s",
-                document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.ARCHIVE, "/dummy.jar"),
-                document);
-        TextUtils.assertPatternInTarget(
-                ReporterTestUtils.documentOut(true, Type.STANDARD, "/ILoggerFactory.java")
-                        + ReporterTestUtils.licenseOut("MIT", "The MIT License"),
-                document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.BINARY, "/Image.png"),
-                document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.NOTICE, "/LICENSE"),
-                document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.NOTICE, "/NOTICE"), document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(false, Type.STANDARD, "/Source.java")
-                + ReporterTestUtils.UNKNOWN_LICENSE, document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.STANDARD, "/Text.txt")
-                + ReporterTestUtils.APACHE_LICENSE, document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.STANDARD, "/Xml.xml")
-                + ReporterTestUtils.APACHE_LICENSE, document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.STANDARD, "/buildr.rb")
-                + ReporterTestUtils.APACHE_LICENSE, document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.STANDARD, "/TextHttps.txt")
-                + ReporterTestUtils.APACHE_LICENSE, document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(true, Type.STANDARD, "/tri.txt")
+                                + "\\Q/sub/Empty.txt\\E\\s", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.ARCHIVE, "/dummy.jar"), Pattern.MULTILINE))
+                .containsPattern(
+                        Pattern.compile(ReporterTestUtils.documentOut(true, Type.STANDARD, "/ILoggerFactory.java")
+                                + ReporterTestUtils.licenseOut("MIT", "The MIT License"), Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.BINARY, "/Image.png"), Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.NOTICE, "/LICENSE"), Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.NOTICE, "/NOTICE"), Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(false, Type.STANDARD, "/Source.java")
+                        + ReporterTestUtils.UNKNOWN_LICENSE, Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.STANDARD, "/Text.txt")
+                        + ReporterTestUtils.APACHE_LICENSE, Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.STANDARD, "/Xml.xml")
+                        + ReporterTestUtils.APACHE_LICENSE, Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.STANDARD, "/buildr.rb")
+                        + ReporterTestUtils.APACHE_LICENSE, Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.STANDARD, "/TextHttps.txt")
+                        + ReporterTestUtils.APACHE_LICENSE, Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(true, Type.STANDARD, "/tri.txt")
                 + ReporterTestUtils.APACHE_LICENSE + ReporterTestUtils.licenseOut("BSD-3", "BSD 3 clause")
-                + ReporterTestUtils.licenseOut("BSD-3", "TMF", "The Telemanagement Forum License"), document);
-        TextUtils.assertPatternInTarget(ReporterTestUtils.documentOut(false, Type.STANDARD, "/sub/Empty.txt")
-                + ReporterTestUtils.UNKNOWN_LICENSE, document);
+                        + ReporterTestUtils.licenseOut("BSD-3", "TMF", "The Telemanagement Forum License"), Pattern.MULTILINE))
+                .containsPattern(Pattern.compile(ReporterTestUtils.documentOut(false, Type.STANDARD, "/sub/Empty.txt")
+                        + ReporterTestUtils.UNKNOWN_LICENSE, Pattern.MULTILINE));
     }
 
     private Validator initValidator() throws SAXException {
@@ -481,8 +506,9 @@ public class ReporterTest {
 
         String document = out.toString();
 
-        TextUtils.assertNotContains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>", document);
-        assertThat(document).as(() -> "'Generated at' is not present in \n" + document).startsWith(HEADER);
+        assertThat(document).as(() -> "'Generated at' is not present in \n" + document)
+                .doesNotContainPattern("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .startsWith(HEADER);
 
         verifyStandardContent(document);
     }
@@ -497,9 +523,9 @@ public class ReporterTest {
 
         String document = out.toString();
 
-        TextUtils.assertContains("Generated at: ", document );
-        TextUtils.assertPatternInTarget("\\Q/Source.java\\E$", document);
-        TextUtils.assertPatternInTarget("\\Q/sub/Empty.txt\\E", document);
+        assertThat(document).containsOnlyOnce("Generated at: ")
+                .containsPattern(Pattern.compile("\\Q/Source.java\\E$", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("\\Q/sub/Empty.txt\\E", Pattern.MULTILINE));
     }
 
     @Test

--- a/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ReporterTest.java
@@ -401,22 +401,22 @@ public class ReporterTest {
 
     private void verifyStandardContent(final String document) {
         assertThat(document)
-                .containsPattern(Pattern.compile("^  Notices:\\s*2 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^  Binaries:\\s*2 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^  Archives:\\s*1 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^  Standards:\\s*8 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^  Ignored:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^ {2}Notices:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^ {2}Binaries:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^ {2}Archives:\\s*1 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^ {2}Standards:\\s*8 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^ {2}Ignored:\\s*2 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^! Unapproved:\\s*2 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^  Unknown:\\s*2 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^ {2}Unknown:\\s*2 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^Apache License 2.0: 5 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^BSD 3 clause: 1 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^The MIT License: 1 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^The Telemanagement Forum License: 1 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^Unknown license: 2 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^\\Q?????\\E: 2 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^AL   : 5 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^AL {3}: 5 ", Pattern.MULTILINE))
                 .containsPattern(Pattern.compile("^BSD-3: 2 ", Pattern.MULTILINE))
-                .containsPattern(Pattern.compile("^MIT  : 1 ", Pattern.MULTILINE))
+                .containsPattern(Pattern.compile("^MIT {2}: 1 ", Pattern.MULTILINE))
                 .containsPattern(
                         Pattern.compile("^Files with unapproved licenses\\s+\\*+\\s+" //
                         + "\\Q/Source.java\\E\\s+" //

--- a/apache-rat-core/src/test/java/org/apache/rat/TestOption.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/TestOption.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   https://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
+package org.apache.rat;
+
+import org.apache.commons.cli.Option;
+import org.apache.rat.ui.ArgumentTracker;
+import org.apache.rat.ui.UIOption;
+import org.apache.rat.ui.UIOptionCollection;
+import org.apache.rat.utils.CasedString;
+
+import java.util.function.Function;
+
+/**
+ * A UIOption implementation to support testing.
+ */
+public class TestOption extends UIOption<TestOption> {
+
+    private <C extends UIOptionCollection<TestOption>> TestOption(TestOptionBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    public String toString() {
+        return option.toString() + " " + this.argumentType;
+    }
+
+    @Override
+    protected String cleanupName(Option option) {
+        return "clean" + option.toString();
+    }
+
+    @Override
+    public String getExample() {
+        return "example " + option.toString();
+    }
+
+    @Override
+    public String getText() {
+        return "text for " + option.toString();
+    }
+
+    /**
+     * The test option builder.
+     */
+    public static class TestOptionBuilder extends Builder<TestOption, TestOptionBuilder> {
+
+        @Override
+        protected Function<Option, CasedString> getNameFactory() {
+            return ArgumentTracker::extractName;
+        }
+
+        @Override
+        protected TestOption doBuild() {
+            return new TestOption(this);
+        }
+    }
+}

--- a/apache-rat-core/src/test/java/org/apache/rat/commandline/ArgTests.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/commandline/ArgTests.java
@@ -18,13 +18,8 @@
  */
 package org.apache.rat.commandline;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.rat.CLIOptionCollection;
-import org.apache.rat.DeprecationReporter;
-import org.apache.rat.OptionCollection;
 import org.apache.rat.ReportConfiguration;
 import org.apache.rat.document.DocumentName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,17 +30,12 @@ import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ArgTests {
-
-    private CommandLine createCommandLine(String[] args) throws ParseException {
-        Options opts = OptionCollection.buildOptions();
-        return DefaultParser.builder().setDeprecatedHandler(DeprecationReporter.getLogReporter())
-                .setAllowPartialMatching(true).build().parse(opts, args);
-    }
+class ArgTests {
+    private final CLIOptionCollection cliOptionCollection = new CLIOptionCollection();
 
     @ParameterizedTest(name = "{0}")
     @ValueSource(strings = { "rat.txt", "./rat.txt", "/rat.txt", "target/rat.test" })
-    public void outputFileNameNoDirectoryTest(String name) throws ParseException {
+    void outputFileNameNoDirectoryTest(String name) throws ParseException {
         class OutputFileConfig extends ReportConfiguration {
             private File actual = null;
 
@@ -62,10 +52,9 @@ public class ArgTests {
         Path workingPath = localFile.getAbsoluteFile().toPath();
         String expected = fsInfo.normalize(workingPath.resolve("./" + fileName).toString());
 
-        CommandLine commandLine = createCommandLine(new String[]{"--output-file", fileName});
         OutputFileConfig configuration = new OutputFileConfig();
-        ArgumentContext ctxt = new ArgumentContext(localFile, configuration, commandLine);
-        Arg.processArgs(ctxt, CLIOptionCollection.INSTANCE);
+        ArgumentContext ctxt = new ArgumentContext(localFile, configuration, cliOptionCollection.getOptions(), new String[]{"--output-file", fileName});
+        Arg.processArgs(ctxt, cliOptionCollection);
         if (name.equals("/rat.txt")) {
             assertThat(fsInfo.normalize(configuration.actual.getAbsolutePath())).isEqualTo(localFileName.getRoot() + "rat.txt");
         } else {

--- a/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/AbstractIgnoreBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/AbstractIgnoreBuilderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/BazaarIgnoreBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/BazaarIgnoreBuilderTest.java
@@ -16,31 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
-import org.apache.rat.config.exclusion.MatcherSet;
-import org.apache.rat.document.DocumentNameMatcher;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-public class CVSIgnoreBuilderTest extends AbstractIgnoreBuilderTest {
+public class BazaarIgnoreBuilderTest extends AbstractIgnoreBuilderTest {
 
     @Test
     public void processExampleFileTest() throws IOException {
         String[] lines = {
-                "thingone thingtwo", System.lineSeparator(), "one_fish", "two_fish", "", "red_* blue_*"};
+                "# a comment", "*.elc", "*.pyc", "*~", System.lineSeparator(),
+                "# switch to regexp syntax.",  "RE:^\\.pc" };
 
-        List<String> matching = Arrays.asList("thingone", "thingtwo", "one_fish", "two_fish", "red_fish", "blue_fish");
-        List<String> notMatching = Arrays.asList("thing", "two", "fish_red", "subdir/two_fish", "subdir/red_fish", "subdir/blue_fish");
+        List<String> matching = Arrays.asList("test.elc", "test.pyc", "test.thing~", ".pc");
+        List<String> notMatching = Arrays.asList("test.foo", ".pc/stuff", "subidr/test.elc");
 
-        writeFile(".cvsignore", Arrays.asList(lines));
+        writeFile(".bzrignore", Arrays.asList(lines));
 
-        CVSIgnoreBuilder processor = new CVSIgnoreBuilder();
-        DocumentNameMatcher matcher = MatcherSet.merge(processor.build(baseName)).createMatcher();
-
-        assertCorrect(new CVSIgnoreBuilder(), matching, notMatching);
+        assertCorrect(new BazaarIgnoreBuilder(), matching, notMatching);
     }
+
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/CVSIgnoreBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/CVSIgnoreBuilderTest.java
@@ -16,28 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
+import org.apache.rat.config.exclusion.MatcherSet;
+import org.apache.rat.document.DocumentNameMatcher;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-public class BazaarIgnoreBuilderTest extends AbstractIgnoreBuilderTest {
+public class CVSIgnoreBuilderTest extends AbstractIgnoreBuilderTest {
 
     @Test
     public void processExampleFileTest() throws IOException {
         String[] lines = {
-                "# a comment", "*.elc", "*.pyc", "*~", System.lineSeparator(),
-                "# switch to regexp syntax.",  "RE:^\\.pc" };
+                "thingone thingtwo", System.lineSeparator(), "one_fish", "two_fish", "", "red_* blue_*"};
 
-        List<String> matching = Arrays.asList("test.elc", "test.pyc", "test.thing~", ".pc");
-        List<String> notMatching = Arrays.asList("test.foo", ".pc/stuff", "subidr/test.elc");
+        List<String> matching = Arrays.asList("thingone", "thingtwo", "one_fish", "two_fish", "red_fish", "blue_fish");
+        List<String> notMatching = Arrays.asList("thing", "two", "fish_red", "subdir/two_fish", "subdir/red_fish", "subdir/blue_fish");
 
-        writeFile(".bzrignore", Arrays.asList(lines));
+        writeFile(".cvsignore", Arrays.asList(lines));
 
-        assertCorrect(new BazaarIgnoreBuilder(), matching, notMatching);
+        CVSIgnoreBuilder processor = new CVSIgnoreBuilder();
+        DocumentNameMatcher matcher = MatcherSet.merge(processor.build(baseName)).createMatcher();
+
+        assertCorrect(new CVSIgnoreBuilder(), matching, notMatching);
     }
-
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/GitIgnoreBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/GitIgnoreBuilderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import java.io.File;
 import java.net.URISyntaxException;

--- a/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/HgIgnoreBuilderTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/config/exclusion/fileprocessors/HgIgnoreBuilderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.rat.config.exclusion.fileProcessors;
+package org.apache.rat.config.exclusion.fileprocessors;
 
 import org.junit.jupiter.api.Test;
 

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOption.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOption.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   https://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
+package org.apache.rat.testhelpers;
+
+import org.apache.commons.cli.Option;
+import org.apache.rat.ui.ArgumentTracker;
+import org.apache.rat.ui.UIOption;
+import org.apache.rat.utils.CasedString;
+
+import java.util.function.Function;
+
+public final class BaseOption extends UIOption<BaseOption> {
+    BaseOption(BaseOptionBuilder builder) {
+        super(builder);
+    }
+
+    public Builder builder() {
+        return new BaseOptionBuilder();
+    }
+
+    protected String cleanupName(Option option) {
+        return ArgumentTracker.extractKey(option);
+    }
+
+    public String getExample() {
+        return "";
+    }
+
+    public String getText() {
+        return "";
+    }
+
+    public static class BaseOptionBuilder extends UIOption.Builder<BaseOption, BaseOptionBuilder> {
+
+        @Override
+        protected Function<Option, CasedString> getNameFactory() {
+            return ArgumentTracker::extractName;
+        }
+
+        @Override
+        protected BaseOption doBuild() {
+            return new BaseOption(this);
+        }
+    }
+}

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOption.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOption.java
@@ -30,7 +30,7 @@ public final class BaseOption extends UIOption<BaseOption> {
         super(builder);
     }
 
-    public Builder builder() {
+    public UIOption.Builder<BaseOption, BaseOptionBuilder> builder() {
         return new BaseOptionBuilder();
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOptionCollection.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOptionCollection.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one   *
+ * or more contributor license agreements.  See the NOTICE file *
+ * distributed with this work for additional information        *
+ * regarding copyright ownership.  The ASF licenses this file   *
+ * to you under the Apache License, Version 2.0 (the            *
+ * "License"); you may not use this file except in compliance   *
+ * with the License.  You may obtain a copy of the License at   *
+ *                                                              *
+ *   https://www.apache.org/licenses/LICENSE-2.0                 *
+ *                                                              *
+ * Unless required by applicable law or agreed to in writing,   *
+ * software distributed under the License is distributed on an  *
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY       *
+ * KIND, either express or implied.  See the License for the    *
+ * specific language governing permissions and limitations      *
+ * under the License.                                           *
+ */
+package org.apache.rat.testhelpers;
+
+import org.apache.rat.ui.UIOptionCollection;
+
+public final class BaseOptionCollection extends UIOptionCollection<BaseOption> {
+    public BaseOptionCollection() {
+        super(new Builder());
+    }
+
+    public BaseOptionCollection(Builder builder) {
+        super(builder);
+    }
+    public static final class Builder extends UIOptionCollection.Builder<BaseOption, Builder> {
+        public Builder() {
+            super(BaseOption.BaseOptionBuilder::new);
+        }
+    }
+}

--- a/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOptionCollection.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/testhelpers/BaseOptionCollection.java
@@ -25,9 +25,6 @@ public final class BaseOptionCollection extends UIOptionCollection<BaseOption> {
         super(new Builder());
     }
 
-    public BaseOptionCollection(Builder builder) {
-        super(builder);
-    }
     public static final class Builder extends UIOptionCollection.Builder<BaseOption, Builder> {
         public Builder() {
             super(BaseOption.BaseOptionBuilder::new);

--- a/apache-rat-core/src/test/java/org/apache/rat/ui/ArgumentTrackerTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ui/ArgumentTrackerTest.java
@@ -113,7 +113,7 @@ class ArgumentTrackerTest {
     @Test
     void invalidAbstractOption() {
         Option option = Option.builder().longOpt("notAValidOption").build();
-        TestingUIOption invalidOption = new TestingUIOption(testingUIOptionCollection, option);
+        TestingUIOption invalidOption = new TestingUIOption.TestingUIOptionBuilder().option(option).optionCollection(testingUIOptionCollection).build();
         underTest.addArg(invalidOption, "foo");
         assertThat(underTest.getArg(invalidOption.keyValue())).isEmpty();
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionCollectionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionCollectionTest.java
@@ -21,6 +21,8 @@ package org.apache.rat.ui;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+
 import org.apache.commons.cli.AlreadySelectedException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.OptionGroup;
@@ -41,9 +43,10 @@ public class UIOptionCollectionTest {
             super(new Builder());
 
         }
+
         private static class Builder extends UIOptionCollection.Builder<TestingUIOption, Builder> {
             Builder() {
-                super(TestingUIOption::new);
+                super(TestingUIOption.TestingUIOptionBuilder::new);
                         uiOption(UI_OPTION)
                         .uiOption(DEPRECATED_UI_OPTION)
                         .unsupported(Arg.COUNTER_MAX)
@@ -54,10 +57,10 @@ public class UIOptionCollectionTest {
         }
     }
 
-    static class TestingUIOption extends UIOption<TestingUIOption> {
+    public static class TestingUIOption extends UIOption<TestingUIOption> {
 
-        TestingUIOption(final UIOptionCollection<TestingUIOption> collection, final Option option) {
-            super(collection, option, ArgumentTracker.extractName(option).as(CasedString.StringCase.DOT));
+        private TestingUIOption(final TestingUIOptionBuilder builder) {
+            super(builder);
         }
 
         @Override
@@ -73,6 +76,19 @@ public class UIOptionCollectionTest {
         @Override
         public String getText() {
             return "Short and long options for " + cleanupName(option);
+        }
+
+        public static class TestingUIOptionBuilder extends UIOption.Builder<TestingUIOption, TestingUIOptionBuilder> {
+
+            @Override
+            protected Function<Option, CasedString> getNameFactory() {
+                return o -> ArgumentTracker.extractName(option()).as(CasedString.StringCase.DOT);
+            }
+
+            @Override
+            protected TestingUIOption doBuild() {
+                return new TestingUIOption(this);
+            }
         }
     }
 

--- a/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionCollectionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionCollectionTest.java
@@ -52,7 +52,6 @@ public class UIOptionCollectionTest {
                         .unsupported(Arg.COUNTER_MAX)
                         .unsupported(Arg.EXCLUDE.option())
                         .defaultValue(UI_OPTION, "foo");
-
             }
         }
     }

--- a/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionTest.java
@@ -18,10 +18,19 @@
  */
 package org.apache.rat.ui;
 
+import org.apache.commons.cli.DeprecatedAttributes;
 import org.apache.commons.cli.Option;
+import org.apache.rat.OptionCollection;
+import org.apache.rat.TestOption;
+import org.apache.rat.utils.CasedString;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class UIOptionTest {
     private UIOption<UIOptionCollectionTest.TestingUIOption> underTest;
@@ -30,12 +39,212 @@ class UIOptionTest {
     @Test
     void cleanup() {
         optionCollection = new UIOptionCollectionTest.TestingUIOptionCollection();
-        underTest = new UIOptionCollectionTest.TestingUIOption(optionCollection, new Option("a", false, "An option"));
+        underTest = new UIOptionCollectionTest.TestingUIOption.TestingUIOptionBuilder().option(new Option("a", false, "An option"))
+                .optionCollection(optionCollection).build();
         String s = underTest.cleanup("The name is --output-licenses because I said so");
         assertThat(s).isEqualTo("The name is output.licenses because I said so");
 
         s = underTest.cleanup("The name is -A because I said so");
         assertThat(s).isEqualTo("The name is addLicense because I said so");
+    }
+
+    @Test
+    void equalsTest() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        TestOption opt2 = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt).isEqualTo(opt2)
+                .hasSameHashCodeAs(opt2)
+                .isNotEqualTo(null);
+
+        opt2 = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg()
+                        .argName("file")
+                .build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt).isNotEqualTo(opt2)
+                .hasSameHashCodeAs(opt2);
+
+        opt2 = new TestOption.TestOptionBuilder() {
+            @Override
+            protected Function<Option, CasedString> getNameFactory() {
+                return o -> new CasedString(CasedString.StringCase.CAMEL, "helloWorld");
+            }
+        }.option(Option.builder("a").hasArg()
+                        .build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt).isNotEqualTo(opt2)
+                .doesNotHaveSameHashCodeAs(opt2);
+    }
+
+    @Test
+    void defaultValueTest() {
+        UIOptionCollection<TestOption> collection = mock(UIOptionCollection.class);
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
+                .optionCollection(collection)
+                .build();
+
+        assertThat(opt.getDefaultValue()).isNull();
+
+        when(collection.defaultValue(any(Option.class))).thenReturn("yeehaw");
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
+                .optionCollection(collection)
+                .build();
+        assertThat(opt.getDefaultValue()).isEqualTo("yeehaw");
+    }
+
+    @Test
+    void getCasedName() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        CasedString casedName = opt.getCasedName();
+        assertThat(casedName).hasToString("hello-world");
+    }
+
+    @Test
+    void getDescriptionName() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt.getDescription()).isNull();
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
+                .desc("This is the description").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt.getDescription()).isEqualTo("This is the description");
+    }
+
+    @Test
+    void getArgName() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgName()).isEmpty();
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgName()).isEqualTo("Arg");
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
+                .argName("file").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgName()).isEqualTo("File");
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
+                        .argName("dummy").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgName()).isEqualTo("Arg");
+
+    }
+
+    @Test
+    void getArgType() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.NONE);
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.ARG);
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
+                        .argName("file").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.FILE);
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
+                        .argName("dummy").build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.ARG);
+
+    }
+
+    @Test
+    void isRequired() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                .hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.isRequired()).isFalse();
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                        .hasArg().required(true).build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.isRequired()).isTrue();
+    }
+
+    @Test
+    void argCheck() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                        .build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.hasArg()).isFalse();
+        assertThat(opt.hasArgs()).isFalse();
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                        .hasArg().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt.hasArg()).isTrue();
+        assertThat(opt.hasArgs()).isFalse();
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                        .hasArgs().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt.hasArg()).isTrue();
+        assertThat(opt.hasArgs()).isTrue();
+    }
+
+    @Test
+    void getDeprecated() {
+        TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                        .build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+
+        assertThat(opt.getDeprecated()).isEmpty();
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                .deprecated().build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt.getDeprecated()).isEqualTo("Deprecated");
+
+        opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
+                        .deprecated(new DeprecatedAttributes.Builder().setSince("fádo fádo").get()).build())
+                .optionCollection(mock(UIOptionCollection.class))
+                .build();
+        assertThat(opt.getDeprecated()).isEqualTo("Deprecated since fádo fádo");
+
     }
 
 }

--- a/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionTest.java
+++ b/apache-rat-core/src/test/java/org/apache/rat/ui/UIOptionTest.java
@@ -24,22 +24,25 @@ import org.apache.rat.OptionCollection;
 import org.apache.rat.TestOption;
 import org.apache.rat.utils.CasedString;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class UIOptionTest {
-    private UIOption<UIOptionCollectionTest.TestingUIOption> underTest;
-    private UIOptionCollectionTest.TestingUIOptionCollection optionCollection;
+    @Mock
+    private UIOptionCollection<TestOption> mockOptionCollection;
 
     @Test
     void cleanup() {
-        optionCollection = new UIOptionCollectionTest.TestingUIOptionCollection();
-        underTest = new UIOptionCollectionTest.TestingUIOption.TestingUIOptionBuilder().option(new Option("a", false, "An option"))
+        UIOptionCollectionTest.TestingUIOptionCollection optionCollection = new UIOptionCollectionTest.TestingUIOptionCollection();
+        UIOption<UIOptionCollectionTest.TestingUIOption> underTest = new UIOptionCollectionTest.TestingUIOption.TestingUIOptionBuilder().option(new Option("a", false, "An option"))
                 .optionCollection(optionCollection).build();
         String s = underTest.cleanup("The name is --output-licenses because I said so");
         assertThat(s).isEqualTo("The name is output.licenses because I said so");
@@ -51,11 +54,11 @@ class UIOptionTest {
     @Test
     void equalsTest() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         TestOption opt2 = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt).isEqualTo(opt2)
@@ -65,7 +68,7 @@ class UIOptionTest {
         opt2 = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg()
                         .argName("file")
                 .build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt).isNotEqualTo(opt2)
                 .hasSameHashCodeAs(opt2);
@@ -77,7 +80,7 @@ class UIOptionTest {
             }
         }.option(Option.builder("a").hasArg()
                         .build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt).isNotEqualTo(opt2)
                 .doesNotHaveSameHashCodeAs(opt2);
@@ -85,16 +88,15 @@ class UIOptionTest {
 
     @Test
     void defaultValueTest() {
-        UIOptionCollection<TestOption> collection = mock(UIOptionCollection.class);
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
-                .optionCollection(collection)
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getDefaultValue()).isNull();
 
-        when(collection.defaultValue(any(Option.class))).thenReturn("yeehaw");
+        when(mockOptionCollection.defaultValue(any(Option.class))).thenReturn("yeehaw");
         opt = new TestOption.TestOptionBuilder().option(Option.builder("a").hasArg().build())
-                .optionCollection(collection)
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.getDefaultValue()).isEqualTo("yeehaw");
     }
@@ -102,7 +104,7 @@ class UIOptionTest {
     @Test
     void getCasedName() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         CasedString casedName = opt.getCasedName();
         assertThat(casedName).hasToString("hello-world");
@@ -111,13 +113,13 @@ class UIOptionTest {
     @Test
     void getDescriptionName() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.getDescription()).isNull();
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
                 .desc("This is the description").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.getDescription()).isEqualTo("This is the description");
     }
@@ -125,75 +127,73 @@ class UIOptionTest {
     @Test
     void getArgName() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgName()).isEmpty();
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgName()).isEqualTo("Arg");
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
                 .argName("file").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgName()).isEqualTo("File");
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
                         .argName("dummy").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgName()).isEqualTo("Arg");
-
     }
 
     @Test
     void getArgType() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.NONE);
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.ARG);
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
                         .argName("file").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.FILE);
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world").hasArg()
                         .argName("dummy").build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getArgType()).isEqualTo(OptionCollection.ArgumentType.ARG);
-
     }
 
     @Test
     void isRequired() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                 .hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.isRequired()).isFalse();
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                         .hasArg().required(true).build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.isRequired()).isTrue();
@@ -203,7 +203,7 @@ class UIOptionTest {
     void argCheck() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                         .build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.hasArg()).isFalse();
@@ -211,14 +211,14 @@ class UIOptionTest {
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                         .hasArg().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.hasArg()).isTrue();
         assertThat(opt.hasArgs()).isFalse();
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                         .hasArgs().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.hasArg()).isTrue();
         assertThat(opt.hasArgs()).isTrue();
@@ -228,23 +228,21 @@ class UIOptionTest {
     void getDeprecated() {
         TestOption opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                         .build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
 
         assertThat(opt.getDeprecated()).isEmpty();
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                 .deprecated().build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.getDeprecated()).isEqualTo("Deprecated");
 
         opt = new TestOption.TestOptionBuilder().option(Option.builder("hello-world")
                         .deprecated(new DeprecatedAttributes.Builder().setSince("fádo fádo").get()).build())
-                .optionCollection(mock(UIOptionCollection.class))
+                .optionCollection(mockOptionCollection)
                 .build();
         assertThat(opt.getDeprecated()).isEqualTo("Deprecated since fádo fádo");
-
     }
-
 }

--- a/apache-rat-plugin/spotbugs-ignore.xml
+++ b/apache-rat-plugin/spotbugs-ignore.xml
@@ -19,7 +19,7 @@
   <Match>
     <!--
     Convenience constructors that allow setting a charset are not available in Java8 for FileReader.
-    <Class name="org.apache.rat.config.exclusion.fileProcessors.GlobIgnoreMatcher"/>
+    <Class name="org.apache.rat.config.exclusion.fileprocessors.GlobIgnoreMatcher"/>
     <Bug pattern="DM_DEFAULT_ENCODING"/>
   -->
   </Match>

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Help.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Help.java
@@ -179,7 +179,7 @@ public class Help extends BaseAntTask {
             int max = optionTitle.length();
             int maxExample = exampleTitle.length();
             final List<AntOption> optList = new ArrayList<>();
-            AntOptionCollection.INSTANCE.getMappedOptions().forEach(optList::add);
+            new AntOptionCollection().getMappedOptions().forEach(optList::add);
             optList.sort(Comparator.comparing(UIOption::getName));
             List<String> exampleList = new ArrayList<>();
             for (final AntOption option : optList) {

--- a/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Help.java
+++ b/apache-rat-tasks/src/main/java/org/apache/rat/anttasks/Help.java
@@ -170,8 +170,8 @@ public class Help extends BaseAntTask {
         protected StringBuffer renderOptions(final StringBuffer sb, final int width, final Options options, final int leftPad, final int descPad) {
             final String dpad = createPadding(descPad);
             // first create list containing only <lpad>-a,--aaa where
-            // -a is opt and --aaa is long opt; in parallel look for
-            // the longest opt string this list will then be used to
+            // -a is option and --aaa is long option; in parallel look for
+            // the longest option string this list will then be used to
             // sort options ascending
             String optionTitle = " -- Option --";
             String exampleTitle = " -- Example --";

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/GeneratedReportTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/GeneratedReportTest.java
@@ -185,7 +185,7 @@ public class GeneratedReportTest {
      */
     static Stream<Arguments> generatedData() {
 
-        List<AntOption> options = AntOptionCollection.INSTANCE.getMappedOptions().toList();
+        List<AntOption> options = new AntOptionCollection().getMappedOptions().toList();
 
         List<Arguments> lst = new ArrayList<>();
 
@@ -228,11 +228,7 @@ public class GeneratedReportTest {
             if (body == null) {
                 xml.append(format("      <%1$s>%2$s</%1$s>%n", actualOption.getName(), getData(option)));
             } else {
-//                if (actualOption.argCount() == 1) {
-//                    xml.append(format("      <%s %s=\"%s\" />%n", actualOption.getName(), createAttribute(option), getData(option)));
-//                } else {
                 xml.append(format("      <%1$s>%2$s</%1$s>%n", actualOption.getName(), body));
-//                }
             }
         }
 

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/GeneratedReportTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/GeneratedReportTest.java
@@ -341,87 +341,82 @@ public class GeneratedReportTest {
         }
     }
 
-    private static class AntTestListener implements BuildListener {
-        private final int logLevel;
-        private final StringBuilder logBuffer;
-        private final StringBuilder fullLogBuffer;
-
-        /**
-         * Constructs a test listener which will ignore log events
-         * above the given level.
-         */
-        public AntTestListener(String name, StringBuilder fullLogBuffer, int logLevel) {
-            this.logBuffer = new StringBuilder();
-            this.fullLogBuffer = fullLogBuffer;
-            this.logLevel = logLevel;
-        }
-
-        /**
-         * Fired before any targets are started.
-         */
-        public void buildStarted(BuildEvent event) {
-        }
-
-        /**
-         * Fired after the last target has finished. This event
-         * will still be thrown if an error occurred during the build.
-         *
-         * @see BuildEvent#getException()
-         */
-        public void buildFinished(BuildEvent event) {
-        }
-
-        /**
-         * Fired when a target is started.
-         *
-         * @see BuildEvent#getTarget()
-         */
-        public void targetStarted(BuildEvent event) {
-        }
-
-        /**
-         * Fired when a target has finished. This event will
-         * still be thrown if an error occurred during the build.
-         *
-         * @see BuildEvent#getException()
-         */
-        public void targetFinished(BuildEvent event) {
-        }
-
-        /**
-         * Fired when a task is started.
-         *
-         * @see BuildEvent#getTask()
-         */
-        public void taskStarted(BuildEvent event) {
-        }
-
-        /**
-         * Fired when a task has finished. This event will still
-         * be thrown if an error occurred during the build.
-         *
-         * @see BuildEvent#getException()
-         */
-        public void taskFinished(BuildEvent event) {
-        }
-
-        /**
-         * Fired whenever a message is logged.
-         *
-         * @see BuildEvent#getMessage()
-         * @see BuildEvent#getPriority()
-         */
-        public void messageLogged(BuildEvent event) {
-            if (event.getPriority() > logLevel) {
-                // ignore event
-                return;
+    private record AntTestListener(int logLevel, StringBuilder logBuffer,
+                                   StringBuilder fullLogBuffer) implements BuildListener {
+            /**
+             * Constructs a test listener which will ignore log events
+             * above the given level.
+             */
+            public AntTestListener(String name, StringBuilder fullLogBuffer, int logLevel) {
+                this(logLevel, new StringBuilder(), fullLogBuffer);
             }
-            if (event.getPriority() <= Project.MSG_INFO) {
-                logBuffer.append(format("[%s] %s%n", Report.fromProjectLevel(event.getPriority()), event.getMessage()));
+
+            /**
+             * Fired before any targets are started.
+             */
+            public void buildStarted(BuildEvent event) {
             }
-            fullLogBuffer.append(format("[%s] %s%n", Report.fromProjectLevel(event.getPriority()), event.getMessage()));
+
+            /**
+             * Fired after the last target has finished. This event
+             * will still be thrown if an error occurred during the build.
+             *
+             * @see BuildEvent#getException()
+             */
+            public void buildFinished(BuildEvent event) {
+            }
+
+            /**
+             * Fired when a target is started.
+             *
+             * @see BuildEvent#getTarget()
+             */
+            public void targetStarted(BuildEvent event) {
+            }
+
+            /**
+             * Fired when a target has finished. This event will
+             * still be thrown if an error occurred during the build.
+             *
+             * @see BuildEvent#getException()
+             */
+            public void targetFinished(BuildEvent event) {
+            }
+
+            /**
+             * Fired when a task is started.
+             *
+             * @see BuildEvent#getTask()
+             */
+            public void taskStarted(BuildEvent event) {
+            }
+
+            /**
+             * Fired when a task has finished. This event will still
+             * be thrown if an error occurred during the build.
+             *
+             * @see BuildEvent#getException()
+             */
+            public void taskFinished(BuildEvent event) {
+            }
+
+            /**
+             * Fired whenever a message is logged.
+             *
+             * @see BuildEvent#getMessage()
+             * @see BuildEvent#getPriority()
+             */
+            public void messageLogged(BuildEvent event) {
+                if (event.getPriority() > logLevel) {
+                    // ignore event
+                    return;
+                }
+                if (event.getPriority() <= Project.MSG_INFO) {
+                    logBuffer.append(format("[%s] %s%n", Report.fromProjectLevel(event.getPriority()), event.getMessage()));
+                }
+                fullLogBuffer.append(format("[%s] %s%n", Report.fromProjectLevel(event.getPriority()), event.getMessage()));
+            }
         }
-    }
 
     protected static class AntOutputStream extends OutputStream {
         private final StringBuilder buffer;

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -96,6 +96,7 @@ public class ReportOptionTest  {
     }
 
     final static class AntOptionsProvider extends AbstractConfigurationOptionsProvider implements ArgumentsProvider {
+        private AntOptionCollection antOptionCollection = new AntOptionCollection();
 
         public AntOptionsProvider() {
             super(BaseAntTask.unsupportedArgs(), testPath.toFile());
@@ -138,7 +139,7 @@ public class ReportOptionTest  {
             final String name;
 
             BuildTask(Option option) {
-                this(AntOptionCollection.INSTANCE.getMappedOption(option).get().getName());
+                this(antOptionCollection.getMappedOption(option).get().getName());
             }
 
             BuildTask() {
@@ -154,7 +155,7 @@ public class ReportOptionTest  {
                 Map<String, String> attributes = new HashMap<>();
                 if (args.get(0).getKey() != null) {
                     for (Pair<Option, String[]> pair : args) {
-                        AntOption argOption = AntOptionCollection.INSTANCE.getMappedOption(pair.getKey()).get();
+                        AntOption argOption = antOptionCollection.getMappedOption(pair.getKey()).get();
                         if (argOption.isAttribute()) {
                             String value = pair.getValue() == null ? "true" : pair.getValue()[0];
                             attributes.put(argOption.getName(), value);

--- a/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
+++ b/apache-rat-tasks/src/test/java/org/apache/rat/anttasks/ReportOptionTest.java
@@ -96,7 +96,7 @@ public class ReportOptionTest  {
     }
 
     final static class AntOptionsProvider extends AbstractConfigurationOptionsProvider implements ArgumentsProvider {
-        private AntOptionCollection antOptionCollection = new AntOptionCollection();
+        private final AntOptionCollection antOptionCollection = new AntOptionCollection();
 
         public AntOptionsProvider() {
             super(BaseAntTask.unsupportedArgs(), testPath.toFile());

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOption.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOption.java
@@ -22,25 +22,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.commons.cli.Option;
 import org.apache.rat.ui.UIOption;
 import org.apache.rat.ui.UIOptionCollection;
+import org.apache.rat.utils.CasedString;
 
 import static java.lang.String.format;
 
 /**
  * A class that wraps the CLI option and provides Ant specific values.
  */
-public class AntOption extends UIOption<AntOption> {
+public final class AntOption extends UIOption<AntOption> {
 
     /**
      * Constructor.
      *
-     * @param option the option to wrap.
+     * @param builder the AntOptionBuilder
      */
-    public AntOption(final UIOptionCollection<AntOption> collection, final Option option) {
-        super(collection, option, AntOptionCollection.createName(option));
+    private AntOption(final AntOptionBuilder builder) {
+        super(builder);
     }
 
     /**
@@ -76,7 +78,8 @@ public class AntOption extends UIOption<AntOption> {
     }
 
     /**
-     * Gets the set of options that are mapped to this option.
+     * Gets the set of options that are mapped to this option.  This is used to allow one implementation to answer for
+     * multiple options.
      * @return the set of options that are mapped to this option.
      */
     public Set<AntOption> convertedFrom() {
@@ -104,15 +107,28 @@ public class AntOption extends UIOption<AntOption> {
         return antOption.cleanupName();
     }
 
+    /**
+     * Cleans up the name of this AntOption.  Used in documentation.
+     * Returns either {@code <name>} or {@code name attribute}.
+     * @return the cleaned up name.
+     */
     public String cleanupName() {
         String fmt = isAttribute() ? "%s attribute" : "<%s>";
         return format(fmt, name);
     }
 
+    /**
+     * Gets the AntOptionCollection this AntOption is associated with.
+     * @return the AntOptionCollection this AntOption is associated with.
+     */
     AntOptionCollection getAntCollection() {
         return getOptionCollection();
     }
 
+    /**
+     * Gets the Ant build type for this option.
+     * @return the Ant build type for this option.
+     */
     public AntOptionCollection.BuildType buildType() {
         return getAntCollection().buildType(this.getArgType());
     }
@@ -192,6 +208,57 @@ public class AntOption extends UIOption<AntOption> {
                 childElements.forEach(x -> result.append(x).append("\n"));
             }
             return result.toString();
+        }
+    }
+
+    /**
+     * The Builder for AntOptions.
+     */
+    public static class AntOptionBuilder extends UIOption.Builder<AntOption, AntOptionBuilder> {
+
+        public AntOptionBuilder() {
+            super();
+        }
+
+        /**
+         * returns the function to convert an Option to its Ant based cased name.
+         * @return the function to convert an Option to its Ant based cased name.
+         */
+        protected Function<Option, CasedString> getNameFactory() {
+            return this::createName;
+        }
+
+        @Override
+        public AntOptionBuilder optionCollection(final UIOptionCollection<AntOption> optionCollection) {
+            if (optionCollection instanceof AntOptionCollection) {
+                return super.optionCollection(optionCollection);
+            }
+            throw new IllegalArgumentException("Option collection must be instance of AntOptionCollection");
+        }
+
+        @Override
+        protected AntOption doBuild() {
+            return new AntOption(this);
+        }
+
+        /**
+         * Creates the name for the option based on rules for conversion of Option names.
+         * Ant names are in PASCAL format.
+         * @param option the standard option.
+         * @return a new CasedString comprising the name of the AntOption.
+         * @see CasedString.StringCase#PASCAL
+         */
+        CasedString createName(final Option option) {
+            List<String> pluralEndings = List.of("approved", "denied");
+            String name = optionCollection().rename(option);
+            CasedString casedName = new CasedString(CasedString.StringCase.KEBAB, name);
+            String[] segments = casedName.getSegments();
+            String lastSegment = segments[segments.length - 1];
+            if (option.hasArgs() && !lastSegment.endsWith("s") && !pluralEndings.contains(lastSegment)) {
+                segments[segments.length - 1] += "s";
+                casedName = new CasedString(CasedString.StringCase.KEBAB, segments);
+            }
+            return casedName.as(CasedString.StringCase.PASCAL);
         }
     }
 }

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOption.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOption.java
@@ -78,7 +78,7 @@ public final class AntOption extends UIOption<AntOption> {
     }
 
     /**
-     * Gets the set of options that are mapped to this option.  This is used to allow one implementation to answer for
+     * Gets the set of options that are mapped to this option. This is used to allow one implementation to answer for
      * multiple options.
      * @return the set of options that are mapped to this option.
      */
@@ -108,7 +108,7 @@ public final class AntOption extends UIOption<AntOption> {
     }
 
     /**
-     * Cleans up the name of this AntOption.  Used in documentation.
+     * Cleans up the name of this AntOption. Used in documentation.
      * Returns either {@code <name>} or {@code name attribute}.
      * @return the cleaned up name.
      */
@@ -159,10 +159,10 @@ public final class AntOption extends UIOption<AntOption> {
 
         /**
          * Gets an example Ant XML report call using ant option with the specified attributes and child elements.
-         * @param data The data value for this option.
-         * @param attributes A map of attribute keys and values.
+         * @param data the data value for this option.
+         * @param attributes a map of attribute keys and values.
          * @param childElements a list of child elements for the example
-         * @return example Ant XML report call using ant option with the specified attributes and child elements.
+         * @return example Ant XML report call using Ant option with the specified attributes and child elements.
          */
         public String getExample(final String data, final Map<String, String> attributes, final List<String> childElements) {
             return "<rat:report" +
@@ -174,8 +174,8 @@ public final class AntOption extends UIOption<AntOption> {
 
         /**
          * Creates a string comprising the attributes for the Ant XML report call.
-         * @param data The data value for this option.
-         * @param attributes A map of attribute keys and values.
+         * @param data the data value for this option.
+         * @param attributes a map of attribute keys and values.
          * @return a string comprising all the attribute keys and values for the Ant XML report element.
          */
         public String getExampleAttributes(final String data, final Map<String, String> attributes) {

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOptionCollection.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOptionCollection.java
@@ -35,30 +35,24 @@ import org.apache.commons.text.WordUtils;
 import org.apache.rat.OptionCollection;
 import org.apache.rat.commandline.Arg;
 import org.apache.rat.document.DocumentName;
-import org.apache.rat.ui.ArgumentTracker;
 import org.apache.rat.ui.UIOptionCollection;
-import org.apache.rat.utils.CasedString;
 
 import static java.lang.String.format;
 
 /**
- * The collection of AntOptions equivalent to the CLI options
- * with any unsupported options removed.
+ * The collection of AntOptions.
  */
 public final class AntOptionCollection extends UIOptionCollection<AntOption> {
     /** mapping of standard name to non-conflicting name. */
-    private static final Map<String, String> RENAME_MAP;
-
+    static final Map<String, String> RENAME_MAP;
     /**
      * The format for an XML element.
      */
     private static final String DEFAULT_XML = "<%1$s>%%s</%1$s>%n";
-
     /** Attributes that are required for example data. */
     private static final Map<String, Map<String, String>> REQUIRED_ATTRIBUTES = new HashMap<>();
     /** The list of data types that are specified as XML attributes in Ant build.xml documents */
     private static final List<Class<?>> ATTRIBUTE_TYPES = new ArrayList<>();
-
     /** The map of option name conversions. */
     private final Map<Option, Option> conversionMap;
 
@@ -82,21 +76,38 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
         ATTRIBUTE_TYPES.add(DocumentName.class);
     }
 
+    /**
+     * Gets the map of standard Option names that are renamed to fit the Ant naming process.
+     * @return the map of renamed Options.
+     */
     public static Map<String, String> getRenameMap() {
         return new TreeMap<>(RENAME_MAP);
     }
 
-    /** The instance of the AntOptionCollection */
-    public static final AntOptionCollection INSTANCE = new Builder().build();
-
+    /** Creates an instance of the AntOption Collection.
+     */
+    public AntOptionCollection() {
+        this(new Builder());
+    }
     /**
      * Create an instance.
      */
     private AntOptionCollection(final Builder builder) {
-        super(builder);
+        super(new Builder());
         conversionMap = builder.conversions;
     }
 
+    @Override
+    public String rename(final Option option) {
+        String key = super.rename(option);
+        return StringUtils.defaultIfEmpty(RENAME_MAP.get(key), key);
+    }
+
+    /**
+     * Returns the set of Antoptions that the argument was converted From.
+     * @param antOption the AntOption to check.
+     * @return returns a Set of AntOptoins that were converted to the argument. May be an empty set.
+     */
     public Set<AntOption> convertedFrom(final AntOption antOption) {
         return conversionMap.entrySet().stream().filter(e -> e.getValue().equals(antOption.getOption()))
                 .map(e -> getMappedOption(e.getKey()))
@@ -115,16 +126,31 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
         return opt == null ? antOption : getMappedOption(opt).orElse(antOption);
     }
 
+    /**
+     * Returns {@code true} if this argument is an attribute to the ANT RAT call.
+     * @param antOption the AntOption to check.
+     * @return {@code true} if this argument is an attribute to the ANT RAT call.
+     */
     public boolean isAttribute(final AntOption antOption) {
         Option opt = antOption.getOption();
         return (!opt.hasArg() || opt.getArgs() == 1) && convertedFrom(antOption).isEmpty() &&
                 ATTRIBUTE_TYPES.contains(opt.getType());
     }
 
+    /**
+     * Gets a map of attributes that are required for the example data.
+     * @param name the attribute name to lookup.
+     * @return the map of attributes that are required for the example data.
+     */
     public Map<String, String> getRequiredAttributes(final String name) {
         return REQUIRED_ATTRIBUTES.get(name);
     }
 
+    /**
+     * Gets the ANT build type for the ArgumentType
+     * @param type ArgumentType to get the ANT build type for.
+     * @return the ANT build type for the ArgumentType
+     */
     BuildType buildType(final OptionCollection.ArgumentType type) {
         return switch (type) {
             case FILE, DIRORARCHIVE -> new BuildType("filename") {
@@ -147,37 +173,6 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
         };
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Provides a new name for an option if it is renamed in the collection.
-     * @param name the option name.
-     * @return the collection name, may be the same as the option name.
-     */
-    static String rename(final String name) {
-        return StringUtils.defaultIfEmpty(RENAME_MAP.get(name), name);
-    }
-
-    /**
-     * Creates the name for the option based on rules for conversion of CLI option names.
-     * @param option the standard option.
-     * @return the new Option name as a CasedString.
-     */
-    static CasedString createName(final Option option) {
-        List<String> pluralEndings = List.of("approved", "denied");
-        String name = rename(ArgumentTracker.extractKey(option));
-        CasedString casedName = new CasedString(CasedString.StringCase.KEBAB, name);
-        String[] segments = casedName.getSegments();
-        String lastSegment = segments[segments.length - 1];
-        if (option.hasArgs() && !lastSegment.endsWith("s") && !pluralEndings.contains(lastSegment)) {
-            segments[segments.length - 1] += "s";
-            casedName = new CasedString(CasedString.StringCase.KEBAB, segments);
-        }
-        return casedName.as(CasedString.StringCase.PASCAL);
-    }
-
     /**
      * The Builder for the AntOptionCollection.
      */
@@ -186,7 +181,7 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
         private final Map<Option, Option> conversions = new HashMap<>();
 
         private Builder() {
-            super(AntOption::new);
+            super(AntOption.AntOptionBuilder::new);
             Arg.getOptions().getOptions()
                     .stream().filter(o -> Objects.isNull(o.getLongOpt()))
                     .forEach(this::unsupported);
@@ -205,11 +200,12 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
                     .convert(Arg.EXCLUDE_STD, Arg.EXCLUDE);
         }
 
-        @Override
-        public AntOptionCollection build() {
-            return new AntOptionCollection(this);
-        }
-
+        /**
+         * Converts one Arg type to another.
+         * @param from the Arg to convert from
+         * @param to the Arg to convert to.
+         * @return this
+         */
         public Builder convert(final Arg from, final Arg to) {
             Option mapTo = to.option();
             for (Option option : from.group().getOptions()) {
@@ -269,6 +265,12 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
             return format("<%1$s>%2$s</%1$s>%n", delegateOption.getName(), inner);
         }
 
+        /**
+         * Gets a string comprising the Ant XML pattern for the specified AntOption.
+         * @param antOption the ant option to get XML example for
+         * @param data the data for the option.
+         * @return an ANT XML formatted option.
+         */
         public String getXml(final AntOption antOption, final String data) {
             AntOption delegateOption = antOption.getActualAntOption();
             if (delegateOption.isAttribute()) {
@@ -278,6 +280,11 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
             }
         }
 
+        /**
+         * Gets a test name for the AntOption.
+         * @param antOption the Ant Option being tested
+         * @return the test name for this type.
+         */
         public String testName(final AntOption antOption) {
             return addExt ? format("%s_%s", antOption.getName(), antOption.getArgName()) : antOption.getName();
         }

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOptionCollection.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/AntOptionCollection.java
@@ -51,7 +51,7 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
     private static final String DEFAULT_XML = "<%1$s>%%s</%1$s>%n";
     /** Attributes that are required for example data. */
     private static final Map<String, Map<String, String>> REQUIRED_ATTRIBUTES = new HashMap<>();
-    /** The list of data types that are specified as XML attributes in Ant build.xml documents */
+    /** The list of data types that are specified as XML attributes in Ant build.xml documents. */
     private static final List<Class<?>> ATTRIBUTE_TYPES = new ArrayList<>();
     /** The map of option name conversions. */
     private final Map<Option, Option> conversionMap;
@@ -84,11 +84,13 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
         return new TreeMap<>(RENAME_MAP);
     }
 
-    /** Creates an instance of the AntOption Collection.
+    /**
+     * Creates an instance of the AntOption Collection.
      */
     public AntOptionCollection() {
         this(new Builder());
     }
+
     /**
      * Create an instance.
      */
@@ -104,9 +106,9 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
     }
 
     /**
-     * Returns the set of Antoptions that the argument was converted From.
+     * Returns the set of AntOptions that the argument was converted from.
      * @param antOption the AntOption to check.
-     * @return returns a Set of AntOptoins that were converted to the argument. May be an empty set.
+     * @return returns a Set of AntOptions that were converted to the argument. May be an empty set.
      */
     public Set<AntOption> convertedFrom(final AntOption antOption) {
         return conversionMap.entrySet().stream().filter(e -> e.getValue().equals(antOption.getOption()))
@@ -127,9 +129,9 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
     }
 
     /**
-     * Returns {@code true} if this argument is an attribute to the ANT RAT call.
+     * Returns {@code true} if this argument is an attribute to the Ant RAT call.
      * @param antOption the AntOption to check.
-     * @return {@code true} if this argument is an attribute to the ANT RAT call.
+     * @return {@code true} if this argument is an attribute to the Ant RAT call.
      */
     public boolean isAttribute(final AntOption antOption) {
         Option opt = antOption.getOption();
@@ -147,9 +149,9 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
     }
 
     /**
-     * Gets the ANT build type for the ArgumentType
-     * @param type ArgumentType to get the ANT build type for.
-     * @return the ANT build type for the ArgumentType
+     * Gets the Ant build type for the ArgumentType
+     * @param type ArgumentType to get the Ant build type for.
+     * @return the Ant build type for the ArgumentType
      */
     BuildType buildType(final OptionCollection.ArgumentType type) {
         return switch (type) {
@@ -202,7 +204,7 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
 
         /**
          * Converts one Arg type to another.
-         * @param from the Arg to convert from
+         * @param from the Arg to convert from.
          * @param to the Arg to convert to.
          * @return this
          */
@@ -226,7 +228,7 @@ public final class AntOptionCollection extends UIOptionCollection<AntOption> {
          */
         private final String tag;
         /**
-         * If True adds the tag as the test extension.
+         * If {@code true} adds the tag as the test extension.
          */
         private final boolean addExt;
 

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOption.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOption.java
@@ -62,7 +62,7 @@ public final class MavenOption extends UIOption<MavenOption> {
     @Override
     protected String cleanupName(final Option option) {
         // only parse the option if we need to.
-        return option == this.option ? format(XML_FMT, this.name) : format(XML_FMT,
+        return format(XML_FMT, option == this.option ? this.name :
                 MavenOptionBuilder.createName(optionCollection.rename(option)));
     }
 

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOption.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOption.java
@@ -18,17 +18,19 @@
  */
 package org.apache.rat.documentation.options;
 
+import java.util.function.Function;
+
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
+import org.apache.rat.ConfigurationException;
 import org.apache.rat.ui.UIOption;
-import org.apache.rat.ui.UIOptionCollection;
 import org.apache.rat.utils.CasedString;
 
 import static java.lang.String.format;
 
 /**
- * A representation of a Maven option based on a CLI option.
+ * A representation of a Maven option based on an Option.
  */
 public final class MavenOption extends UIOption<MavenOption> {
 
@@ -38,10 +40,10 @@ public final class MavenOption extends UIOption<MavenOption> {
     /**
      * Constructor.
      *
-     * @param option The CLI option
+     * @param builder The MavenOption builder.
      */
-    MavenOption(final UIOptionCollection<MavenOption> collection, final Option option) {
-        super(collection, option, MavenOptionCollection.createName(option));
+    private MavenOption(final MavenOptionBuilder builder) {
+        super(builder);
     }
 
     @Override
@@ -60,7 +62,8 @@ public final class MavenOption extends UIOption<MavenOption> {
     @Override
     protected String cleanupName(final Option option) {
         // only parse the option if we need to.
-        return option == this.option ? format(XML_FMT, this.name) : format(XML_FMT, MavenOptionCollection.createName(option));
+        return option == this.option ? format(XML_FMT, this.name) : format(XML_FMT,
+                MavenOptionBuilder.createName(optionCollection.rename(option)));
     }
 
     @Override
@@ -102,29 +105,43 @@ public final class MavenOption extends UIOption<MavenOption> {
         return sb.toString();
     }
 
+    /**
+     * Gets the Maven Mojo method signature for this Option.
+     * @param indent the number of spaces to indent the text.
+     * @param multiple {@code true} if this option takes multiple arguments.
+     * @return the method signature for this Option.
+     */
     public String getMethodSignature(final String indent, final boolean multiple) {
         StringBuilder sb = new StringBuilder();
         if (isDeprecated()) {
             sb.append(format("%s@Deprecated%n", indent));
         }
-        String fname = name.toCase(CasedString.StringCase.CAMEL);
+        // the camel case name for this option.
+        String camelName = name.toCase(CasedString.StringCase.CAMEL);
+        if (camelName == null) {
+            throw new ConfigurationException("Name can not be null");
+        }
         String args = option.hasArg() ? "String" : "boolean";
         if (multiple) {
-            if (!(fname.endsWith("s") || fname.endsWith("Approved") || fname.endsWith("Denied"))) {
-                fname = fname + "s";
+            if (!(camelName.endsWith("s") || camelName.endsWith("Approved") || camelName.endsWith("Denied"))) {
+                camelName = camelName + "s";
             }
             args = args + "[]";
         }
 
         return sb.append(format("%1$s%5$s%n%1$spublic void set%3$s(%4$s %2$s)",
-                        indent, name, fname, args, getPropertyAnnotation(fname)))
+                        indent, name, camelName, args, getParameterAnnotation(camelName)))
                 .toString();
     }
 
-
-    public String getPropertyAnnotation(final String fname) {
+    /**
+     * Creates the {@code @Parameter} annotation for this option.
+     * @param camelName The camel cased name for this option.
+     * @return the string that is the parameter annotation.
+     */
+    public String getParameterAnnotation(final String camelName) {
         StringBuilder sb = new StringBuilder("@Parameter");
-        String property = option.hasArgs() ? null : format("property = \"rat.%s\"", fname);
+        String property = option.hasArgs() ? null : format("property = \"rat.%s\"", camelName);
         String defaultValue = option.isDeprecated() ? null : getDefaultValue();
         if (property != null || defaultValue != null) {
             sb.append("(");
@@ -137,5 +154,31 @@ public final class MavenOption extends UIOption<MavenOption> {
             sb.append(")");
         }
         return sb.toString();
+    }
+
+    /**
+     * The builder for the MavenOptions.
+     */
+    public static class MavenOptionBuilder extends UIOption.Builder<MavenOption, MavenOptionBuilder> {
+
+        @Override
+        protected Function<Option, CasedString> getNameFactory() {
+            return o -> createName(optionCollection().rename(o));
+        }
+
+        @Override
+        protected MavenOption doBuild() {
+            return new MavenOption(this);
+        }
+
+        /**
+         * Create the cased name
+         * @param key the renamed key from the collection.
+         * @return the name for the key.
+         * @see MavenOptionCollection#rename(Option)
+         */
+        static CasedString createName(final String key) {
+            return new CasedString(CasedString.StringCase.KEBAB, key).as(CasedString.StringCase.PASCAL);
+        }
     }
 }

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOption.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOption.java
@@ -30,11 +30,13 @@ import org.apache.rat.utils.CasedString;
 import static java.lang.String.format;
 
 /**
- * A representation of a Maven option based on an Option.
+ * A representation of a Maven option based on an option.
  */
 public final class MavenOption extends UIOption<MavenOption> {
 
-    /** The format to start an XML entity */
+    /**
+     * The format to start an XML entity.
+     */
     private static final String XML_FMT = "<%s>";
 
     /**
@@ -119,7 +121,7 @@ public final class MavenOption extends UIOption<MavenOption> {
         // the camel case name for this option.
         String camelName = name.toCase(CasedString.StringCase.CAMEL);
         if (camelName == null) {
-            throw new ConfigurationException("Name can not be null");
+            throw new ConfigurationException("Name must not be null");
         }
         String args = option.hasArg() ? "String" : "boolean";
         if (multiple) {
@@ -136,7 +138,7 @@ public final class MavenOption extends UIOption<MavenOption> {
 
     /**
      * Creates the {@code @Parameter} annotation for this option.
-     * @param camelName The camel cased name for this option.
+     * @param camelName the camel cased name for this option.
      * @return the string that is the parameter annotation.
      */
     public String getParameterAnnotation(final String camelName) {

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOptionCollection.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOptionCollection.java
@@ -26,9 +26,7 @@ import java.util.TreeMap;
 import org.apache.commons.cli.Option;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.rat.commandline.Arg;
-import org.apache.rat.ui.ArgumentTracker;
 import org.apache.rat.ui.UIOptionCollection;
-import org.apache.rat.utils.CasedString;
 
 /**
  * The collection of MavenOptions equivalent to the CLI options
@@ -47,10 +45,9 @@ public final class MavenOptionCollection extends UIOptionCollection<MavenOption>
     }
 
     /**
-     * The instance of the MavenOptionCollection.
+     * Gets the Map of renamed Options indexed by original option name.
+     * @return the map of renamed Options indexed by original option name.
      */
-    public static final MavenOptionCollection INSTANCE = new Builder().build();
-
     public static Map<String, String> getRenameMap() {
         return new TreeMap<>(RENAME_MAP);
     }
@@ -58,33 +55,14 @@ public final class MavenOptionCollection extends UIOptionCollection<MavenOption>
     /**
      * Create an instance.
      */
-    private MavenOptionCollection(final Builder builder) {
-        super(builder);
+    public MavenOptionCollection() {
+        super(new Builder());
     }
 
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Provides a new name for an option if it is renamed in the collection.
-     *
-     * @param name the option name.
-     * @return the collection name, may be the same as the option name.
-     */
-    static String rename(final String name) {
-        return StringUtils.defaultIfEmpty(RENAME_MAP.get(name), name);
-    }
-
-    /**
-     * Creates the name for the option based on rules for conversion of CLI option names.
-     *
-     * @param option the standard option.
-     * @return the new Option name as a CasedString.
-     */
-    static CasedString createName(final Option option) {
-        String name = rename(ArgumentTracker.extractKey(option));
-        return new CasedString(CasedString.StringCase.KEBAB, name).as(CasedString.StringCase.PASCAL);
+    @Override
+    public String rename(final Option option) {
+        String key = super.rename(option);
+        return StringUtils.defaultIfEmpty(RENAME_MAP.get(key), key);
     }
 
     /**
@@ -92,16 +70,11 @@ public final class MavenOptionCollection extends UIOptionCollection<MavenOption>
      */
     public static final class Builder extends UIOptionCollection.Builder<MavenOption, Builder> {
         private Builder() {
-            super(MavenOption::new);
+            super(MavenOption.MavenOptionBuilder::new);
             Arg.getOptions().getOptions()
                     .stream().filter(o -> Objects.isNull(o.getLongOpt()))
                     .forEach(this::unsupported);
             unsupported(Arg.DIR).unsupported(Arg.LOG_LEVEL);
-        }
-
-        @Override
-        public MavenOptionCollection build() {
-            return new MavenOptionCollection(this);
         }
     }
 }

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOptionCollection.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/options/MavenOptionCollection.java
@@ -45,7 +45,7 @@ public final class MavenOptionCollection extends UIOptionCollection<MavenOption>
     }
 
     /**
-     * Gets the Map of renamed Options indexed by original option name.
+     * Gets the map of renamed Options indexed by original option name.
      * @return the map of renamed Options indexed by original option name.
      */
     public static Map<String, String> getRenameMap() {

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/velocity/RatTool.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/velocity/RatTool.java
@@ -48,6 +48,7 @@ import org.apache.rat.documentation.options.MavenOptionCollection;
 import org.apache.rat.help.AbstractHelp;
 import org.apache.rat.license.ILicense;
 import org.apache.rat.license.LicenseSetFactory;
+import org.apache.rat.ui.UIOption;
 import org.apache.velocity.tools.config.DefaultKey;
 import org.apache.velocity.tools.config.ValidScope;
 
@@ -87,6 +88,22 @@ public class RatTool {
     private final LicenseSetFactory licenseSetFactory;
 
     /**
+     * The Client option instance
+     */
+    // visible for testing
+    private final CLIOptionCollection cliOptions = new CLIOptionCollection();
+
+    /**
+     * The ANT option instance.
+     */
+    private final AntOptionCollection antOptions = new AntOptionCollection();
+
+    /**
+     * The Maven option instance
+     */
+    private final MavenOptionCollection mavenOptions = new MavenOptionCollection();
+
+    /**
      * Constructor.
      */
     public RatTool() {
@@ -99,8 +116,8 @@ public class RatTool {
      * @return the list of command line options.
      */
     public List<Option> options() {
-        return CLIOptionCollection.INSTANCE.getMappedOptions()
-        .map(CLIOption::getOption).toList();
+        return cliOptions.getMappedOptions()
+        .map(UIOption::getOption).toList();
     }
 
     /**
@@ -108,7 +125,7 @@ public class RatTool {
      * @return a map client option name to Ant Option.
      */
     public Map<String, AntOption> antOptions() {
-        return AntOptionCollection.INSTANCE.getOptionMap();
+        return antOptions.getOptionMap();
     }
 
     /**
@@ -116,7 +133,7 @@ public class RatTool {
      * @return a map client option name to CLI Option.
      */
     public Map<String, CLIOption> cliOptions() {
-        return CLIOptionCollection.INSTANCE.getOptionMap();
+        return cliOptions.getOptionMap();
     }
 
     /**
@@ -124,7 +141,7 @@ public class RatTool {
      * @return a map client option name to Maven Option.
      */
     public Map<String, MavenOption> mvnOptions() {
-        return MavenOptionCollection.INSTANCE.getOptionMap();
+        return mavenOptions.getOptionMap();
     }
 
     /**

--- a/apache-rat-tools/src/main/java/org/apache/rat/documentation/velocity/RatTool.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/documentation/velocity/RatTool.java
@@ -84,22 +84,24 @@ public class RatTool {
     // TODO remove this when velocity-tools 3.3 is available // NOSONAR
     private static final String[] APT_CHARS = charParser("\\~=-+*[]<>{}");
 
-    /** The license factory this tool uses. */
+    /**
+     * The license factory this tool uses.
+     */
     private final LicenseSetFactory licenseSetFactory;
 
     /**
-     * The Client option instance
+     * The client option instance.
      */
     // visible for testing
     private final CLIOptionCollection cliOptions = new CLIOptionCollection();
 
     /**
-     * The ANT option instance.
+     * The Ant option instance.
      */
     private final AntOptionCollection antOptions = new AntOptionCollection();
 
     /**
-     * The Maven option instance
+     * The Maven option instance.
      */
     private final MavenOptionCollection mavenOptions = new MavenOptionCollection();
 
@@ -200,8 +202,8 @@ public class RatTool {
     }
 
     /**
-     * Gets the set of Matchers.
-     * @return the set of Matchers.
+     * Gets the set of matchers.
+     * @return the set of matchers.
      */
     public Set<Matcher> matchers() {
         Set<Matcher> documentationSet = new TreeSet<>(Comparator.comparing(Matcher::getName));

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/AntDocumentation.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/AntDocumentation.java
@@ -49,6 +49,11 @@ public final class AntDocumentation {
     private final File outputDir;
 
     /**
+     * THe Ant Option collection instance.
+     */
+    private final AntOptionCollection antOptions = new AntOptionCollection();
+
+    /**
      * Creates APT documentation files for Ant.
      * Requires 1 argument:
      * <ol>
@@ -83,7 +88,7 @@ public final class AntDocumentation {
     }
 
     public void execute() {
-        List<AntOption> options = AntOptionCollection.INSTANCE.getMappedOptions().toList();
+        List<AntOption> options = antOptions.getMappedOptions().toList();
         writeAttributes(options);
         writeElements(options);
         printValueTypes();
@@ -151,7 +156,7 @@ public final class AntDocumentation {
         List<List<String>> table = new ArrayList<>();
         table.add(Arrays.asList("Value Type", "Description"));
 
-        AntOptionCollection.INSTANCE.getMappedOptions()
+        antOptions.getMappedOptions()
                 .map(antOption -> Arrays.asList(antOption.getName(), antOption.getDescription()))
                 .forEach(table::add);
 

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/AntGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/AntGenerator.java
@@ -124,12 +124,13 @@ public final class AntGenerator {
             System.err.println("At least three arguments are required: package, simple class name, target directory.");
             return;
         }
+        final AntOptionCollection antOptions = new AntOptionCollection();
 
         String packageName = args[0];
         String className = args[1];
         String destDir = args[2];
 
-        List<AntOption> options = AntOptionCollection.INSTANCE.getMappedOptions().toList();
+        List<AntOption> options = antOptions.getMappedOptions().toList();
 
         String pkgName = String.join(File.separator, new CasedString(StringCase.DOT, packageName).getSegments());
         File file = new File(new File(new File(destDir), pkgName), className + ".java");
@@ -150,12 +151,12 @@ public final class AntGenerator {
                             writer.append(format("        xlateName.put(\"%s\", \"%s\");%n", entry.getKey(), entry.getValue()));
                         }
 
-                        for (Option option : AntOptionCollection.INSTANCE.getUnsupportedOptions()
+                        for (Option option : antOptions.getUnsupportedOptions()
                                 .getOptions()) {
                             writer.append(format("        unsupportedArgs.add(\"%s\");%n", argsKey(option)));
                         }
 
-                        for (AntOption option : AntOptionCollection.INSTANCE.getMappedOptions().filter(AntOption::isDeprecated).toList()) {
+                        for (AntOption option : antOptions.getMappedOptions().filter(AntOption::isDeprecated).toList()) {
                             writer.append(format("        deprecatedArgs.put(\"%s\", \"%s\");%n", argsKey(option.getOption()),
                                     format("Use of deprecated option '%s'. %s", option.getName(), option.getDeprecated())));
                         }

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/MavenGenerator.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/MavenGenerator.java
@@ -74,6 +74,9 @@ public final class MavenGenerator {
         String packageName = args[0];
         String className = args[1];
         String destDir = args[2];
+
+        final MavenOptionCollection mavenOptions = new MavenOptionCollection();
+
         String pkgName = String.join(File.separator, new CasedString(StringCase.DOT, packageName).getSegments());
         File file = new File(new File(new File(destDir), pkgName), className + ".java");
         System.out.println("Creating " + file);
@@ -91,16 +94,16 @@ public final class MavenGenerator {
                         for (Map.Entry<?, ?> entry : MavenOptionCollection.getRenameMap().entrySet()) {
                             writer.append(format("        xlateName.put(\"%s\", \"%s\");%n", entry.getKey(), entry.getValue()));
                         }
-                        for (Option option : MavenOptionCollection.INSTANCE.getUnsupportedOptions().getOptions()) {
+                        for (Option option : mavenOptions.getUnsupportedOptions().getOptions()) {
                             writer.append(format("        unsupportedArgs.add(\"%s\");%n", argsKey(option)));
                         }
-                        for (MavenOption option : MavenOptionCollection.INSTANCE.getMappedOptions().filter(MavenOption::isDeprecated).toList()) {
+                        for (MavenOption option : mavenOptions.getMappedOptions().filter(MavenOption::isDeprecated).toList()) {
                             writer.append(format("        deprecatedArgs.put(\"%s\", \"%s\");%n", argsKey(option.getOption()),
                                     format("Use of deprecated option '%s'. %s", option.getName(), option.getDeprecated())));
                         }
                         break;
                     case "${methods}":
-                        writeMethods(writer);
+                        writeMethods(mavenOptions, writer);
                         break;
                     case "${package}":
                         writer.append(format("package %s;%n", packageName));
@@ -162,8 +165,8 @@ public final class MavenGenerator {
         return sb.append(format("     */%n")).toString();
     }
 
-    private static void writeMethods(final FileWriter writer) throws IOException {
-        for (MavenOption option : MavenOptionCollection.INSTANCE.getMappedOptions().toList()) {
+    private static void writeMethods(final MavenOptionCollection mavenOptions, final FileWriter writer) throws IOException {
+        for (MavenOption option : mavenOptions.getMappedOptions().toList()) {
             writer.append(getComment(option))
                     .append(option.getMethodSignature("    ", option.hasArgs())).append(" {").append(System.lineSeparator())
                     .append(getBody(option))

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/Naming.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/Naming.java
@@ -42,7 +42,7 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.QuoteMode;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.rat.CLIOptionCollection;
 import org.apache.rat.OptionCollection;
 import org.apache.rat.documentation.options.AntOptionCollection;
 import org.apache.rat.documentation.options.MavenOptionCollection;
@@ -81,10 +81,30 @@ public final class Naming {
             .addOption(INCLUDE_DEPRECATED)
             .addOption(WIDTH);
 
-    /**
-     * No instantiation of utility class.
-     */
-    private Naming() { }
+    /** The porsed command line */
+    private final CommandLine cl;
+    /** The width of the output */
+    private final int outputWidth;
+    /** The Maven options */
+    private final MavenOptionCollection mavenCollection = new MavenOptionCollection();
+    /** The Ant options */
+    private final AntOptionCollection antCollection = new AntOptionCollection();
+    /** The CLI options */
+    private final CLIOptionCollection cliCollection = new CLIOptionCollection();
+    /** The filter to include only non-deprecated long options */
+    private final Predicate<Option> filter;
+    /** The columns to display */
+    private final List<String> columns;
+    /** if {@code true} then show Maven options */
+    private final boolean showMaven;
+    /** if {@code true} then show Ant options */
+    private final boolean showAnt;
+    /** if {@code true} then show CLI options */
+    private final boolean addCLI;
+    /** if {@code true} then include deprecated options in output. */
+    private final boolean includeDeprecated;
+    /** The function to display the description of the option */
+    private final Function<Option, String> descriptionFunction;
 
     /**
      * Creates the CSV file.
@@ -101,123 +121,105 @@ public final class Naming {
             System.err.println("At least one argument is required: path to file is missing.");
             return;
         }
-        CommandLine cl = DefaultParser.builder().build().parse(OPTIONS, args);
-        int width = Math.max(cl.getParsedOptionValue(WIDTH, AbstractHelp.HELP_WIDTH), AbstractHelp.HELP_WIDTH);
+        Naming naming = new Naming(args);
+        naming.write();
+    }
 
-        boolean showMaven = cl.hasOption(MAVEN);
-        MavenOptionCollection mavenCollection = MavenOptionCollection.INSTANCE;
+    private Naming(final String[] args) throws ParseException {
+        cl = DefaultParser.builder().build().parse(OPTIONS, args);
 
-        boolean showAnt = cl.hasOption(ANT);
-        AntOptionCollection antCollection = AntOptionCollection.INSTANCE;
+        outputWidth = Math.max(cl.getParsedOptionValue(WIDTH, AbstractHelp.HELP_WIDTH), AbstractHelp.HELP_WIDTH);
+        showMaven = cl.hasOption(MAVEN);
+        showAnt = cl.hasOption(ANT);
+        addCLI = cl.hasOption(CLI);
+        includeDeprecated = cl.hasOption(INCLUDE_DEPRECATED);
+        filter = o -> o.hasLongOpt() && (!o.isDeprecated() || includeDeprecated);
 
-        boolean includeDeprecated = cl.hasOption(INCLUDE_DEPRECATED);
-        Predicate<Option> filter = o -> o.hasLongOpt() && (!o.isDeprecated() || includeDeprecated);
-
-        List<String> columns = new ArrayList<>();
-
-        if (cl.hasOption(CLI)) {
-            columns.add("CLI");
+        List<String> columnsBuilder = new ArrayList<>();
+        if (addCLI) {
+            columnsBuilder.add("CLI");
         }
-
         if (showAnt) {
-            columns.add("Ant");
+            columnsBuilder.add("Ant");
         }
-
         if (showMaven) {
-            columns.add("Maven");
+            columnsBuilder.add("Maven");
         }
-        columns.add("Description");
-        columns.add("Argument Type");
-
-        Function<Option, String> descriptionFunction;
-
-        if (cl.hasOption(CLI) || !showAnt && !showMaven) {
-            descriptionFunction = o -> {
-                StringBuilder desc = new StringBuilder();
-            if (o.isDeprecated()) {
-                desc.append("[").append(o.getDeprecated().toString()).append("] ");
-            }
-            return desc.append(StringUtils.defaultIfEmpty(o.getDescription(), "")).toString();
-            };
+        columnsBuilder.add("Description");
+        columnsBuilder.add("Argument Type");
+        columns = columnsBuilder;
+        if (addCLI || !showAnt && !showMaven) {
+            descriptionFunction = cliCollection::getDescription;
         } else if (showAnt) {
-            descriptionFunction = o -> {
-                StringBuilder desc = new StringBuilder();
-                antCollection.getMappedOption(o).ifPresent(
-                        antOption -> {
-                            if (antOption.isDeprecated()) {
-                                desc.append("[").append(antOption.getDeprecated()).append("] ");
-                            }
-                            desc.append(StringUtils.defaultIfEmpty(antOption.getDescription(), ""));
-                        });
-                return desc.toString();
-            };
+            descriptionFunction = antCollection::getDescription;
         } else {
-            descriptionFunction = o -> {
-                StringBuilder desc = new StringBuilder();
-                mavenCollection.getMappedOption(o).ifPresent(mavenOption -> {
-                    if (mavenOption.isDeprecated()) {
-                        desc.append("[").append(mavenOption.getDeprecated()).append("] ");
-                    }
-                    desc.append(StringUtils.defaultIfEmpty(mavenOption.getDescription(), ""));
-                });
-                return desc.toString();
-            };
+            descriptionFunction = mavenCollection::getDescription;
         }
+    }
 
+    private void write() throws IOException {
         try (Writer underWriter = cl.getArgs().length != 0 ?
                 new FileWriter(cl.getArgs()[0], StandardCharsets.UTF_8) : new OutputStreamWriter(System.out, StandardCharsets.UTF_8)) {
             if (cl.hasOption(CSV)) {
-                printCSV(columns, filter, cl.hasOption(CLI), showMaven, showAnt, descriptionFunction, underWriter);
-            }
-            else {
-                printText(columns, filter, cl.hasOption(CLI), showMaven, showAnt, descriptionFunction, underWriter, width);
+                printCSV(underWriter);
+            } else {
+                printText(underWriter);
             }
         }
     }
 
-    private static List<String> fillColumns(final List<String> columns, final Option option, final boolean addCLI, final boolean showMaven,
-                                            final boolean showAnt, final Function<Option, String> descriptionFunction) {
-        AntOptionCollection antCollection = AntOptionCollection.INSTANCE;
-        MavenOptionCollection mavenCollection = MavenOptionCollection.INSTANCE;
 
+    private List<String> fillColumns(final Option option) {
+        List<String> columnsBuilder = new ArrayList<>();
         if (addCLI) {
             if (option.hasLongOpt()) {
-                columns.add("--" + option.getLongOpt());
+                columnsBuilder.add("--" + option.getLongOpt());
             } else {
-                columns.add("-" + option.getOpt());
+                columnsBuilder.add("-" + option.getOpt());
             }
         }
         if (showAnt) {
-            antCollection.getMappedOption(option).ifPresentOrElse(antOption -> columns.add(antOption.getExample()),
-                    () -> columns.add(" "));
+            antCollection.getMappedOption(option).ifPresentOrElse(antOption -> columnsBuilder.add(antOption.getExample()),
+                    () -> columnsBuilder.add(" "));
         }
         if (showMaven) {
-            mavenCollection.getMappedOption(option).ifPresentOrElse(mavenOption -> columns.add(mavenOption.getExample()),
-                    () -> columns.add(" "));
+            mavenCollection.getMappedOption(option).ifPresentOrElse(mavenOption -> columnsBuilder.add(mavenOption.getExample()),
+                    () -> columnsBuilder.add(" "));
         }
 
-        columns.add(descriptionFunction.apply(option));
-        columns.add(option.hasArgName() ? option.getArgName() : option.hasArgs() ? "Strings" : option.hasArg() ? "String" : "-- none --");
-        columns.add(option.hasArgName() ? option.getArgName() : option.hasArgs() ? "Strings" : option.hasArg() ? "String" : "-- none --");
-        columns.add(option.hasArgName() ? option.getArgName() : option.hasArgs() ? "Strings" : option.hasArg() ? "String" : "-- none --");
-        return columns;
+        columnsBuilder.add(descriptionFunction.apply(option));
+        columnsBuilder.add(getOptionArgumentName(option));
+        return columnsBuilder;
     }
 
-    private static void printCSV(final List<String> columns, final Predicate<Option> filter, final boolean addCLI, final boolean showMaven,
-                                 final boolean showAnt, final Function<Option, String> descriptionFunction,
-                                 final Writer underWriter) throws IOException {
+    /**
+     * Extracts the option argument name for the documentation.
+     * @param option the option to extract the argument name from.
+     * @return the argument name.
+     */
+    private String getOptionArgumentName(final Option option) {
+        if (option.hasArgName()) {
+            return option.getArgName();
+        }
+        if (option.hasArgs()) {
+            return "Strings";
+        }
+        return option.hasArg() ? "String" : "-- none --";
+    }
+
+    private void printCSV(final Appendable underWriter) throws IOException {
         try (CSVPrinter printer = new CSVPrinter(underWriter, CSVFormat.DEFAULT.builder().setQuoteMode(QuoteMode.ALL).get())) {
             printer.printRecord(columns);
             for (Option option : OptionCollection.buildOptions().getOptions()) {
                 if (filter.test(option)) {
                     columns.clear();
-                    printer.printRecord(fillColumns(columns, option, addCLI, showMaven, showAnt, descriptionFunction));
+                    printer.printRecord(fillColumns(option));
                 }
             }
         }
     }
 
-    private static int[] calculateColumnWidth(final int width, final int columnCount, final List<List<String>> page) {
+    private int[] calculateColumnWidth(final int width, final int columnCount, final List<List<String>> page) {
         int[] columnWidth = new int[columnCount];
         for (List<String> row : page) {
             for (int i = 0; i < columnCount; i++) {
@@ -246,9 +248,7 @@ public final class Naming {
         return columnWidth;
     }
 
-    private static void printText(final List<String> columns, final Predicate<Option> filter, final boolean addCLI,
-                                  final boolean showMaven, final boolean showAnt,
-                                  final Function<Option, String> descriptionFunction, final Writer underWriter, final int width) throws IOException {
+    private void printText(final Appendable appendable) throws IOException {
         List<List<String>> page = new ArrayList<>();
 
         int columnCount = columns.size();
@@ -256,13 +256,13 @@ public final class Naming {
 
         for (Option option : OptionCollection.buildOptions().getOptions()) {
             if (filter.test(option)) {
-                page.add(fillColumns(new ArrayList<>(), option, addCLI, showMaven, showAnt, descriptionFunction));
+                page.add(fillColumns(option));
             }
         }
-        int[] columnWidth = calculateColumnWidth(width, columnCount, page);
+        int[] columnWidth = calculateColumnWidth(outputWidth, columnCount, page);
         HelpFormatter helpFormatter;
         helpFormatter = new HelpFormatter.Builder().get();
-        helpFormatter.setWidth(width);
+        helpFormatter.setWidth(outputWidth);
 
 
         List<Deque<String>> entries = new ArrayList<>();
@@ -286,26 +286,37 @@ public final class Naming {
                 entries.add(entryLines);
                 cWriter.reset();
             }
-            // print the entries by printing the items from the queues until all queues are empty.
-            boolean cont = true;
-            while (cont) {
-                cont = false;
-                for (int columnNumber = 0; columnNumber < entries.size(); columnNumber++) {
-                    Deque<String> queue = entries.get(columnNumber);
-                    if (queue.isEmpty()) {
-                        underWriter.append(AbstractHelp.createPadding(columnWidth[columnNumber] + 2));
-                    } else {
-                        String ln = queue.pop();
-                        underWriter.append(ln);
-                        underWriter.append(AbstractHelp.createPadding(columnWidth[columnNumber] - ln.length() + 2));
-                        if (!queue.isEmpty()) {
-                            cont = true;
-                        }
+            printLines(entries, appendable, columnWidth);
+            appendable.append(System.lineSeparator());
+        }
+    }
+
+    /**
+     * Prints the entries by printing the items from the queues until all queues are empty.
+     *
+     * @param entries the list queues of text for each column.
+     * @param appendable the appendable to write hte text to.
+     * @param columnWidth the with of the columns.
+     */
+    private void printLines(final List<Deque<String>> entries, final Appendable appendable, final int[] columnWidth) throws IOException {
+        boolean cont = true;
+        while (cont) {
+            cont = false;
+            for (int columnNumber = 0; columnNumber < entries.size(); columnNumber++) {
+                Deque<String> queue = entries.get(columnNumber);
+                if (queue.isEmpty()) {
+                    appendable.append(AbstractHelp.createPadding(columnWidth[columnNumber] + 2));
+                } else {
+                    String ln = queue.pop();
+                    appendable.append(ln);
+                    appendable.append(AbstractHelp.createPadding(columnWidth[columnNumber] - ln.length() + 2));
+                    if (!queue.isEmpty()) {
+                        cont = true;
                     }
                 }
-                underWriter.append(System.lineSeparator());
             }
-            underWriter.append(System.lineSeparator());
+            appendable.append(System.lineSeparator());
         }
+
     }
 }

--- a/apache-rat-tools/src/main/java/org/apache/rat/tools/Naming.java
+++ b/apache-rat-tools/src/main/java/org/apache/rat/tools/Naming.java
@@ -81,7 +81,7 @@ public final class Naming {
             .addOption(INCLUDE_DEPRECATED)
             .addOption(WIDTH);
 
-    /** The porsed command line */
+    /** The parsed command line */
     private final CommandLine cl;
     /** The width of the output */
     private final int outputWidth;
@@ -95,13 +95,13 @@ public final class Naming {
     private final Predicate<Option> filter;
     /** The columns to display */
     private final List<String> columns;
-    /** if {@code true} then show Maven options */
+    /** If {@code true} then show Maven options */
     private final boolean showMaven;
-    /** if {@code true} then show Ant options */
+    /** If {@code true} then show Ant options */
     private final boolean showAnt;
-    /** if {@code true} then show CLI options */
+    /** If {@code true} then show CLI options */
     private final boolean addCLI;
-    /** if {@code true} then include deprecated options in output. */
+    /** If {@code true} then include deprecated options in output. */
     private final boolean includeDeprecated;
     /** The function to display the description of the option */
     private final Function<Option, String> descriptionFunction;
@@ -167,7 +167,6 @@ public final class Naming {
             }
         }
     }
-
 
     private List<String> fillColumns(final Option option) {
         List<String> columnsBuilder = new ArrayList<>();
@@ -259,11 +258,11 @@ public final class Naming {
                 page.add(fillColumns(option));
             }
         }
+
         int[] columnWidth = calculateColumnWidth(outputWidth, columnCount, page);
         HelpFormatter helpFormatter;
         helpFormatter = new HelpFormatter.Builder().get();
         helpFormatter.setWidth(outputWidth);
-
 
         List<Deque<String>> entries = new ArrayList<>();
         CharArrayWriter cWriter = new CharArrayWriter();
@@ -295,8 +294,8 @@ public final class Naming {
      * Prints the entries by printing the items from the queues until all queues are empty.
      *
      * @param entries the list queues of text for each column.
-     * @param appendable the appendable to write hte text to.
-     * @param columnWidth the with of the columns.
+     * @param appendable the appendable to write the text to.
+     * @param columnWidth the width of the columns.
      */
     private void printLines(final List<Deque<String>> entries, final Appendable appendable, final int[] columnWidth) throws IOException {
         boolean cont = true;
@@ -317,6 +316,5 @@ public final class Naming {
             }
             appendable.append(System.lineSeparator());
         }
-
     }
 }

--- a/apache-rat-tools/src/test/java/org/apache/rat/documentation/options/MavenOptionTest.java
+++ b/apache-rat-tools/src/test/java/org/apache/rat/documentation/options/MavenOptionTest.java
@@ -27,9 +27,10 @@ import org.junit.jupiter.api.Test;
 public class MavenOptionTest {
     @Test
     void getDeprecatedTest() {
+        MavenOptionCollection mavenOptionCollection = new MavenOptionCollection();
         for (Option option : Arg.getOptions().getOptions()) {
             if (option.isDeprecated()) {
-                MavenOptionCollection.INSTANCE.getMappedOption(option).ifPresent( mavenOption -> //
+                mavenOptionCollection.getMappedOption(option).ifPresent( mavenOption -> //
                         TextUtils.assertPatternNotInTarget("\\-\\- ", mavenOption.getDeprecated()));
             }
         }

--- a/apache-rat-tools/src/test/java/org/apache/rat/documentation/velocity/RatToolTest.java
+++ b/apache-rat-tools/src/test/java/org/apache/rat/documentation/velocity/RatToolTest.java
@@ -42,6 +42,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RatToolTest {
     final RatTool underTest = new RatTool();
+    final CLIOptionCollection cliOptionCollection = new CLIOptionCollection();
+    final AntOptionCollection antOptionCollection = new AntOptionCollection();
+    final MavenOptionCollection mavenOptionCollection = new MavenOptionCollection();
 
     @Test
     void environmentVariables() {
@@ -57,13 +60,13 @@ public class RatToolTest {
     void antOptions() {
         Map<String, AntOption> options = underTest.antOptions();
         assertThat(options).isNotEmpty();
-        assertThat(options.values()).containsExactlyInAnyOrderElementsOf(AntOptionCollection.INSTANCE.getMappedOptions().toList());
+        assertThat(options.values()).containsExactlyInAnyOrderElementsOf(antOptionCollection.getMappedOptions().toList());
     }
 
     @Test
     void options() {
         List<Option> options = underTest.options();
-        assertThat(options).isNotEmpty().containsExactlyInAnyOrderElementsOf(CLIOptionCollection.INSTANCE.getMappedOptions()
+        assertThat(options).isNotEmpty().containsExactlyInAnyOrderElementsOf(cliOptionCollection.getMappedOptions()
                     .map(CLIOption::getOption).toList());
     }
 
@@ -71,14 +74,14 @@ public class RatToolTest {
     void cliOptions() {
         Map<String, CLIOption> options = underTest.cliOptions();
         assertThat(options).isNotEmpty();
-        assertThat(options.values()).containsExactlyInAnyOrderElementsOf(CLIOptionCollection.INSTANCE.getMappedOptions().toList());
+        assertThat(options.values()).containsExactlyInAnyOrderElementsOf(cliOptionCollection.getMappedOptions().toList());
     }
 
     @Test
     void mvnOptions() {
         Map<String, MavenOption> options = underTest.mvnOptions();
         assertThat(options).isNotEmpty();
-        assertThat(options.values()).containsExactlyInAnyOrderElementsOf(MavenOptionCollection.INSTANCE.getMappedOptions().toList());
+        assertThat(options.values()).containsExactlyInAnyOrderElementsOf(mavenOptionCollection.getMappedOptions().toList());
     }
 
     @Test

--- a/apache-rat-tools/src/test/java/org/apache/rat/tools/AntDocumentationTest.java
+++ b/apache-rat-tools/src/test/java/org/apache/rat/tools/AntDocumentationTest.java
@@ -45,14 +45,15 @@ class AntDocumentationTest {
 
     @BeforeEach
     void setup(@TempDir(cleanup = CleanupMode.NEVER) Path path) {
-        optionCollection = AntOptionCollection.INSTANCE;
+        optionCollection = new AntOptionCollection();
         testPath = path;
         underTest = new AntDocumentation(path.toFile());
     }
 
     @Test
     void writeAttributes() throws IOException {
-        List<AntOption> antOptions = options.getOptions().stream().map(opt -> new AntOption(optionCollection, opt)).toList();
+        AntOption.AntOptionBuilder builder = new AntOption.AntOptionBuilder().optionCollection(optionCollection);
+        List<AntOption> antOptions = options.getOptions().stream().map(opt -> builder.option(opt).build()).toList();
         underTest.writeAttributes(antOptions);
         File result = new File(testPath.toFile(), "report_attributes.txt");
         assertThat(result).exists();
@@ -63,7 +64,8 @@ class AntDocumentationTest {
 
     @Test
     void writeElements() throws IOException {
-        List<AntOption> antOptions = options.getOptions().stream().map(opt -> new AntOption(optionCollection, opt)).toList();
+        AntOption.AntOptionBuilder builder = new AntOption.AntOptionBuilder().optionCollection(optionCollection);
+        List<AntOption> antOptions = options.getOptions().stream().map(opt -> builder.option(opt).build()).toList();
         underTest.writeElements(antOptions);
         File result = new File(testPath.toFile(), "report_elements.txt");
         assertThat(result).exists();


### PR DESCRIPTION
Refactor UIOption, AntOption, and MavenOption along with their collections to provide cleaner implementations for multi threaded use as well as a better division of responsibility.

- Implemented Builders for UIOption and UIOption derived classes.
- Adjusted UIOptionCollection to utilize UIOption.Builder
- Simplified ArgumentContext construction by creating the CommandLine instance within the context.
- Adapted command line parsing to accept UIOptionCollection as the source of arguments.
- added isNull() to CasedString to indicate when the string will be null.
- Updated tools to utilize new UIOption builders and collections.